### PR TITLE
NOREF Add multiprocessing to S3 Process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # CHANGELOG
 
 ## Unreleased -- v0.0.5
+### Added
+- Added multiprocessing to S3FileProcess
 ### Fixed
 - Add ability to define default role for agents in ElasticSearch manager
 - Clean up dates as they are processed to remove duplicate values

--- a/processes/s3Files.py
+++ b/processes/s3Files.py
@@ -1,30 +1,47 @@
 import json
+from multiprocessing import Process, Queue
 import os
 import requests
-from time import sleep
+from time import sleep, time
 
 from .core import CoreProcess
+from managers import S3Manager, RabbitMQManager
 
 
 class S3Process(CoreProcess):
     def __init__(self, process, customFile, ingestPeriod):
         super(S3Process, self).__init__(process, customFile, ingestPeriod)
 
-        # Create RabbitMQ Connection
-        self.createRabbitConnection()
-        self.createChannel()
-
-        # Create S3 Connection
-        self.createS3Client()
-        self.bucket = os.environ['FILE_BUCKET']
-    
     def runProcess(self):
         self.receiveAndProcessMessages()
 
     def receiveAndProcessMessages(self):
+        processes = 4
+        epubProcesses = []
+        for _ in range(processes):
+            proc = Process(target=S3Process.storeFilesInS3)
+            proc.start()
+            epubProcesses.append(proc)
+
+        for proc in epubProcesses:
+            proc.join()
+
+    @staticmethod
+    def storeFilesInS3():
+        storageManager = S3Manager()
+        storageManager.createS3Client()
+
+        fileQueue = os.environ['FILE_QUEUE']
+        rabbitManager = RabbitMQManager()
+        rabbitManager.createRabbitConnection()
+        rabbitManager.createOrConnectQueue(fileQueue)
+
+        bucket = os.environ['FILE_BUCKET']
+
         attempts = 1
         while True:
-            msgProps, msgParams, msgBody = self.getMessageFromQueue(os.environ['FILE_QUEUE'])
+            print(rabbitManager)
+            msgProps, _, msgBody = rabbitManager.getMessageFromQueue(fileQueue)
             if msgProps is None:
                 if attempts <= 3:
                     sleep(30 * attempts)
@@ -35,20 +52,31 @@ class S3Process(CoreProcess):
             
             attempts = 1
 
-            self.storeFileInS3(msgBody)
-            self.acknowledgeMessageProcessed(msgProps.delivery_tag)
-    
-    def storeFileInS3(self, msg):
-        fileMeta = json.loads(msg)['fileData']
-        fileURL = fileMeta['fileURL']
-        filePath = fileMeta['bucketPath']
-        epubB = self.getFileContents(fileURL)
+            fileMeta = json.loads(msgBody)['fileData']
+            fileURL = fileMeta['fileURL']
+            filePath = fileMeta['bucketPath']
 
-        self.putObjectInBucket(epubB, filePath, self.bucket)
-    
-    def getFileContents(self, epubURL):
-        epubResp = requests.get(epubURL)
+            try:
+                epubB = S3Process.getFileContents(fileURL)
+                storageManager.putObjectInBucket(epubB, filePath, bucket)
+                rabbitManager.acknowledgeMessageProcessed(msgProps.delivery_tag)
+                print('Sending Tag {} for {}'.format(fileURL, msgProps.delivery_tag))
+            except Exception as e:
+                print(e)
+
+    @staticmethod
+    def getFileContents(epubURL):
+        start = time()
+        timeout = 90
+        epubResp = requests.get(epubURL, stream=True, timeout=90)
         if epubResp.status_code == 200:
-            return epubResp.content
+            content = bytes()
+            for byteChunk in epubResp.iter_content(1024):
+                print(byteChunk)
+                if time() - start > timeout:
+                    raise TimeoutError('Unable to process {} in time'.format(epubURL))
+                content += byteChunk
+
+            return content
         
         raise Exception('Unable to fetch ePub file')

--- a/processes/s3Files.py
+++ b/processes/s3Files.py
@@ -56,9 +56,9 @@ class S3Process(CoreProcess):
             filePath = fileMeta['bucketPath']
 
             try:
-                rabbitManager.acknowledgeMessageProcessed(msgProps.delivery_tag)
                 epubB = S3Process.getFileContents(fileURL)
                 storageManager.putObjectInBucket(epubB, filePath, bucket)
+                rabbitManager.acknowledgeMessageProcessed(msgProps.delivery_tag)
                 print('Sending Tag {} for {}'.format(fileURL, msgProps.delivery_tag))
             except Exception as e:
                 print(e)
@@ -66,8 +66,8 @@ class S3Process(CoreProcess):
     @staticmethod
     def getFileContents(epubURL):
         start = time()
-        timeout = 90
-        epubResp = requests.get(epubURL, stream=True, timeout=90)
+        timeout = 120 
+        epubResp = requests.get(epubURL, stream=True, timeout=timeout)
         if epubResp.status_code == 200:
             content = bytes()
             for byteChunk in epubResp.iter_content(1024):

--- a/tests/unit/test_sfrFile_process.py
+++ b/tests/unit/test_sfrFile_process.py
@@ -45,53 +45,63 @@ class TestS3Process:
         mockCommit.assert_called_once
 
     def test_receiveAndProcessMessages(self, testInstance, mocker):
+        mockProc = mocker.MagicMock()
+        mockProcess = mocker.patch('processes.s3Files.Process')
+        mockProcess.return_value = mockProc
+
+        testInstance.receiveAndProcessMessages()
+
+        assert mockProcess.call_count == 4
+        assert mockProc.start.call_count == 4
+        assert mockProc.join.call_count == 4
+
+    def test_storeFilesInS3(self, testFile, mocker):
         mockSleep = mocker.patch('processes.s3Files.sleep')
-        mockQueueGet = mocker.patch.object(S3Process, 'getMessageFromQueue')
+
+        mockS3 = mocker.MagicMock()
+        mockS3Manager = mocker.patch('processes.s3Files.S3Manager')
+        mockS3Manager.return_value = mockS3
+
+        mockRabbit = mocker.MagicMock()
+        mockRabbitManager = mocker.patch('processes.s3Files.RabbitMQManager')
+        mockRabbitManager.return_value = mockRabbit
+
         mockProps = mocker.MagicMock()
         mockProps.delivery_tag = 'rabbitMQTag'
-        mockQueueGet.side_effect = [
-            (mockProps, {}, 'epub_record'),
+        mockRabbit.getMessageFromQueue.side_effect = [
+            (mockProps, {}, testFile),
             (None, None, None),
             (None, None, None),
             (None, None, None),
             (None, None, None)
         ]
-        mockStore = mocker.patch.object(S3Process, 'storeFileInS3')
-        mockAcknowledge = mocker.patch.object(S3Process, 'acknowledgeMessageProcessed')
 
-        testInstance.receiveAndProcessMessages()
+        mockGet = mocker.patch.object(S3Process, 'getFileContents')
+        mockGet.return_value = 'testFileBytes'
 
-        assert mockQueueGet.call_count == 5
-        mockQueueGet.assert_called_with('test_file_queue')
+        S3Process.storeFilesInS3()
+
+        assert mockRabbit.getMessageFromQueue.call_count == 5
+        mockRabbit.getMessageFromQueue.assert_called_with('test_file_queue')
 
         mockSleep.assert_has_calls([
             mocker.call(30), mocker.call(60), mocker.call(90)
         ])
 
-        mockStore.assert_called_once_with('epub_record')
-        mockAcknowledge.assert_called_once_with('rabbitMQTag')
-
-    def test_storeFileInS3(self, testInstance, testFile, mocker):
-        mockGetContents = mocker.patch.object(S3Process, 'getFileContents')
-        mockGetContents.return_value = 'epubBinary'
-        mockPutInS3 = mocker.patch.object(S3Process, 'putObjectInBucket')
-
-        testInstance.storeFileInS3(testFile)
-
-        mockGetContents.assert_called_once_with('testSourceURL')
-        mockPutInS3.assert_called_once_with('epubBinary', 'testBucketPath', 'testBucket')
+        mockS3.putObjectInBucket.assert_called_once_with('testFileBytes', 'testBucketPath', 'test_aws_bucket')
+        mockRabbit.acknowledgeMessageProcessed.assert_called_once_with('rabbitMQTag')
 
     def test_getFileContents_success(self, testInstance, mocker):
         mockGet = mocker.patch.object(requests, 'get')
         mockResp = mocker.MagicMock()
         mockResp.status_code = 200
-        mockResp.content = 'epubBinary'
+        mockResp.iter_content.return_value = [b'e', b'p', b'u', b'b']
         mockGet.return_value = mockResp
 
         testEpubFile = testInstance.getFileContents('testURL')
 
-        assert testEpubFile == 'epubBinary'
-        mockGet.assert_called_once_with('testURL')
+        assert testEpubFile == b'epub'
+        mockGet.assert_called_once_with('testURL', stream=True, timeout=90)
         
     def test_getFileContents_error(self, testInstance, mocker):
         mockGet = mocker.patch.object(requests, 'get')
@@ -100,5 +110,4 @@ class TestS3Process:
         mockGet.return_value = mockResp
 
         with pytest.raises(Exception):
-            testEpubFile = testInstance.getFileContents('testURL')
-            mockGet.assert_called_once_with('testURL')
+            testInstance.getFileContents('testURL')

--- a/tests/unit/test_sfrFile_process.py
+++ b/tests/unit/test_sfrFile_process.py
@@ -101,7 +101,7 @@ class TestS3Process:
         testEpubFile = testInstance.getFileContents('testURL')
 
         assert testEpubFile == b'epub'
-        mockGet.assert_called_once_with('testURL', stream=True, timeout=90)
+        mockGet.assert_called_once_with('testURL', stream=True, timeout=120)
         
     def test_getFileContents_error(self, testInstance, mocker):
         mockGet = mocker.patch.object(requests, 'get')


### PR DESCRIPTION
This adds a performance boost to the storing of files in S3 by allowing several threads to run in parallel.

This also includes a naive fix to timeout issue that was being encountered with a very small number of large ePub files (generally 100 MB+). These were causing timeouts because of the long download/upload times. The process now detects these large files and omits them. This is not ideal but allows for a smoother overall process.