### PR TITLE
NOREF Gutenberg batched imports and epub manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # CHANGELOG
 
 ## Unreleased -- v0.0.5
+### Added
+- `limit` and `offset` as optional arguments to the main process
 ### Fixed
 - Add ability to define default role for agents in ElasticSearch manager
 - Clean up dates as they are processed to remove duplicate values

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased -- v0.0.5
 ### Added
 - `limit` and `offset` as optional arguments to the main process
+- "Exploded" versions of ePub files in S3
 ### Fixed
 - Add ability to define default role for agents in ElasticSearch manager
 - Clean up dates as they are processed to remove duplicate values

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ All services share a single entry point in `main.py` file. This script dynamical
 - `--ingestType` Applicable for processes that fetch records from external sources. Generally three settings are available (see individual processes for their own settings): `daily`, `complete` and `custom`
 - `--inputFile` Used with the `custom` ingest setting provides a local file of records to import
 - `--startDate` Also used with the `custom` ingest setting, sets a start point for a period to query or ingest records
+- `--limit` Limits the total number of rows imported in a single process
+- `--offset` Skips the first `n` rows of an import process
 
 To set up a local environment there is a special process (which is also run when creating a local Kubernetes cluster) to initialize a database and search cluster. To set this up run `python main.py --process DevelopmentSetupProcess` which will run a short import process and populate the database with some sample data.
 

--- a/main.py
+++ b/main.py
@@ -9,11 +9,13 @@ def main(args):
     procType = args.ingestType
     customFile = args.inputFile
     startDate = args.startDate
+    limit = args.limit
+    offset = args.offset
 
     availableProcesses = registerProcesses()
 
     procClass = availableProcesses[process]
-    processInstance = procClass(procType, customFile, startDate)
+    processInstance = procClass(procType, customFile, startDate, limit, offset)
     processInstance.runProcess()
 
 
@@ -35,6 +37,10 @@ def createArgParser():
                         help='Name of file to ingest. Ignored if -i custom is not set')
     parser.add_argument('-s', '--startDate',
                         help='Start point for coverage period to query/process')
+    parser.add_argument('-l', '--limit',
+                        help='Set overall limit for number of records imported in this process')
+    parser.add_argument('-o', '--offset',
+                        help='Set start offset for current processed (for batched import process)')
     
     return parser
 

--- a/mappings/gutenberg.py
+++ b/mappings/gutenberg.py
@@ -85,11 +85,20 @@ class GutenbergMapping(XMLMapping):
         # Add Read Online links
         self.record.has_part = []
         for i, extension in enumerate(['.images', '.noimages']):
-            epubLink = '{}|{}|{}|{}|{}'.format(
+            epubDownloadLink = '{}|{}|{}|{}|{}'.format(
                 i + 1,
                 'https://gutenberg.org/ebooks/{}.epub{}'.format(gutenbergID, extension),
                 'gutenberg',
                 'application/epub+zip',
-                json.dumps({'reader': True, 'download': True, 'catalog': False})
+                json.dumps({'reader': False, 'download': True, 'catalog': False})
             )
-            self.record.has_part.append(epubLink)
+
+            epubReadLink = '{}|{}|{}|{}|{}'.format(
+                i + 1,
+                'https://gutenberg.org/ebooks/{}.epub{}'.format(gutenbergID, extension),
+                'gutenberg',
+                'application/epub',
+                json.dumps({'reader': True, 'download': False, 'catalog': False})
+            )
+
+            self.record.has_part.extend([epubDownloadLink, epubReadLink])

--- a/processes/api.py
+++ b/processes/api.py
@@ -3,8 +3,8 @@ from api.app import FlaskAPI
 
 
 class APIProcess(CoreProcess):
-    def __init__(self, process, customFile, ingestPeriod):
-        super(APIProcess, self).__init__(process, customFile, ingestPeriod)
+    def __init__(self, *args):
+        super(APIProcess, self).__init__(*args[:3])
 
         self.createElasticConnection()
         self.generateEngine()

--- a/processes/developmentSetup.py
+++ b/processes/developmentSetup.py
@@ -15,7 +15,7 @@ from .sfrCluster import ClusterProcess
 
 
 class DevelopmentSetupProcess(CoreProcess):
-    def __init__(self, process, customFile, ingestPeriod):
+    def __init__(self, *args):
         self.adminDBConnection = DBManager(
             user=os.environ['ADMIN_USER'],
             pswd=os.environ['ADMIN_PSWD'],
@@ -25,7 +25,7 @@ class DevelopmentSetupProcess(CoreProcess):
         )
         self.initializeDB()
 
-        super(DevelopmentSetupProcess, self).__init__(process, customFile, ingestPeriod)
+        super(DevelopmentSetupProcess, self).__init__(*args[:3])
 
     def runProcess(self):
         # Setup database if necessary

--- a/processes/hathiTrust.py
+++ b/processes/hathiTrust.py
@@ -13,8 +13,8 @@ from model import Record
 class HathiTrustProcess(CoreProcess):
     HATHI_RIGHTS_SKIPS = ['ic', 'icus', 'ic-world', 'und']
 
-    def __init__(self, process, customFile, ingestPeriod):
-        super(HathiTrustProcess, self).__init__(process, customFile, ingestPeriod)
+    def __init__(self, *args):
+        super(HathiTrustProcess, self).__init__(*args[:3])
         self.generateEngine()
         self.createSession()
 

--- a/processes/nypl.py
+++ b/processes/nypl.py
@@ -8,8 +8,8 @@ from mappings.nypl import NYPLMapping
 
 
 class NYPLProcess(CoreProcess):
-    def __init__(self, process, customFile, ingestPeriod):
-        super(NYPLProcess, self).__init__(process, customFile, ingestPeriod)
+    def __init__(self, *args):
+        super(NYPLProcess, self).__init__(*args[:3])
         self.generateEngine()
         self.createSession()
         self.generateAccessToken()

--- a/processes/oclcCatalog.py
+++ b/processes/oclcCatalog.py
@@ -10,8 +10,8 @@ from model import Record
 
 
 class CatalogProcess(CoreProcess):
-    def __init__(self, process, customFile, ingestPeriod):
-        super(CatalogProcess, self).__init__(process, customFile, ingestPeriod)
+    def __init__(self, *args):
+        super(CatalogProcess, self).__init__(*args[:3])
 
         # PostgreSQL Connection
         self.generateEngine()

--- a/processes/oclcClassify.py
+++ b/processes/oclcClassify.py
@@ -9,8 +9,8 @@ from model import Record
 
 
 class ClassifyProcess(CoreProcess):
-    def __init__(self, process, customFile, ingestPeriod):
-        super(ClassifyProcess, self).__init__(process, customFile, ingestPeriod)
+    def __init__(self, *args):
+        super(ClassifyProcess, self).__init__(*args[:3])
 
         # PostgreSQL Connection
         self.generateEngine()

--- a/processes/s3Files.py
+++ b/processes/s3Files.py
@@ -7,8 +7,8 @@ from .core import CoreProcess
 
 
 class S3Process(CoreProcess):
-    def __init__(self, process, customFile, ingestPeriod):
-        super(S3Process, self).__init__(process, customFile, ingestPeriod)
+    def __init__(self, *args):
+        super(S3Process, self).__init__(*args[:3])
 
         # Create RabbitMQ Connection
         self.createRabbitConnection()

--- a/processes/sfrCluster.py
+++ b/processes/sfrCluster.py
@@ -8,8 +8,8 @@ from model import Record
 
 
 class ClusterProcess(CoreProcess):
-    def __init__(self, process, customFile, ingestPeriod):
-        super(ClusterProcess, self).__init__(process, customFile, ingestPeriod)
+    def __init__(self, *args):
+        super(ClusterProcess, self).__init__(*args[:3])
 
         # PostgreSQL Connection
         self.generateEngine()

--- a/tests/unit/test_gutenberg_mapping.py
+++ b/tests/unit/test_gutenberg_mapping.py
@@ -56,6 +56,8 @@ class TestGutenbergMapping:
         assert testMapping.record.contributors == ['Contributor|1234|n9876|Tester']
         assert testMapping.record.authors == ['Author1 (1950-2020)|||true', 'Author2|||false']
         assert testMapping.record.has_part == [
-            '1|https://gutenberg.org/ebooks/1.epub.images|gutenberg|application/epub+zip|{"reader": true, "download": true, "catalog": false}',
-            '2|https://gutenberg.org/ebooks/1.epub.noimages|gutenberg|application/epub+zip|{"reader": true, "download": true, "catalog": false}',
+            '1|https://gutenberg.org/ebooks/1.epub.images|gutenberg|application/epub+zip|{"reader": false, "download": true, "catalog": false}',
+            '1|https://gutenberg.org/ebooks/1.epub.images|gutenberg|application/epub|{"reader": true, "download": false, "catalog": false}',
+            '2|https://gutenberg.org/ebooks/1.epub.noimages|gutenberg|application/epub+zip|{"reader": false, "download": true, "catalog": false}',
+            '2|https://gutenberg.org/ebooks/1.epub.noimages|gutenberg|application/epub|{"reader": true, "download": false, "catalog": false}'
         ]

--- a/tests/unit/test_gutenberg_process.py
+++ b/tests/unit/test_gutenberg_process.py
@@ -20,6 +20,8 @@ class TestGutenbergProcess:
         class TestGutenbergProcess(GutenbergProcess):
             def __init__(self, process, customFile, ingestPeriod):
                 self.statics = {}
+                self.ingestOffset = 0
+                self.ingestLimit = 5000
                 self.s3Bucket = os.environ['FILE_BUCKET']
                 self.fileQueue = os.environ['FILE_QUEUE']
         

--- a/tests/unit/test_gutenberg_process.py
+++ b/tests/unit/test_gutenberg_process.py
@@ -158,8 +158,9 @@ class TestGutenbergProcess:
     def test_storeEpubsInS3(self, testInstance, mocker):
         mockRecord = mocker.MagicMock()
         mockRecord.record.has_part = [
-            '1|gutenberg.org/ebook/1.epub.images|gutenberg|application/epub|{}',
-            '2|gutenberg.org/ebook/2.epub.noimages|gutenberg|application/epub|{}',
+            '1|gutenberg.org/ebook/1.epub.images|gutenberg|application/epub+zip|{"download": true}',
+            '1|gutenberg.org/ebook/1.epub.images|gutenberg|application/epub|{"download": false}',
+            '2|gutenberg.org/ebook/2.epub.noimages|gutenberg|application/epub+zip|{"download": true}',
         ]
 
         mockSendToQueue = mocker.patch.object(GutenbergProcess, 'sendFileToProcessingQueue')
@@ -171,8 +172,9 @@ class TestGutenbergProcess:
             mocker.call('gutenberg.org/ebook/2.epub.noimages', 'epubs/gutenberg/2_noimages.epub')
         ])
         assert mockRecord.record.has_part == [
-            '1|https://test_aws_bucket.s3.amazonaws.com/epubs/gutenberg/1_images.epub|gutenberg|application/epub|{}',
-            '2|https://test_aws_bucket.s3.amazonaws.com/epubs/gutenberg/2_noimages.epub|gutenberg|application/epub|{}',
+            '1|https://test_aws_bucket.s3.amazonaws.com/epubs/gutenberg/1_images.epub|gutenberg|application/epub+zip|{"download": true}',
+            '1|https://test_aws_bucket.s3.amazonaws.com/epubs/gutenberg/1_images/oebps/content.opf|gutenberg|application/epub|{"download": false}',
+            '2|https://test_aws_bucket.s3.amazonaws.com/epubs/gutenberg/2_noimages.epub|gutenberg|application/epub+zip|{"download": true}',
         ]
 
     def test_addCoverAndStoreInS3(self, testInstance, testMetadataYAML, mocker):

--- a/tests/unit/test_main_process.py
+++ b/tests/unit/test_main_process.py
@@ -17,6 +17,8 @@ class TestMainProcess:
         mockArgs.ingestType = 'test'
         mockArgs.inputFile = 'testFile'
         mockArgs.startDate = 'testDate'
+        mockArgs.limit = 'testLimit'
+        mockArgs.offset = 'testOffset'
 
         return mockArgs
 
@@ -36,7 +38,7 @@ class TestMainProcess:
 
         main(processArgs)
 
-        mockProcess.assert_called_with('test', 'testFile', 'testDate')
+        mockProcess.assert_called_with('test', 'testFile', 'testDate', 'testLimit', 'testOffset')
         mockInstance.runProcess.assert_called_once
 
     def test_registerProcesses(self, mocker):
@@ -56,7 +58,9 @@ class TestMainProcess:
             '-e', 'test',
             '-i', 'testIngest',
             '-f', 'testFile',
-            '-s', 'testDate'     
+            '-s', 'testDate',
+            '-l', 'testLimit',
+            '-o', 'testOffset'
         ]
 
         argParser = createArgParser()
@@ -67,6 +71,8 @@ class TestMainProcess:
         assert testArgs.ingestType == 'testIngest'
         assert testArgs.inputFile == 'testFile'
         assert testArgs.startDate == 'testDate'
+        assert testArgs.limit == 'testLimit'
+        assert testArgs.offset == 'testOffset'
 
     def test_argParser_allArgs_longform(self, mocker):
         sys.argv = [
@@ -75,7 +81,9 @@ class TestMainProcess:
             '--environment', 'test',
             '--ingestType', 'testIngest',
             '--inputFile', 'testFile',
-            '--startDate', 'testDate'     
+            '--startDate', 'testDate',
+            '--limit', 'testLimit',
+            '--offset', 'testOffset'
         ]
 
         argParser = createArgParser()
@@ -86,6 +94,8 @@ class TestMainProcess:
         assert testArgs.ingestType == 'testIngest'
         assert testArgs.inputFile == 'testFile'
         assert testArgs.startDate == 'testDate'
+        assert testArgs.limit == 'testLimit'
+        assert testArgs.offset == 'testOffset'
 
     def test_argParser_missingReqArg(self, mocker):
         sys.argv = [


### PR DESCRIPTION
This adds two new parameters to the main invocation process: `limit` and `offset`. These allow for processed to be batched, which is useful when testing and doing bulk loading of data. The impetus for this was the need to rate limit the Gutenberg ingest process due to restrictions on the GitHub GraphQL API, but it will likely prove to be useful in other areas as well.

This also adds the "exploded" versions of Gutenberg ePub files for use by the webpub reader. This also generally improves the handling of the epub ingest process and handles errors better.