### PR TITLE
SFR-228 Fix Daily Ingesters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,9 @@
 - YAML file for QA ECS environment
 ### Fixed
 - Made s3 ingest process more generic to handle cover images
+
+## Unreleased -- v0.0.4
+### Added
+- NYPL filter to identify public domain works
+### Fixed
+- NYPL and HathiTrust date boundary calculation for daily runs

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -42,3 +42,6 @@ NYPL_LOCATIONS_BY_CODE: https://nypl-core-objects-mapping-qa.s3.amazonaws.com/by
 # GITHUB API Credentials
 # GITHUB_API_KEY must be configured in secrets file
 GITHUB_API_ROOT: https://api.github.com/graphql
+
+# Bardo CCE API URL
+BARDO_CCE_API: http://sfr-bardo-copyright-development.us-east-1.elasticbeanstalk.com/search

--- a/config/example.yaml
+++ b/config/example.yaml
@@ -53,3 +53,6 @@ API_CLIENT_TOKEN_URL: xxx
 # GITHUB API Credentials
 GITHUB_API_KEY: xxx
 GITHUB_API_ROOT: https://api.github.com/graphql
+
+# Bardo CCE API URL
+BARDO_CCE_API: xxx

--- a/config/qa.yaml
+++ b/config/qa.yaml
@@ -40,3 +40,6 @@ API_CLIENT_TOKEN_URL: https://isso.nypl.org/oauth/token
 # GITHUB API Credentials
 # GITHUB_API_KEY must be configured in secrets file
 GITHUB_API_ROOT: https://api.github.com/graphql
+
+# Bardo CCE API URL
+BARDO_CCE_API: http://sfr-bardo-copyright-development.us-east-1.elasticbeanstalk.com/search

--- a/processes/hathiTrust.py
+++ b/processes/hathiTrust.py
@@ -59,7 +59,7 @@ class HathiTrustProcess(CoreProcess):
         fileJSON.sort(
             key=lambda x: datetime.strptime(
                 x['created'],
-                '%Y-%m-%dT%H:%M:%S-%f'
+                '%Y-%m-%dT%H:%M:%S%z'
             ).timestamp(),
             reverse=True
         )

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -36,7 +36,8 @@ class TestHelpers:
         'API_CLIENT_SECRET': 'test_api_secret',
         'API_CLIENT_TOKEN_URL': 'test_api_token_url',
         'GITHUB_API_KEY': 'test_github_key',
-        'GITHUB_API_ROOT': 'test_github_url'
+        'GITHUB_API_ROOT': 'test_github_url',
+        'BARDO_CCE_API': 'test_cce_url'
     }
 
     @classmethod

--- a/tests/unit/test_hathitrust_process.py
+++ b/tests/unit/test_hathitrust_process.py
@@ -27,9 +27,9 @@ class TestHathiTrustProcess:
     @pytest.fixture
     def hathiFilesData(self):
         return [
-            {'created': '2020-01-01T00:00:00-0', 'url': 'hathiUrl1', 'full': False},
-            {'created': '2019-01-01T00:00:00-0', 'url': 'hathiUrl2', 'full': True},
-            {'created': '2018-01-01T00:00:00-0', 'url': 'hathiUrl3', 'full': False}
+            {'created': '2020-01-01T00:00:00-0000', 'url': 'hathiUrl1', 'full': False},
+            {'created': '2019-01-01T00:00:00-0000', 'url': 'hathiUrl2', 'full': True},
+            {'created': '2018-01-01T00:00:00-0000', 'url': 'hathiUrl3', 'full': False}
         ]
 
     @pytest.fixture


### PR DESCRIPTION
Two of the daily ingesters -- for HathiTrust and NYPL records -- relied on a `datetime` format that was misconfigured regarding time zones. This corrects the issue to allow for accurate fetching of records over the past 24 hours.

This also adds some additional conditions to the NYPL process. Previously the ingest process fetched all research bibs updated in the past 24 hours, but that group includes primarily non-open sourced recently published works, which are no the focus of DRB. The process now checks the publication date and only takes pre-95 years ago records and records up to 1964 if we can be somewhat confident in their copyright status. This utilizes, in a very conservative way, the Bardo CCE API to make that determination, and which defaults to assume that work is copyrighted. This limits the number of records we ingest to provide a better focus on public domain records.