### PR TITLE
NOREF Extend Classify Fetching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,5 +22,6 @@
 ## Unreleased -- v0.0.4
 ### Added
 - NYPL filter to identify public domain works
+- Paging for OCLC Classify to fetch all associated editions
 ### Fixed
 - NYPL and HathiTrust date boundary calculation for daily runs

--- a/mappings/oclcCatalog.py
+++ b/mappings/oclcCatalog.py
@@ -135,10 +135,10 @@ class CatalogMapping(XMLMapping):
                 '{0}|{1}|{2}'),
 
             ],
-            'has_part': ([
-                '//oclc:datafield[@tag=\'856\']/oclc:subfield[@code=\'u\']/text()',
-                '//oclc:datafield[@tag=\'856\']/oclc:subfield[@code=\'z\']/text()'
-            ], '1|{0}|oclc|unknown|{1}')
+            'has_part': [(
+                '//oclc:datafield[@tag=\'856\']/oclc:subfield[@code=\'z\']/text()',
+                '1|{0}|oclc|text/html|{{"ebook": true, "download": false, "reader": false, "catalog": true}}'
+            )]
         }
 
     def applyFormatting(self):

--- a/mappings/oclcCatalog.py
+++ b/mappings/oclcCatalog.py
@@ -135,19 +135,10 @@ class CatalogMapping(XMLMapping):
                 '{0}|{1}|{2}'),
 
             ],
-<<<<<<< HEAD
             'has_part': [(
                 '//oclc:datafield[@tag=\'856\']/oclc:subfield[@code=\'z\']/text()',
                 '1|{0}|oclc|text/html|{{"ebook": true, "download": false, "reader": false, "catalog": true}}'
             )]
-=======
-            'has_part': [
-                ([
-                    '//oclc:datafield[@tag=\'856\']/oclc:subfield[@code=\'u\']/text()',
-                    '//oclc:datafield[@tag=\'856\']/oclc:subfield[@code=\'z\']/text()'
-                ], '1|{0}|oclc|unknown|{1}')
-            ]
->>>>>>> main
         }
 
     def applyFormatting(self):

--- a/mappings/oclcClassify.py
+++ b/mappings/oclcClassify.py
@@ -66,3 +66,6 @@ class ClassifyMapping(XMLMapping):
             trueAuthors.append(author)
 
         self.record.authors = trueAuthors
+
+    def extendIdentifiers(self, additionalIdentifiers):
+        self.record.identifiers.extend(additionalIdentifiers)

--- a/mappings/oclcClassify.py
+++ b/mappings/oclcClassify.py
@@ -51,14 +51,14 @@ class ClassifyMapping(XMLMapping):
 
         for author in self.record.authors:
             name, viaf, lcnaf, primary = tuple(author.split('|'))
-            bracketedRoles = re.match(r'\[(.*)\]$', name)
+            bracketedRoles = re.search(r'\[(.*)\]$', name)
 
             if bracketedRoles:
                 roles = bracketedRoles.group(1).lower()
 
                 if 'author' not in roles:
                     self.record.contributors.append('{}|{}|{}|{}'.format(
-                        name.replace(bracketedRoles.group(0), ''), viaf, lcnaf, roles
+                        name.replace(bracketedRoles.group(0), '').strip(), viaf, lcnaf, roles
                     ))
                     continue
             

--- a/processes/oclcClassify.py
+++ b/processes/oclcClassify.py
@@ -72,10 +72,11 @@ class ClassifyProcess(CoreProcess):
             iden=identifier, idenType=idType, author=author, title=title
         )
 
-        for classifyXML in classifier.getClassifyResponse():
-            self.createClassifyDCDWRecord(classifyXML, identifier, idType)
+        for classifyResult in classifier.getClassifyResponse():
+            self.createClassifyDCDWRecord(classifyResult, identifier, idType)
     
-    def createClassifyDCDWRecord(self, classifyXML, identifier, idType):
+    def createClassifyDCDWRecord(self, classifyResult, identifier, idType):
+        classifyXML, additionalOCLCs = classifyResult
         classifyRec = ClassifyMapping(
             classifyXML,
             {'oclc': 'http://classify.oclc.org'},
@@ -83,6 +84,8 @@ class ClassifyProcess(CoreProcess):
             (identifier, idType)
         )
         classifyRec.applyMapping()
+
+        classifyRec.extendIdentifiers(additionalOCLCs)
 
         self.addDCDWToUpdateList(classifyRec)
 

--- a/tests/unit/test_oclcClassify_mapping.py
+++ b/tests/unit/test_oclcClassify_mapping.py
@@ -24,6 +24,8 @@ class TestClassifyMapping:
     def testRecord_standard(self, mocker):
         return mocker.MagicMock(
             identifiers=['1|owi', '2|test'],
+            authors=['Test Author|||true', 'Test Editor [Editor]|||false', 'Test Other [Author, Editor]|||false'],
+            contributors=[]
         )
 
     def test_createMapping(self, testMapping):
@@ -43,3 +45,12 @@ class TestClassifyMapping:
         assert testMapping.record.source_id == '1|owi'
         assert testMapping.record.frbr_status == 'complete'
         assert testMapping.record.identifiers == ['1|owi', '2|test', '1|classifyTest']
+        assert testMapping.record.authors == ['Test Author|||true', 'Test Other [Author, Editor]|||false']
+        assert testMapping.record.contributors == ['Test Editor|||editor']
+
+    def test_extendIdentifiers(self, testMapping, testRecord_standard):
+        testMapping.record = testRecord_standard
+
+        testMapping.extendIdentifiers(['3|test', '4|other']) 
+
+        assert testMapping.record.identifiers == ['1|owi', '2|test', '3|test', '4|other']

--- a/tests/unit/test_oclcClassify_process.py
+++ b/tests/unit/test_oclcClassify_process.py
@@ -220,12 +220,13 @@ class TestOCLCClassifyProcess:
         mockAddDCDW = mocker.patch.object(ClassifyProcess, 'addDCDWToUpdateList')
         mockfetchOCLC = mocker.patch.object(ClassifyProcess, 'fetchOCLCCatalogRecords')
 
-        testInstance.createClassifyDCDWRecord('testXML', '1', 'test')
+        testInstance.createClassifyDCDWRecord(('testXML', []), '1', 'test')
 
         mockMapping.assert_called_once_with(
             'testXML', {'oclc': 'http://classify.oclc.org'}, {}, ('1', 'test')
         )
-        mockMappingInstance.applyMapping.assert_called_once
+        mockMappingInstance.applyMapping.assert_called_once()
+        mockMappingInstance.extendIdentifiers.assert_called_once_with([])
         mockAddDCDW.assert_called_once_with(mockMappingInstance)
         mockfetchOCLC.assert_called_once_with(['1|test', '2|test'])
 


### PR DESCRIPTION
This adds a new condition that allows the `OCLCClassify` process to page through large Work records retrieved from the classify service. Each page is limited to 500 edition records, so this allows for fetching of larger sets of edition records and thereby improving the accuracy of the DRB records for that work.