### PR TITLE
NOREF Indexing Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## Unreleased -- v0.0.5
+### Fixed
+- Add ability to define default role for agents in ElasticSearch manager
+- Clean up dates as they are processed to remove duplicate values
+- Fix regression in API with ElasticSearch aggregation
+
 ## 2020-12-28 -- v0.0.4
 ### Added
 - Improved Clustering to use Edition data more accurately (e.g. only when present)

--- a/api/elastic.py
+++ b/api/elastic.py
@@ -143,7 +143,7 @@ class ElasticClient():
 
         dateFilter, dateAggregation = (None, None)
         formatFilter, formatAggregation = (None, None)
-        displayFilter, displayAggregation = (Q('exists', field='editions.formats'),A('filters', **{'exists': {'field': 'editions.formats'}}))
+        displayFilter, displayAggregation = (Q('exists', field='editions.formats'),A('filter', **{'exists': {'field': 'editions.formats'}}))
 
         if len(dateFilters) > 0:
             dateRange = ElasticClient.generateDateRange(dateFilters)

--- a/managers/sfrElasticRecord.py
+++ b/managers/sfrElasticRecord.py
@@ -49,7 +49,7 @@ class SFRElasticRecordManager:
         self.work.subjects = [ESSubject(**s) for s in self.dbWork.subjects]
 
         self.work.agents = [
-            ESAgent(**SFRElasticRecordManager.addAgent(a))
+            ESAgent(**SFRElasticRecordManager.addAgent(a, defaultRole='author'))
             for a in [*self.dbWork.authors, *self.dbWork.contributors]
         ]
 
@@ -69,9 +69,9 @@ class SFRElasticRecordManager:
         self.work.editions = [self.createEdition(e) for e in self.dbWork.editions]
 
     @staticmethod
-    def addAgent(agent):
+    def addAgent(agent, defaultRole='author'):
         agent['sort_name'] = agent['name'].lower()
-        agent['roles'] = agent.get('roles', ['author'])
+        agent['roles'] = agent.get('roles', [defaultRole])
         return agent
     
     @staticmethod
@@ -98,7 +98,7 @@ class SFRElasticRecordManager:
         newEd.identifiers = [ESIdentifier(**dict(i)) for i in edition.identifiers]
 
         newEd.agents = [
-            ESAgent(**SFRElasticRecordManager.addAgent(a))
+            ESAgent(**SFRElasticRecordManager.addAgent(a, defaultRole='publisher'))
             for a in [*edition.publishers, *edition.contributors]
         ]
 

--- a/managers/sfrRecord.py
+++ b/managers/sfrRecord.py
@@ -169,7 +169,7 @@ class SFRRecordManager:
             workData['subjects'].update(rec.subjects)
         
         # Dates
-        editionData['dates'].update(rec.dates)
+        editionData['dates'].update(self.normalizeDates(rec.dates))
 
         # Languages
         workData['languages'].update(rec.languages)
@@ -466,6 +466,14 @@ class SFRRecordManager:
                 ag['roles'] = list(ag['roles'])
 
         return outAgents
+
+    def normalizeDates(self, dates):
+        outDates = set()
+        for date in dates:
+            cleanDate = re.search(r'\d+.*\d+', date).group()
+            outDates.add(cleanDate)
+
+        return list(outDates)
 
     @staticmethod
     def mergeAgents(existing, new):

--- a/tests/unit/test_api_es.py
+++ b/tests/unit/test_api_es.py
@@ -386,7 +386,7 @@ class TestElasticClient:
         filtersAndAggs = ElasticClient.addFilterClausesAndAggregations(mockSearch, [])
 
         mockQuery.assert_called_once_with('exists', field='editions.formats')
-        mockAgg.assert_called_once_with('filters', exists={'field': 'editions.formats'})
+        mockAgg.assert_called_once_with('filter', exists={'field': 'editions.formats'})
 
         mockApply.assert_called_once_with(mockSearch, [], ['formatFilter'])
         mockApplyAggs.assert_called_once_with(mockSearch, ['formatAggregation'])
@@ -412,7 +412,7 @@ class TestElasticClient:
             mocker.call('range', **{'editions.publication_date': 'testRange'})
         ])
         mockAgg.assert_has_calls([
-            mocker.call('filters', exists={'field': 'editions.formats'}),
+            mocker.call('filter', exists={'field': 'editions.formats'}),
             mocker.call('filter', range={'editions.publication_date': 'testRange'})
         ])
 
@@ -438,7 +438,7 @@ class TestElasticClient:
             mocker.call('terms', instances__formats=['test1', 'test2'])
         ])
         mockAgg.assert_has_calls([
-            mocker.call('filters', exists={'field': 'editions.formats'}),
+            mocker.call('filter', exists={'field': 'editions.formats'}),
             mocker.call('filter', terms={'editions.formats': ['test1', 'test2']})
         ])
 
@@ -463,7 +463,7 @@ class TestElasticClient:
             mocker.call('exists', field='editions.formats'),
         ])
         mockAgg.assert_has_calls([
-            mocker.call('filters', exists={'field': 'editions.formats'}),
+            mocker.call('filter', exists={'field': 'editions.formats'}),
         ])
 
         mockApply.assert_called_once_with(mockSearch, [('language', 'Test1')], ['displayFilter'])
@@ -485,7 +485,7 @@ class TestElasticClient:
             mocker.call('exists', field='editions.formats'),
         ])
         mockAgg.assert_has_calls([
-            mocker.call('filters', exists={'field': 'editions.formats'}),
+            mocker.call('filter', exists={'field': 'editions.formats'}),
         ])
 
         mockApply.assert_called_once_with(mockSearch, [], [])

--- a/tests/unit/test_sfrElastic_manager.py
+++ b/tests/unit/test_sfrElastic_manager.py
@@ -137,11 +137,17 @@ class TestSFRElasticRecordManager:
         assert testAgent['sort_name'] == 'test agent'
         assert testAgent['roles'] == ['Role 1', 'Role 2']
 
-    def test_addAgent_without_roles(self):
+    def test_addAgent_without_roles_default(self):
         testAgent = SFRElasticRecordManager.addAgent({'name': 'Test Agent'})
 
         assert testAgent['sort_name'] == 'test agent'
         assert testAgent['roles'] == ['author']
+
+    def test_addAgent_without_roles_custom(self):
+        testAgent = SFRElasticRecordManager.addAgent({'name': 'Test Agent'}, defaultRole='tester')
+
+        assert testAgent['sort_name'] == 'test agent'
+        assert testAgent['roles'] == ['tester']
 
     def test_addGovDocStatus_measurement_present_true(self, mocker):
         govMeasure = mocker.MagicMock()

--- a/tests/unit/test_sfrRecord_manager.py
+++ b/tests/unit/test_sfrRecord_manager.py
@@ -190,6 +190,8 @@ class TestSFRRecordManager:
 
     def test_parseInstance(self, testInstance, testDCDWRecord, mocker):
         mockItemBuild = mocker.patch.object(SFRRecordManager, 'buildItems')
+        mockNormalizeDates = mocker.patch.object(SFRRecordManager, 'normalizeDates')
+        mockNormalizeDates.return_value = ['Date 1', 'Date 2']
         testWork = SFRRecordManager.createEmptyWorkRecord()
         testEdition = SFRRecordManager.createEmptyEditionRecord()
 
@@ -218,6 +220,7 @@ class TestSFRRecordManager:
         assert testEdition['measurements'] == set(['test|other'])
         assert testEdition['dcdw_uuids'] == ['testUUID']
         mockItemBuild.assert_called_once_with(testEdition, testDCDWRecord, set(['Contrib 2|||provider']))
+        mockNormalizeDates.assert_called_once_with(['Date 1', 'Date 2'])
 
     def test_buildItems(self, testInstance, testDCDWRecord):
         testEditionData = {'items': [], 'links': []}
@@ -356,3 +359,8 @@ class TestSFRRecordManager:
         testInstance.setSortTitle()
 
         assert testInstance.work.sort_title == 'kplagh: batleth handbook'
+
+    def test_normalizeDates(self, testInstance):
+        testDates = testInstance.normalizeDates(['1999.', '2000', 'sometime 1900-12 [pub]'])
+
+        assert sorted(testDates) == sorted(['1999', '2000', '1900-12'])


### PR DESCRIPTION
This is a somewhat minor PR that resolves several bugs in the indexing process:

- Add ability to define default role for agents in ElasticSearch manager
- Clean up dates as they are processed to remove duplicate values
- Fix regression in API with ElasticSearch aggregation