### PR TITLE
NOREF HathiTrust Error Handling Improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add ability to define default role for agents in ElasticSearch manager
 - Clean up dates as they are processed to remove duplicate values
 - Fix regression in API with ElasticSearch aggregation
+- Improved error handling in HathiTrust processor
 
 ## 2020-12-28 -- v0.0.4
 ### Added

--- a/mappings/hathitrust.py
+++ b/mappings/hathitrust.py
@@ -41,6 +41,7 @@ class HathiMapping(CSVMapping):
         self.record.source_id = self.record.identifiers[0]
 
         # Parse publisher from publication date
+        self.record.dates = self.record.dates or ['']
         pubDate = self.record.dates[0]
         try:
             pubDateExtract = re.search(r'[0-9]{4}', pubDate).group(0)
@@ -53,13 +54,14 @@ class HathiMapping(CSVMapping):
 
         
         # Parse contributers into full names
+        self.record.contributors = self.record.contributors or []
         for i, contributor in enumerate(self.record.contributors):
             contribElements = contributor.lower().split('|')
             fullContribName = self.staticValues['hathitrust']['sourceCodes'].get(contribElements[0], contribElements[0])
             self.record.contributors[i] = contributor.replace(contribElements[0], fullContribName)
 
         # Parse rights codes
-        rightsElements = self.record.rights.split('|')
+        rightsElements = self.record.rights.split('|') if self.record.rights else [''] * 5
         rightsMetadata = self.staticValues['hathitrust']['rightsValues'].get(rightsElements[1], {'license': 'und', 'statement': 'und'}) 
         self.record.rights = '{}|{}|{}|{}'.format(
             rightsMetadata['license'],
@@ -86,4 +88,5 @@ class HathiMapping(CSVMapping):
         self.record.has_part = [readOnlineLink, downloadLink]
 
         # Parse spatial (pub place) codes
+        self.record.spatial = self.record.spatial or ''
         self.record.spatial = self.staticValues['marc']['countryCodes'].get(self.record.spatial.strip(), 'xx')

--- a/processes/hathiTrust.py
+++ b/processes/hathiTrust.py
@@ -38,11 +38,8 @@ class HathiTrustProcess(CoreProcess):
         except FileNotFoundError:
             raise IOError('Unable to open local CSV file')
 
-        hathiReader = csv.reader(hathiFile)
-
-        for row in hathiReader:
-            if row[2] not in self.HATHI_RIGHTS_SKIPS and row[0] != 'htid':
-                self.parseHathiDataRow(row)
+        hathiReader = csv.reader(hathiFile, delimiter='\t')
+        self.readHathiFile(hathiReader)
 
     def parseHathiDataRow(self, dataRow):
         hathiRec = HathiMapping(dataRow, self.statics)
@@ -73,6 +70,16 @@ class HathiTrustProcess(CoreProcess):
 
         with gzip.open('/tmp/tmp_hathi.txt.gz', 'rt') as unzipTSV:
             hathiTSV = csv.reader(unzipTSV, delimiter='\t')
-            for row in hathiTSV:
-                if row[2] not in self.HATHI_RIGHTS_SKIPS:
-                    self.parseHathiDataRow(row)
+            self.readHathiFile(hathiTSV)
+
+    def readHathiFile(self, hathiTSV):
+        while True:
+            try:
+                row = next(hathiTSV)
+            except csv.Error:
+                continue
+            except StopIteration:
+                break
+
+            if row is not None and row[2] not in self.HATHI_RIGHTS_SKIPS:
+                self.parseHathiDataRow(row)


### PR DESCRIPTION
This improves error handling in the HathiTrust process through a small refactor that moves the iteration of the CSV file into its own method. This allows for error handling for individual rows, and prevents a case where a single malformed row could block and entire import.