### PR TITLE
NOREF Add batching to limit size of Classify Process

### DIFF
--- a/processes/oclcClassify.py
+++ b/processes/oclcClassify.py
@@ -12,6 +12,8 @@ class ClassifyProcess(CoreProcess):
     def __init__(self, *args):
         super(ClassifyProcess, self).__init__(*args[:3])
 
+        self.ingestLimit = args[3] or None
+
         # PostgreSQL Connection
         self.generateEngine()
         self.createSession()
@@ -41,6 +43,9 @@ class ClassifyProcess(CoreProcess):
             if not startDateTime:
                 startDateTime = datetime.utcnow() - timedelta(hours=24)
             baseQuery = baseQuery.filter(Record.date_modified > startDateTime)
+
+        if self.ingestLimit:
+            baseQuery = baseQuery.limit(self.ingestLimit)
         
         for rec in baseQuery.yield_per(100):
             self.frbrizeRecord(rec)


### PR DESCRIPTION
This allows the classify process to be run in batches of arbitrary size. This will not be used in the daily import process but provides useful functionality when running large (or complete) custom import jobs. It allows for the control of records going to the Catalog service, which is rate limited.