### PR TITLE
OCLC Classify Updates and Bugfixes

### DIFF
--- a/dcdw/managers/oclcClassify.py
+++ b/dcdw/managers/oclcClassify.py
@@ -175,7 +175,7 @@ class ClassifyManager:
             
             return outRecords
         else:
-            print(responesXML)
+            print(responseXML)
             raise ClassifyError(message='Got unexpected response code')
     
     def checkTitle(self, oclcTitle):

--- a/dcdw/managers/oclcClassify.py
+++ b/dcdw/managers/oclcClassify.py
@@ -137,7 +137,7 @@ class ClassifyManager:
             raise ClassifyError(message='No matching Classify records found')
         elif responseCode == 200:
             raise ClassifyError(message='Internal Classify API error encountered')
-        if responseCode == 101:
+        elif responseCode == 101:
             print('Invalid identifier received. Cleaning and retrying')
             oldID = self.identifier
             cleanIdentifier = self.cleanIdentifier()
@@ -174,6 +174,9 @@ class ClassifyManager:
                     outRecords.append(multiRec.getClassifyResponse()[0])
             
             return outRecords
+        else:
+            print(responesXML)
+            raise ClassifyError(message='Got unexpected response code')
     
     def checkTitle(self, oclcTitle):
         oclcCode = ClassifyManager.getStrLang(oclcTitle)

--- a/dcdw/processes/core.py
+++ b/dcdw/processes/core.py
@@ -25,6 +25,7 @@ class CoreProcess(DBManager, RabbitMQManager, RedisManager, StaticManager, Elast
         
         if len(self.records) >= 10000:
             self.saveRecords()
+            self.records = []
     
     def saveRecords(self):
         self.bulkSaveObjects(self.records)

--- a/dcdw/processes/oclcClassify.py
+++ b/dcdw/processes/oclcClassify.py
@@ -46,6 +46,7 @@ class ClassifyProcess(CoreProcess):
             self.frbrizeRecord(rec)
     
     def frbrizeRecord(self, record):
+        completed = False
         for iden in ClassifyManager.getQueryableIdentifiers(record.identifiers):
             identifier, idenType = tuple(iden.split('|'))
 
@@ -55,26 +56,28 @@ class ClassifyProcess(CoreProcess):
                 author = None
 
             if self.checkSetRedis('classify', identifier, idenType) is True:
-                record.frbr_status = 'complete'
-                self.records.append(record)
+                completed = True
                 continue
 
-            self.classifyRecordByMetadata(
-                identifier, idenType, author, record.title
-            )
+            try:
+                self.classifyRecordByMetadata(
+                    identifier, idenType, author, record.title
+                )
+                completed = True
+            except ClassifyError as err:
+                print(err.message)
+                return None
+
+        if completed:
+            record.frbr_status = 'complete'
+            self.records.append(record)
 
     def classifyRecordByMetadata(self, identifier, idType, author, title):
         classifier = ClassifyManager(
             iden=identifier, idenType=idType, author=author, title=title
         )
 
-        try:
-            xmlRecords = classifier.getClassifyResponse()
-        except ClassifyError as err:
-            print(err.message)
-            return None
-        
-        for classifyXML in xmlRecords:
+        for classifyXML in classifier.getClassifyResponse():
             self.createClassifyDCDWRecord(classifyXML, identifier, idType)
     
     def createClassifyDCDWRecord(self, classifyXML, identifier, idType):


### PR DESCRIPTION
This updates several components of the OCLC Classify process to improve its output and resolve several small bugs:

- Add a handler for unexpected status codes from the Classify service. The service will always return a `200` response, with custom response codes in the response XML which must be checked for. The current structure accounts for all documented responses but it seems that this is not guaranteed
- Improves parsing of authors/contributors to separate authors from contributors (who have specific roles assigned to them in the creation of a work). As these distinctions are made in a free text field this must be done with a regex
- Fix a bug where the process was repeatedly persisting ALL records to the database after the 10,000th record
- Improve the means by which records are marked as "FRBRized" (aka looked up in the Classify service). This simply marks all results as FRBRized once processed here, rather than looking at a specific outcome as this more accurately reflects that status.