### PR TITLE
SFR-956 Add Project MUSE Process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## unreleased -- v0.1.0
+### Added
+- Mapping for parsing `MARC` records
+- Manager for generating PDF manifest files (in JSON-LD)
+- Process for ingesting records from Project MUSE
+
 ## 2021-01-06 -- v0.0.5
 ### Added
 - Added multiprocessing to S3FileProcess

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ The currently available processes are:
 - `S3Process` Fetch files (e.g. ePubs, cover images, etc.) associated with Item and Edition records and store them in AWS s3
 - `NYPLProcess` Fetch files from the NYPL catalog (specifically Bib records) and import them
 - `GutenbergProcess` Fetch updated files from Project Gutenberg and import them
+- `MUSEProcess` Fetch open access books from Project MUSE and import them
 
 #### Starting a local Kubernetes cluster
 

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -45,3 +45,6 @@ GITHUB_API_ROOT: https://api.github.com/graphql
 
 # Bardo CCE API URL
 BARDO_CCE_API: http://sfr-bardo-copyright-development.us-east-1.elasticbeanstalk.com/search
+
+# Project MUSE MARC endpoint
+MUSE_MARC_URL: https://about.muse.jhu.edu/lib/metadata?format=marc&content=book&include=oa&filename=open_access_books&no_auth=1

--- a/config/example.yaml
+++ b/config/example.yaml
@@ -56,3 +56,6 @@ GITHUB_API_ROOT: https://api.github.com/graphql
 
 # Bardo CCE API URL
 BARDO_CCE_API: xxx
+
+# Project MUSE MARC endpoint
+MUSE_MARC_URL: xxx

--- a/config/qa.yaml
+++ b/config/qa.yaml
@@ -43,3 +43,6 @@ GITHUB_API_ROOT: https://api.github.com/graphql
 
 # Bardo CCE API URL
 BARDO_CCE_API: http://sfr-bardo-copyright-development.us-east-1.elasticbeanstalk.com/search
+
+# Project MUSE MARC endpoint
+MUSE_MARC_URL: https://about.muse.jhu.edu/lib/metadata?format=marc&content=book&include=oa&filename=open_access_books&no_auth=1

--- a/managers/__init__.py
+++ b/managers/__init__.py
@@ -4,6 +4,7 @@ from .kMeans import KMeansManager
 from .oclcCatalog import OCLCCatalogManager
 from .oclcClassify import ClassifyManager
 from .nyplApi import NyplApiManager
+from .pdfManifest import PDFManifest
 from .rabbitmq import RabbitMQManager
 from .redis import RedisManager
 from .sfrRecord import SFRRecordManager

--- a/managers/pdfManifest.py
+++ b/managers/pdfManifest.py
@@ -1,0 +1,140 @@
+import json
+import os
+import re
+
+
+class PDFManifest:
+    def __init__(self, source):
+        self.metadata = {'@type': 'https://schema.org/Book'}
+        self.links = [
+            {'rel': 'alternate', 'href': source, 'type': 'text/html'}
+        ]
+        self.components = []
+        self.tableOfContents = []
+
+        self.openSection = None
+
+    # TODO validate kwargs against schema.org/Book
+    def addMetadata(self, dcdwRecord):
+        self.metadata['title'] = dcdwRecord.title
+
+        if len(dcdwRecord.authors) > 0:
+            self.metadata['author'] = list(dcdwRecord.authors[0].split('|'))[0]
+
+        isbns = list(filter(lambda x: x[-4:] == 'isbn', dcdwRecord.identifiers))
+        if len(isbns) > 0:
+            self.metadata['identifier'] = 'urn:isbn:{}'.format(isbns[0][:-5])
+
+    def addSection(self, sectionTitle, sectionURL):
+        if self.openSection:
+            self.tableOfContents.append(self.openSection)
+
+        self.openSection = {
+            'href': sectionURL,
+            'title': sectionTitle,
+            'children': []
+        }
+
+    def closeSection(self):
+        if self.openSection:
+            self.tableOfContents.append(self.openSection)
+        
+        self.openSection = None
+
+    # TODO Make it possible to add subsections iteratively
+    def addChapter(self, link, title, pageRange, subsections=None):
+        newChapter = PDFChapter(link, title, pageRange)
+        newChapter.parsePageRange()
+
+        tocEntry = {
+            'href': link, 'title': title, 'pages': pageRange
+        }
+
+        if subsections and isinstance(subsections, list):
+            tocEntry['children'] = subsections
+
+        if self.openSection:
+            self.openSection['children'].append(tocEntry)
+        else:
+            self.tableOfContents.append(tocEntry)
+
+        self.components.append(newChapter)
+
+    def toDict(self):
+        return {
+            'context': 'https://{}-s3.amazonaws.com/manifests/context.jsonld'.format(os.environ['FILE_BUCKET']),
+            'media_type': 'application/pdf+json',
+            'metadata': self.metadata,
+            'links': self.links,
+            'components': [c.toDict() for c in self.components],
+            'table_of_contents': self.tableOfContents
+        }
+
+    def toJson(self):
+        return json.dumps(self.toDict())
+
+
+class PDFChapter:
+    ROMAN_NUMERALS = {'i': 1, 'v': 5, 'x': 10, 'l': 50, 'c': 100, 'm': 1000}
+    def __init__(self, link, title, pageRange):
+        self.link = link
+        self.title = title
+        self.pageRange = pageRange
+        self.startPage = None
+        self.endPage = None
+
+    def parsePageRange(self):
+        if not self.pageRange: return None
+
+        rangeMatch = re.search(r'([\w]+)\-([\w]+)', self.pageRange)
+
+        if rangeMatch:
+            self.startPage = self.parseRangeValue(rangeMatch.group(1))
+            self.endPage = self.parseRangeValue(rangeMatch.group(2))
+
+    @classmethod
+    def parseRangeValue(cls, rangeValue):
+        try:
+            return int(rangeValue)
+        except ValueError:
+            return cls.translateRomanNumeral(rangeValue)
+
+    @classmethod
+    def translateRomanNumeral(cls, rangeValue):
+        rangeLower = rangeValue.lower()
+
+        if not re.search(r'^[ivxlcm]+$', rangeLower): return None
+
+        num = 0
+        pos = 0
+        charVal = cls.ROMAN_NUMERALS[rangeLower[pos]]
+        while pos < len(rangeLower):
+            pos += 1
+
+            try:
+                nextCharVal = cls.ROMAN_NUMERALS[rangeLower[pos]]
+            except IndexError:
+                num += charVal
+                break
+
+            if charVal < nextCharVal:
+                charVal = charVal * -1
+
+            num += charVal
+
+            charVal = nextCharVal
+                
+        return num
+
+    def toDict(self):
+        componentEntry = {
+            'href': self.link, 'title': self.title
+        }
+
+        if self.startPage:
+            componentEntry['pageStart'] = self.startPage
+
+        if self.endPage:
+            componentEntry['pageEnd'] = self.endPage
+
+        return componentEntry

--- a/managers/pdfManifest.py
+++ b/managers/pdfManifest.py
@@ -6,9 +6,10 @@ import re
 class PDFManifest:
     def __init__(self, source):
         self.metadata = {'@type': 'https://schema.org/Book'}
-        self.links = [
-            {'rel': 'alternate', 'href': source, 'type': 'text/html'}
-        ]
+        self.links = {
+            'self': {},
+            'alternate': [{'href': source, 'type': 'text/html'}]
+        }
         self.components = []
         self.tableOfContents = []
 

--- a/mappings/marc.py
+++ b/mappings/marc.py
@@ -1,0 +1,74 @@
+import re
+
+from .core import Core
+
+
+class MARCMapping(Core):
+    def __init__(self, source, statics):
+        super().__init__(source, statics)
+
+    def applyMapping(self):
+        newRecord = self.initEmptyRecord()
+
+        for field, structure in self.mapping.items():
+            try:
+                if isinstance(structure, tuple):
+                    fieldData = self.getFieldData(structure)[0]
+                else:
+                    fieldData = [f for s in structure for f in self.getFieldData(s)]
+            except IndexError:
+                print('Missing data from field {}'.format(field))
+                continue
+            
+            setattr(newRecord, field, fieldData)
+
+        newRecord.identifiers = list(filter(
+            lambda x: x[0] != '|', newRecord.identifiers
+        ))
+
+        self.record = newRecord
+        self.applyFormatting()
+    
+    def getFieldData(self, structure):
+        marcTag, stringFormat = structure
+
+        marcData = self.getMARCData(marcTag)
+
+        return [fd for fd in self.setFieldValues(marcData, stringFormat)]
+
+    def getMARCData(self, marcTag):
+        outData = []
+        for fieldInstance in self.source.get_fields(marcTag):
+            if fieldInstance.is_control_field():
+                outData.append(getattr(fieldInstance, 'data'))
+            else:
+                subfields = {}
+                for i in range(0, len(fieldInstance.subfields), 2):
+                    subfields[fieldInstance.subfields[i]] = fieldInstance.subfields[i + 1]
+
+                outData.append(subfields)                
+        
+        return outData
+
+    def setFieldValues(self, marcData, stringFormat):
+        for marcField in marcData:
+            if marcField is None: continue
+
+            try:
+                yield self.applyStringFormat(marcField, stringFormat)
+            except KeyError:
+                pass
+
+    def applyStringFormat(self, marcField, stringFormat):
+        if isinstance(marcField, str):
+            outStr = self.formatter.format(stringFormat, marcField)
+        else:
+            outStr = self.formatter.format(stringFormat, **marcField)
+
+        # Remove extra spaces from combining multiple subfields
+        outNoDupeSpaces = re.sub(r'\s{2,}', ' ', outStr)
+
+        # Remove spaces at ends of strings, including extraneous punctuation
+        # The negative lookbehind preserves punctuation with initialisms
+        print(outNoDupeSpaces)
+        return re.sub(r'((?<![A-Z]{1}))[ .,;:]+(\||$)', r'\1\2', outNoDupeSpaces)

--- a/mappings/marc.py
+++ b/mappings/marc.py
@@ -70,5 +70,4 @@ class MARCMapping(Core):
 
         # Remove spaces at ends of strings, including extraneous punctuation
         # The negative lookbehind preserves punctuation with initialisms
-        print(outNoDupeSpaces)
         return re.sub(r'((?<![A-Z]{1}))[ .,;:]+(\||$)', r'\1\2', outNoDupeSpaces)

--- a/mappings/muse.py
+++ b/mappings/muse.py
@@ -32,6 +32,7 @@ class MUSEMapping(MARCMapping):
             'dates': [
                 ('264', '{c}|publication_date')
             ],
+            'languages': [('008', '||{0}')],
             'extent': ('300', '{a}{b}{c}'),
             'table_of_contents': ('505', '{a}'),
             'abstract': [
@@ -67,6 +68,9 @@ class MUSEMapping(MARCMapping):
         # Take first title as they are in order of preference
         self.record.title = self.record.title[0]
 
+        # Extract language code from 008 fixed data field
+        self.record.languages = [self.extractLanguage(l) for l in self.record.languages]
+
         # Clean up subjects to remove spots for missing subheadings
         self.record.subjects = [
             self.cleanUpSubjectHead(s)
@@ -89,6 +93,10 @@ class MUSEMapping(MARCMapping):
         cleanSubject = ' -- '.join([p for p in outParts])
 
         return '|'.join([cleanSubject] + subjectMeta)
+
+    def extractLanguage(self, language):
+        _, _, marcData = language.split('|')
+        return '||{}'.format(marcData[35:38])
 
     def addHasPartLink(self, url, mediaType, flags):
         lastItemNo = int(self.record.has_part[0][0])

--- a/mappings/muse.py
+++ b/mappings/muse.py
@@ -95,7 +95,7 @@ class MUSEMapping(MARCMapping):
         return '|'.join([cleanSubject] + subjectMeta)
 
     def extractLanguage(self, language):
-        _, _, marcData = language.split('|')
+        _, _, marcData, *_ = language.split('|')
         return '||{}'.format(marcData[35:38])
 
     def addHasPartLink(self, url, mediaType, flags):

--- a/mappings/muse.py
+++ b/mappings/muse.py
@@ -1,0 +1,98 @@
+from mappings.marc import MARCMapping
+
+class MUSEMapping(MARCMapping):
+    def __init__(self, source):
+        super(MUSEMapping, self).__init__(source, {})
+        self.mapping = self.createMapping()
+    
+    def createMapping(self):
+        return {
+            'identifiers': [
+                ('001', '{0}|muse'),
+                ('010', '{z}|lccn'),
+                ('020', '{a}{z}|isbn'),
+                ('022', '{a}|issn'),
+                ('035', '{a}|oclc'),
+                ('040', '{a}|muse')
+            ],
+            'authors': [
+                ('100', '{a} {b} {c} {d}|||true'),
+                ('110', '{a} {b} {c} {n} {d}|||true'),
+            ],
+            'title': [
+                ('245', '{a} {b}'),
+                ('130', '{a}')
+            ],
+            'alternative': [
+                ('240', '{a} {k}') # Uniform Title
+            ],
+            'has_version': ('250', '{a} {b}|'),
+            'publisher': ('264', '{b}||'),
+            'spatial': ('264', '{a}'),
+            'dates': [
+                ('264', '{c}|publication_date')
+            ],
+            'extent': ('300', '{a}{b}{c}'),
+            'table_of_contents': ('505', '{a}'),
+            'abstract': [
+                ('500', '{a}'),
+                ('504', '{a}'),
+                ('520', '{a}'),
+            ],
+            'subjects': [
+                ('600', '{a} {d} -- {v} -- {x} -- {y} -- {z}|{2}|{0}'),
+                ('610', '{a} {d} -- {v} -- {x} -- {y} -- {z}|{2}|{0}'),
+                ('611', '{a} {d} -- {v} -- {x} -- {y} -- {z}|{2}|{0}'),
+                ('630', '{a} {p} -- {v} -- {x} -- {y} -- {z}|{2}|{0}'),
+                ('650', '{a} {b} -- {v} -- {x} -- {y} -- {z}|{2}|{0}'),
+                ('651', '{a} -- {v} -- {x} -- {y} -- {z}|{2}|{0}'),
+                ('656', '{a} -- {v} -- {x} -- {y} -- {z}|{2}|{0}')
+            ],
+            'contributors': [
+                ('260', '{f}|||manufacturer'),
+                ('700', '{a} {b} {c} {d}|||{e}'),
+                ('710', '{a} {b} {c} {d}|||{e}'),
+                ('711', '{a} {e}|||{j}'),
+            ],
+            'is_part_of': ('490', '{a}|{v}|volume'),
+            'has_part': [
+                ('856', '1|{u}|muse|text/html|{{"reader": false, "download": false, "catalog": false}}')
+            ]
+        }
+
+    def applyFormatting(self):
+        self.record.source = 'muse'
+        self.record.source_id = list(self.record.identifiers[0].split('|'))[0]
+
+        # Take first title as they are in order of preference
+        self.record.title = self.record.title[0]
+
+        # Clean up subjects to remove spots for missing subheadings
+        self.record.subjects = [
+            self.cleanUpSubjectHead(s)
+            for s in self.record.subjects
+        ]
+
+    def cleanUpSubjectHead(self, subject):
+        subjectStr, *subjectMeta = subject.split('|')
+        subjectParts = subjectStr.split('--')
+
+        outParts = []
+
+        for part in subjectParts:
+            cleanPart = part.strip(' .')
+            
+            if cleanPart == '': continue
+
+            outParts.append(cleanPart)
+
+        cleanSubject = ' -- '.join([p for p in outParts])
+
+        return '|'.join([cleanSubject] + subjectMeta)
+
+    def addHasPartLink(self, url, mediaType, flags):
+        lastItemNo = int(self.record.has_part[0][0])
+
+        self.record.has_part.append(
+            '{}|{}|muse|{}|{}'.format(lastItemNo + 1, url, mediaType, flags)
+        )

--- a/processes/__init__.py
+++ b/processes/__init__.py
@@ -7,3 +7,4 @@ from .sfrCluster import ClusterProcess
 from .developmentSetup import DevelopmentSetupProcess
 from .s3Files import S3Process
 from .api import APIProcess
+from .muse import MUSEProcess

--- a/processes/muse.py
+++ b/processes/muse.py
@@ -1,0 +1,127 @@
+from bs4 import BeautifulSoup
+from datetime import datetime, timedelta
+from io import BytesIO
+import json
+import os
+from pymarc import MARCReader
+import requests
+
+from .core import CoreProcess
+from mappings.muse import MUSEMapping
+from managers import PDFManifest
+
+
+class MUSEProcess(CoreProcess):
+    MUSE_ROOT_URL = 'https://muse.jhu.edu'
+
+    def __init__(self, *args):
+        super(MUSEProcess, self).__init__(*args[:3])
+
+        self.generateEngine()
+        self.createSession()
+
+        self.createS3Client()
+        self.s3Bucket = os.environ['FILE_BUCKET']
+
+    def runProcess(self):
+        if self.process == 'daily':
+            self.importMARCRecords()
+        elif self.process == 'complete':
+            self.importMARCRecords(fullOrPartial=True)
+        elif self.process == 'custom':
+            self.importMARCRecords(startTimestamp=self.ingestPeriod)
+
+        self.saveRecords()
+        self.commitChanges()
+    
+    def parseMuseRecord(self, marcRec):
+        museRec = MUSEMapping(marcRec)
+        museRec.applyMapping()
+
+        # Use the available source link to create a PDF manifest file and store in S3
+        _, museLink, *_ = list(museRec.record.has_part[0].split('|'))
+        pdfManifest = self.constructPDFManifest(museLink, museRec.record)
+
+        s3URL = self.createManifestInS3(pdfManifest, museRec.record.source_id)
+        museRec.addHasPartLink(
+            s3URL, 'application/pdf+json',
+            json.dumps({'reader': True, 'download': False, 'catalog': False})
+        )
+        self.addDCDWToUpdateList(museRec)
+    
+    def importMARCRecords(self, fullOrPartial=False, startTimestamp=None):
+        museFile = self.downloadMARCRecords()
+
+        marcReader = MARCReader(museFile)
+
+        for record in marcReader:
+            self.parseMuseRecord(record)
+
+    def downloadMARCRecords(self):
+        marcURL = os.environ['MUSE_MARC_URL']
+
+        museResponse = requests.get(marcURL, stream=True, timeout=30)
+
+        if museResponse.status_code == 200:
+            content = bytes()
+            for chunk in museResponse.iter_content(1024):
+                content += chunk
+
+            return BytesIO(content)
+
+        raise Exception('Unable to load Project MUSE MARC file')
+
+    def constructPDFManifest(self, museLink, museRecord):
+        try:
+            museHTML = self.loadMusePage(museLink)
+        except Exception as e:
+            return None
+
+        pdfManifest = PDFManifest(museLink)
+        pdfManifest.addMetadata(museRecord)
+
+        museSoup = BeautifulSoup(museHTML, features='lxml')
+
+        chapterTable = museSoup.find(id='available_items_list_wrap')
+        for card in chapterTable.find_all(class_='card_text'):
+            titleItem = card.find('li', class_='title')
+            pageItem = card.find('li', class_='pg')
+
+            if not titleItem:
+                continue
+            elif not titleItem.span.a:
+                pdfManifest.addSection(titleItem.span.string, '')
+                continue
+            else:
+                if card.parent.get('style') != 'margin-left:30px;':
+                    pdfManifest.closeSection()
+
+                pdfManifest.addChapter(
+                    '{}{}/pdf'.format(self.MUSE_ROOT_URL, titleItem.span.a.get('href')),
+                    titleItem.span.a.string,
+                    pageItem.string if pageItem else None
+                )
+        
+        pdfManifest.closeSection()
+        
+        return pdfManifest
+    
+    def loadMusePage(self, museLink):
+        museResponse = requests.get(museLink, timeout=15, headers={'User-agent': 'Mozilla/5.0'})
+
+        if museResponse.status_code == 200:
+            return museResponse.text
+
+        raise Exception('Unable to load HTML page from Project MUSE')
+
+    def createManifestInS3(self, pdfManifest, museID):
+        bucketLocation = 'manifests/muse/{}.json'.format(museID)
+        s3URL = 'https://{}.s3.amazonaws.com/{}'.format(self.s3Bucket, bucketLocation)
+
+        pdfManifest.links.append({
+            'rel': 'self', 'href': s3URL, 'type': 'application/pdf+json'
+        })
+
+        self.putObjectInBucket(pdfManifest.toJson().encode('utf-8'), bucketLocation, self.s3Bucket)
+
+        return s3URL

--- a/processes/muse.py
+++ b/processes/muse.py
@@ -118,9 +118,7 @@ class MUSEProcess(CoreProcess):
         bucketLocation = 'manifests/muse/{}.json'.format(museID)
         s3URL = 'https://{}.s3.amazonaws.com/{}'.format(self.s3Bucket, bucketLocation)
 
-        pdfManifest.links.append({
-            'rel': 'self', 'href': s3URL, 'type': 'application/pdf+json'
-        })
+        pdfManifest.links['self'] = {'href': s3URL, 'type': 'application/pdf+json'}
 
         self.putObjectInBucket(pdfManifest.toJson().encode('utf-8'), bucketLocation, self.s3Bucket)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+beautifulsoup4
 boto3
 elasticsearch-dsl>=6.0.0,<7.0.0
 flask
@@ -10,6 +11,7 @@ git+https://github.com/aboSamoor/polyglot.git@master
 psycopg2-binary
 python-levenshtein
 pycountry
+pymarc
 pyyaml
 redis
 requests

--- a/tests/fixtures/muse_book_42.html
+++ b/tests/fixtures/muse_book_42.html
@@ -1,0 +1,2198 @@
+
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<!-- Global site tag (gtag.js) - Google Analytics -->
+		<script async src="https://www.googletagmanager.com/gtag/js?id=UA-58347753-2"></script>
+		<script>
+		  window.dataLayer = window.dataLayer || [];
+		  function gtag(){dataLayer.push(arguments);}
+		  gtag('js', new Date());		
+		  gtag('config', 'UA-58347753-2');
+		</script>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+		<meta property="og:image" content="/book/42/og_image.jpg" />
+		
+		
+		
+		
+		<title>Project MUSE - Reading Fiction in Antebellum America</title>
+		<link rel="search" type="application/opensearchdescription+xml" title="Search Project MUSE from your browser's Searchbar" href="/plugins/muse-opensearch.xml" />
+		
+		
+		<link rel="stylesheet" type="text/css" href="/css/normalize.css"/>
+		<link href="/css/jquery.qtip2.css" rel="stylesheet" type="text/css" />
+<!-- 		foundation 6.4.1 custom float/typ/vis 250rem max width 30col float grid -->
+		<link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,600,600i,700,700i" rel="stylesheet">
+		<link rel="stylesheet" type="text/css" href="/css/foundation.min.css"/>
+		<link rel="stylesheet" type="text/css" href="/css/style_home2.css?031820"/>
+		
+		
+			<link href="/css/print.css" rel="stylesheet" type="text/css" media="print" />
+		
+		
+		
+		
+
+		<script type="text/javascript" src="/js/jquery3.js"></script>		
+		<script type="text/javascript" src="/js/pre.js"></script>
+		<script type="text/javascript" src="/js/core/head.js?new"></script>
+		
+		<script type="text/javascript" src="https://s7.addthis.com/js/250/addthis_widget.js#pubid=ra-4ecb5479089cb81a"></script>
+
+		
+		
+		
+		<title>Article</title>
+	</head>
+	<body>
+		<a id="skip" href="#skip_target">[Skip to Content]</a>
+		<span id="top" role="none"></span>
+		<div id="header" role="banner" aria-label="header">
+			<div class="row wrap" id="institution_banner">
+				<div class="content">
+					<div id="institution_wrap" class="columns small-15 medium-text-left">
+						<div id="institution" class="img_text_col">
+							<div class="img_contain_left"><img src="/images/institution.png" alt="institution icon" /></div>
+							<div class="text_contain_left"><span class="small"><a href='/account' class='color_white login_status'>Institutional Login</a></span></div>
+						</div>
+					</div>
+					<div id="person_wrap" class="columns small-15">
+						<div id="person" class="img_text_col">
+							<div class="img_contain_right"><img src="/images/person.png" alt="account icon" /></div>
+							<div class="text_contain_right"><span class="small"><a href="/account/" class="color_white login_status" onclick="gtag('event', 'click', {'event_category': 'Account link', 'event_label': 'account name link - header'});"><span class="login_statement_unauthenticated">LOG IN</span></a></span></div>
+						</div>
+					</div>
+				</div>
+			</div>
+			
+			
+			
+			<div class="row wrap" id="search_banner">
+				<div class="content">
+					<div class="medium-4 small-4 columns" id="header_logo_wrap">
+						<div id="header_logo">
+							<a href="/"><img src="/images/muselogo.png" alt="Project MUSE" class="show-for-large"/>
+							<img src="/images/muselogo_notext.png" alt="Project MUSE" class="hide-for-large"/></a>							
+						</div>
+					</div>
+					<div class="medium-21 small-22 columns" id="search_bar_wrap">				
+						<div class="row"> 
+							<div id="browse_button_wrap">
+								<a id="browse_button" href="/browse" onclick="gtag('event', 'click', {'event_category': 'Browse link', 'event_label': 'browse button - header'});"><span class="small">browse</span></a>
+							</div>
+							<div id="or_text_wrap" class="show-for-medium">
+								<div id="or_text">
+									<span class="small">or</span> 
+								</div>
+							</div>
+							<div id="search_input_wrap" class="small-30">
+								<div id="search_input">
+  								
+  								<noscript>
+										<form method="post" action="/search/">
+                    <label for="nojs_search_input_header" class="hide">Search:</label>
+										<input name="no_js_header_query" id="nojs_search_input_header">
+										<input type="hidden" name="action" value="search">
+										<input type="hidden" name="t" value="header">
+										<button id="search_button">
+										<input type="image" src="/images/search_blue.png" alt="Search icon">										
+                    </button>
+										</form>
+									</noscript>
+								
+									<script>document.write('<label for="search_input_header" class="hide">Search:</label><input placeholder="Search..." name="search_input_header" id="search_input_header" aria-label="search input"><button type="button" id="search_button"><img src="/images/search_blue.png" alt="Search icon"/></button>');</script>																		
+								</div>
+							</div>
+						</div>				
+					</div>
+				
+					<div class="medium-5 small-4 columns" id="menu_wrap">
+						<div id="menu" class="menu-btn">
+	<div class="nav-toggle">
+		<div role="button" class="nav-toggle-btn" tabindex="0" aria-expanded="false">
+			<div role="presentation" class="menu-icon-wrap">
+				<span role="presentation" class="icon"></span>
+				<span role="presentation" class="small show-for-large">menu</span>
+			</div>
+		</div>
+		<div class="nav-mobile">
+			<a href="/search">Advanced Search</a>
+			<a href="/browse">Browse</a>
+			<script>
+				document.write('<div class="accordion">');
+			</script>
+			<noscript>
+				<div class="accordion noscript">
+			</noscript>
+				<a href="#" class="acc_trig open"><span>MyMUSE Account</span></a>
+				<div class="acc_block">
+					<a href="/account">Log In / Sign Up</a>
+					<a href="/account/change">Change My Account</a>
+					<a href="/account/user_settings">User Settings</a>
+					<a href="/account/">Access via Institution</a>
+					<a href="/account/saved_items">MyMUSE Library</a>
+					<a href="/account/search_history">Search History</a>
+					<a href="/account/view_history">View History</a>
+					<a href="/account/purchase_history">Purchase History</a>
+					<a href="/account/alerts">MyMUSE Alerts</a>
+																
+				</div>
+			</div>									
+			<div class="nav-mobile-footer">
+				<a href="/contact">Contact Support</a>
+			</div>
+		</div>
+	</div>
+</div>
+		
+ 
+					</div>
+				</div>
+			</div>
+			
+			
+			
+		</div>
+
+
+
+
+
+
+  
+<script type="text/javascript">
+  $(document).ready(function() {
+    var window_w = $(window).width();
+    var img_w = "";
+    var img_h = "";
+    var opt_w = img_w;
+    var opt_h = img_h;    
+    var ratio = 1;
+    if(img_w >= window_w) { 
+      opt_w = window_w - 60; 
+      ratio = opt_w/img_w;
+    }    
+    opt_h = ratio*img_h;
+    $('#book_cover_thumb').qtip({
+      content: {
+        text: "<div class='qtip-cover'><p><a href='/book/42/image/front_cover.jpg'>View Full Resolution</a></p><img height='"+opt_h+"' width='"+opt_w+"' src='/book/42/image/front_cover.jpg' /> </div>",
+        title: {
+          text: 'Cover for Reading Fiction in Antebellum America',
+          button: 'Close'
+        }, 
+      },
+      show: 'click',
+      hide: false,
+      position: {
+        my: 'top left',
+        at: 'top left',
+        target: $('.content')
+      },
+      style: {
+        classes: 'ui-tooltip-dark ui-tooltip-rounded ui-tooltip-shadow qtip-bookcover'
+      },
+      hide: 'unfocus'      
+    });
+  });
+</script>
+ 
+
+<div id="main">
+			
+	<div id="book_about_wrap" class="about_wrap">
+		<div id="book_banner_wrap" class="banner_wrap">
+			<div class="content" style="background-color:rgb(51,51,51);background:linear-gradient(to right, rgb(0,0,0),rgb(51,51,51) 100%); filter:progid:DXImageTransform.Microsoft.gradient(GradientType=1,startColorstr='#000000', endColorstr='#333333');">
+	
+				<div id="book_banner_title_wrap" class="wrap left banner_title_wrap">
+					<div id="book_banner_title" class="banner_title">
+						<h1>Reading Fiction in Antebellum America: Informed Response and Reception Histories, 1820–1865</h1>
+					</div>
+				</div>
+				<div id="book_banner_search_wrap" class="wrap banner_search_wrap">
+					<div id="book_banner_search" role="search" aria-label="search inside this book">
+						<div>
+							<!-- nojs variant -->
+							<noscript>
+							  <form method="post" action="/search/" aria-label="search within this book text input" title="search within this book text input">
+								<input type="text" name="no_js_header_query" aria-label="search within this book text input" placeholder="Search Within Book"/>
+								<input type="hidden" name="action" value="search" />
+								<input type="hidden" name="t" value="search_book_header" />
+								<input type="hidden" name="search_within_book_id" id="search_within_book_id" value="42" />
+								<a id="search_within_book_button">
+								  
+									<input type="image" alt="a magnifying glass search icon" src="/images/search_blue.png" aria-label="submit search"/>
+								  
+								</a>
+							  </form>
+							</noscript>
+  
+							<!-- js variant -->
+							<script>
+							  // hook for js, book limiter
+							  document.write('<input type="hidden" name="search_within_book_id" id="search_within_book_id" value="42" />');
+							  // text input
+							  document.write('<input type="text" name="search_within_book_input" id="search_within_book_input" title="search within book" aria-label="search within book" placeholder="Search Within Book"/>');
+							</script>
+							
+							<script>
+							  // light mode button
+							  document.write('<a id="search_within_book_button"><img src="/images/search_blue.png" alt="a magnifying glass search icon"/></a>');
+							</script>
+							
+						</div>
+					</div>
+				</div>
+				<div class="clear"></div>
+			</div>
+		</div>
+		<div id="book_about" class="wrap about">
+			<script>
+				var html = '<div id="share_block">'+
+				'<div id="share_block_text">'+
+				'<div class="social">'+
+				'<ul class="addthis_toolbox addthis_default_style rightnav_links_share" addthis:url="https://muse.jhu.edu/book/42" addthis:title="'+
+				"Project MUSE - Reading Fiction in Antebellum America: Informed Response and Reception Histories, 1820–1865"+
+				'">'+
+				'<li><a class="addthis_button_citeulike addthis_24x24_style"></a>'+
+				'<a class="addthis_button_facebook addthis_24x24_style"></a>'+
+				'<a class="addthis_button_delicious addthis_24x24_style"></a>'+
+				'<a class="addthis_button_twitter addthis_24x24_style" tw:screen_name="ProjectMUSE"></a>'+
+				'<a class="addthis_button_google addthis_24x24_style"></a>'+
+				'<a href="http://www.addthis.com/bookmark.php?v=250&amp;pubid=xa-4ecac55a1fd58a05" tabindex="-1" class="addthis_button_compact addthis_24x24_style"></a></li>'+
+				''+
+				'</div>'+
+				'</div>'+
+				'</div>';
+				document.write(html);
+			</script>
+			
+			<div class="title_wrap">
+				<h2>In this Book</h2>
+			</div>
+		
+			<div id="book_about_info_wrap" class="about_info_wrap">
+				<div id="book_about_info" class="cards_wrap about_info">
+					<div class="card">
+						<div class="card_image">
+							
+							<img src="/book/42/image/front_cover.jpg?format=180" alt="Reading Fiction in Antebellum America" id="book_cover_thumb" />
+							
+							<div style="text-align: center; padding-top: 10px; font-size: 15px;">
+								<a href="#info_wrap">Additional Information</a>
+							</div>
+							
+						</div>
+						<div class="card_text ">
+							<ul>
+								<li class="title"><span><a>Reading Fiction in Antebellum America: Informed Response and Reception Histories, 1820–1865</a></span></li>
+								
+								
+								<li class="author">
+								
+									James L. Machor
+								
+								</li>
+								
+								<li class="date">2011</li>
+								<li class="type"><span class="book">Book</span></li>
+
+								<!-- Publisher Object In Use --><li class="pub"><span>Published by: <a href="/search?action=browse&limit=publisher_id:1">Johns Hopkins University Press</a></span></li>
+
+								
+								<li>
+								
+								
+								<div class="content_action">
+
+<span class="content_access_icon">
+
+</span>
+
+<ul class="action_btns">
+
+
+
+<li>
+<a href="">
+
+	
+
+	<span class="link_text">
+	<b>Viewed</b>
+	</span>
+	</a>
+</li>
+
+
+
+
+
+
+
+	
+	<li>
+		
+			<script>
+				document.write('<span class="save_content link_text" id="book:42"><a tabindex="0">Save</a></span>');
+			</script>	
+			<noscript>
+				<span class="link_text"><a class="save_content" href="/account/save/book:42/non_js">Save</a></span>
+			</noscript>
+		
+	</li>
+	
+
+
+
+    <li class="view_citation">
+    <a href="/view_citations?type=book&id=42">View Citation</a>
+    </li>
+
+
+</ul>
+  <a href="/book/042" style="display:none" tabindex="-1">contents</a>
+</div>
+
+								
+								
+								
+								</li>
+								
+								
+								
+								
+									<li class="cc_wrap">
+
+
+
+
+
+<div class="cc-image"><a href="http://creativecommons.org/licenses/by-nc-nd/4.0/" rel="license"><img src="https://i.creativecommons.org/l/by-nc-nd/4.0/88x31.png" alt="Creative Commons License"></a>
+</div>
+<div class="cc-text">
+This work is licensed under a <a href="http://creativecommons.org/licenses/by-nc-nd/4.0/" rel="license">Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International License</a>.
+</div>
+</li>
+								
+								
+
+
+							</ul>
+							
+							<a href="http://jhupbooks.press.jhu.edu/ecom/MasterServlet/GetItemDetailsHandler?iN=9780801898747&qty=1&viewMode=1&loggedIN=false&JavaScript=y" target="_blank" class="btn_buy_book">
+							
+							<img src="/images/icon_book.png" alt="buy this book">
+							 Buy This Book in Print</a>
+							
+							
+							
+							
+						</div>
+						
+						<div class="card_summary_wrap">
+							<div class="card_summary_title">
+								<span class="small title">summary</span>
+							</div>
+							<div class="card_summary no_border">James L. Machor offers a sweeping exploration of how American fiction was received in both public and private spheres in the United States before the Civil War. 
+
+Machor takes four antebellum authors—Edgar Allan Poe, Herman Melville, Catharine Sedgwick, and Caroline Chesebro'—and analyzes how their works were published, received, and interpreted. Drawing on discussions found in book reviews and in private letters and diaries, Machor examines how middle-class readers of the time engaged with contemporary fiction and how fiction reading evolved as an interpretative practice in nineteenth-century America.
+
+Through careful analysis, Machor illuminates how the reading practices of nineteenth-century Americans shaped not only the experiences of these writers at the time but also the way the writers were received in the twentieth century. What Machor reveals is that these authors were received in ways strikingly different from how they are currently read, thereby shedding significant light on their present status in the literary canon in comparison to their critical and popular positions in their own time.
+
+Machor deftly combines response and reception criticism and theory with work in the history of reading to engage with groundbreaking scholarship in historical hermeneutics. In so doing, Machor takes us ever closer to understanding the particular and varying reading strategies of historical audiences and how they impacted authors’ conceptions of their own readership.</div>
+							
+							
+							
+							
+							
+						</div>
+						
+
+
+						
+
+						
+					</div>
+				</div>
+				
+				
+				<div class="row">
+<!-- 					<div id="available_items_list_wrap" class="columns full small-30 large-20"> -->
+					<div id="available_items_list_wrap" class="columns full small-30">
+					<div id="book_about_content_select" class="about_content_select">
+						<div class="toc_header_wrap">
+							<div class="option" id="book_available">
+								<h2>Table of Contents</h2>
+							</div>
+						</div>
+
+					<div id="available_items_list_text" class="toc">					
+						<div class="cards_wrap row vertical_list">
+            
+						
+						
+						
+
+							
+								
+								 
+								
+								<div class="card row small-30 no_image" >
+									<div class="card_text">
+										<ol>
+										
+											<li class="title"><span><a href="/chapter/440">Cover</a></span></li>
+																						
+											
+											
+											
+
+
+
+											<li class="interact">
+				<span>
+				
+				
+				
+				
+				<div class="content_action">
+
+<span class="content_access_icon">
+<img src="/images/access/open_access.png" alt="open access"/>
+</span>
+
+<ul class="action_btns">
+
+
+
+<li>
+<a href="/chapter/440">
+
+	<img src="/images/html_icon.png" class="icon" alt="View HTML">
+
+	<span class="link_text">
+	View
+	</span>
+	</a>
+</li>
+
+
+
+
+<li>
+  <a href="/chapter/440/pdf">
+  <img src="/images/pdf.png" alt="Download PDF" class="icon">
+  <span class="link_text">
+	  
+		
+		Download
+		
+    
+	</span>
+	</a>
+</li>
+
+
+
+
+	
+	<li>
+		
+			<script>
+				document.write('<span class="save_content link_text" id="chapter:440"><a tabindex="0">Save</a></span>');
+			</script>	
+			<noscript>
+				<span class="link_text"><a class="save_content" href="/account/save/chapter:440/non_js">Save</a></span>
+			</noscript>
+		
+	</li>
+	
+
+
+
+
+</ul>
+  <a href="/chapter/0440" style="display:none" tabindex="-1">contents</a>
+</div>
+
+				
+				
+				
+				
+				</span>
+				
+				</li>
+
+
+										
+										</ol>
+									</div>
+								</div>
+							
+								
+								 
+								
+								<div class="card row small-30 no_image" >
+									<div class="card_text">
+										<ol>
+										
+											<li class="title"><span><a href="/chapter/2183675">Title Page</a></span></li>
+																						
+											<li class="pg">pp. i-iii</li>
+											
+											
+
+
+
+											<li class="interact">
+				<span>
+				
+				
+				
+				
+				<div class="content_action">
+
+<span class="content_access_icon">
+<img src="/images/access/open_access.png" alt="open access"/>
+</span>
+
+<ul class="action_btns">
+
+
+
+<li>
+<a href="/chapter/2183675">
+
+	<img src="/images/html_icon.png" class="icon" alt="View HTML">
+
+	<span class="link_text">
+	View
+	</span>
+	</a>
+</li>
+
+
+
+
+<li>
+  <a href="/chapter/2183675/pdf">
+  <img src="/images/pdf.png" alt="Download PDF" class="icon">
+  <span class="link_text">
+	  
+		
+		Download
+		
+    
+	</span>
+	</a>
+</li>
+
+
+
+
+	
+	<li>
+		
+			<script>
+				document.write('<span class="save_content link_text" id="chapter:2183675"><a tabindex="0">Save</a></span>');
+			</script>	
+			<noscript>
+				<span class="link_text"><a class="save_content" href="/account/save/chapter:2183675/non_js">Save</a></span>
+			</noscript>
+		
+	</li>
+	
+
+
+
+
+</ul>
+  <a href="/chapter/02183675" style="display:none" tabindex="-1">contents</a>
+</div>
+
+				
+				
+				
+				
+				</span>
+				
+				</li>
+
+
+										
+										</ol>
+									</div>
+								</div>
+							
+								
+								 
+								
+								<div class="card row small-30 no_image" >
+									<div class="card_text">
+										<ol>
+										
+											<li class="title"><span><a href="/chapter/2183674">Copyright</a></span></li>
+																						
+											<li class="pg">p. iv</li>
+											
+											
+
+
+
+											<li class="interact">
+				<span>
+				
+				
+				
+				
+				<div class="content_action">
+
+<span class="content_access_icon">
+<img src="/images/access/open_access.png" alt="open access"/>
+</span>
+
+<ul class="action_btns">
+
+
+
+<li>
+<a href="/chapter/2183674">
+
+	<img src="/images/html_icon.png" class="icon" alt="View HTML">
+
+	<span class="link_text">
+	View
+	</span>
+	</a>
+</li>
+
+
+
+
+<li>
+  <a href="/chapter/2183674/pdf">
+  <img src="/images/pdf.png" alt="Download PDF" class="icon">
+  <span class="link_text">
+	  
+		
+		Download
+		
+    
+	</span>
+	</a>
+</li>
+
+
+
+
+	
+	<li>
+		
+			<script>
+				document.write('<span class="save_content link_text" id="chapter:2183674"><a tabindex="0">Save</a></span>');
+			</script>	
+			<noscript>
+				<span class="link_text"><a class="save_content" href="/account/save/chapter:2183674/non_js">Save</a></span>
+			</noscript>
+		
+	</li>
+	
+
+
+
+
+</ul>
+  <a href="/chapter/02183674" style="display:none" tabindex="-1">contents</a>
+</div>
+
+				
+				
+				
+				
+				</span>
+				
+				</li>
+
+
+										
+										</ol>
+									</div>
+								</div>
+							
+								
+								 
+								
+								<div class="card row small-30 no_image" >
+									<div class="card_text">
+										<ol>
+										
+											<li class="title"><span><a href="/chapter/2183673">Dedication</a></span></li>
+																						
+											<li class="pg">pp. v-vi</li>
+											
+											
+
+
+
+											<li class="interact">
+				<span>
+				
+				
+				
+				
+				<div class="content_action">
+
+<span class="content_access_icon">
+<img src="/images/access/open_access.png" alt="open access"/>
+</span>
+
+<ul class="action_btns">
+
+
+
+<li>
+<a href="/chapter/2183673">
+
+	<img src="/images/html_icon.png" class="icon" alt="View HTML">
+
+	<span class="link_text">
+	View
+	</span>
+	</a>
+</li>
+
+
+
+
+<li>
+  <a href="/chapter/2183673/pdf">
+  <img src="/images/pdf.png" alt="Download PDF" class="icon">
+  <span class="link_text">
+	  
+		
+		Download
+		
+    
+	</span>
+	</a>
+</li>
+
+
+
+
+	
+	<li>
+		
+			<script>
+				document.write('<span class="save_content link_text" id="chapter:2183673"><a tabindex="0">Save</a></span>');
+			</script>	
+			<noscript>
+				<span class="link_text"><a class="save_content" href="/account/save/chapter:2183673/non_js">Save</a></span>
+			</noscript>
+		
+	</li>
+	
+
+
+
+
+</ul>
+  <a href="/chapter/02183673" style="display:none" tabindex="-1">contents</a>
+</div>
+
+				
+				
+				
+				
+				</span>
+				
+				</li>
+
+
+										
+										</ol>
+									</div>
+								</div>
+							
+								
+								 
+								
+								<div class="card row small-30 no_image" >
+									<div class="card_text">
+										<ol>
+										
+											<li class="title"><span><a href="/chapter/441">Contents</a></span></li>
+																						
+											<li class="pg">pp. vii-viii</li>
+											
+											
+
+
+
+											<li class="interact">
+				<span>
+				
+				
+				
+				
+				<div class="content_action">
+
+<span class="content_access_icon">
+<img src="/images/access/open_access.png" alt="open access"/>
+</span>
+
+<ul class="action_btns">
+
+
+
+<li>
+<a href="/chapter/441">
+
+	<img src="/images/html_icon.png" class="icon" alt="View HTML">
+
+	<span class="link_text">
+	View
+	</span>
+	</a>
+</li>
+
+
+
+
+<li>
+  <a href="/chapter/441/pdf">
+  <img src="/images/pdf.png" alt="Download PDF" class="icon">
+  <span class="link_text">
+	  
+		
+		Download
+		
+    
+	</span>
+	</a>
+</li>
+
+
+
+
+	
+	<li>
+		
+			<script>
+				document.write('<span class="save_content link_text" id="chapter:441"><a tabindex="0">Save</a></span>');
+			</script>	
+			<noscript>
+				<span class="link_text"><a class="save_content" href="/account/save/chapter:441/non_js">Save</a></span>
+			</noscript>
+		
+	</li>
+	
+
+
+
+
+</ul>
+  <a href="/chapter/0441" style="display:none" tabindex="-1">contents</a>
+</div>
+
+				
+				
+				
+				
+				</span>
+				
+				</li>
+
+
+										
+										</ol>
+									</div>
+								</div>
+							
+								
+								 
+								
+								<div class="card row small-30 no_image" >
+									<div class="card_text">
+										<ol>
+										
+											<li class="title"><span><a href="/chapter/442">Preface</a></span></li>
+																						
+											<li class="pg">pp. ix-xiv</li>
+											<li class="doi"><span>DOI: <a href="https://doi.org/10.1353/chapter.442">https://doi.org/10.1353/chapter.442</a></span></li>
+											
+
+
+
+											<li class="interact">
+				<span>
+				
+				
+				
+				
+				<div class="content_action">
+
+<span class="content_access_icon">
+<img src="/images/access/open_access.png" alt="open access"/>
+</span>
+
+<ul class="action_btns">
+
+
+
+<li>
+<a href="/chapter/442">
+
+	<img src="/images/html_icon.png" class="icon" alt="View HTML">
+
+	<span class="link_text">
+	View
+	</span>
+	</a>
+</li>
+
+
+
+
+<li>
+  <a href="/chapter/442/pdf">
+  <img src="/images/pdf.png" alt="Download PDF" class="icon">
+  <span class="link_text">
+	  
+		
+		Download
+		
+    
+	</span>
+	</a>
+</li>
+
+
+
+
+	
+	<li>
+		
+			<script>
+				document.write('<span class="save_content link_text" id="chapter:442"><a tabindex="0">Save</a></span>');
+			</script>	
+			<noscript>
+				<span class="link_text"><a class="save_content" href="/account/save/chapter:442/non_js">Save</a></span>
+			</noscript>
+		
+	</li>
+	
+
+
+
+
+</ul>
+  <a href="/chapter/0442" style="display:none" tabindex="-1">contents</a>
+</div>
+
+				
+				
+				
+				
+				</span>
+				
+				</li>
+
+
+										
+										</ol>
+									</div>
+								</div>
+							
+								
+								 
+								
+								<div class="card row small-30 no_image" >
+									<div class="card_text">
+										<ol>
+										
+										<li class="title"><span>Part One. Reading Reading Historically</span></li>
+										<li class="pg">pp. 1-2</li>
+										
+										</ol>
+									</div>
+								</div>
+							
+								
+								 
+								
+								<div class="card row small-30 no_image" style="margin-left:30px;">
+									<div class="card_text">
+										<ol>
+										
+											<li class="title"><span><a href="/chapter/444">Chapter 1. Historical Hermeneutics, Reception Theory, and the Social Conditions of Reading in Antebellum America</a></span></li>
+																						
+											<li class="pg">pp. 3-35</li>
+											<li class="doi"><span>DOI: <a href="https://doi.org/10.1353/chapter.444">https://doi.org/10.1353/chapter.444</a></span></li>
+											
+
+
+
+											<li class="interact">
+				<span>
+				
+				
+				
+				
+				<div class="content_action">
+
+<span class="content_access_icon">
+<img src="/images/access/open_access.png" alt="open access"/>
+</span>
+
+<ul class="action_btns">
+
+
+
+<li>
+<a href="/chapter/444">
+
+	<img src="/images/html_icon.png" class="icon" alt="View HTML">
+
+	<span class="link_text">
+	View
+	</span>
+	</a>
+</li>
+
+
+
+
+<li>
+  <a href="/chapter/444/pdf">
+  <img src="/images/pdf.png" alt="Download PDF" class="icon">
+  <span class="link_text">
+	  
+		
+		Download
+		
+    
+	</span>
+	</a>
+</li>
+
+
+
+
+	
+	<li>
+		
+			<script>
+				document.write('<span class="save_content link_text" id="chapter:444"><a tabindex="0">Save</a></span>');
+			</script>	
+			<noscript>
+				<span class="link_text"><a class="save_content" href="/account/save/chapter:444/non_js">Save</a></span>
+			</noscript>
+		
+	</li>
+	
+
+
+
+
+</ul>
+  <a href="/chapter/0444" style="display:none" tabindex="-1">contents</a>
+</div>
+
+				
+				
+				
+				
+				</span>
+				
+				</li>
+
+
+										
+										</ol>
+									</div>
+								</div>
+							
+								
+								 
+								
+								<div class="card row small-30 no_image" style="margin-left:30px;">
+									<div class="card_text">
+										<ol>
+										
+											<li class="title"><span><a href="/chapter/445">Chapter 2. Interpretive Strategies and Informed Reading in the Antebellum Public Sphere</a></span></li>
+																						
+											<li class="pg">pp. 36-84</li>
+											<li class="doi"><span>DOI: <a href="https://doi.org/10.1353/chapter.445">https://doi.org/10.1353/chapter.445</a></span></li>
+											
+
+
+
+											<li class="interact">
+				<span>
+				
+				
+				
+				
+				<div class="content_action">
+
+<span class="content_access_icon">
+<img src="/images/access/open_access.png" alt="open access"/>
+</span>
+
+<ul class="action_btns">
+
+
+
+<li>
+<a href="/chapter/445">
+
+	<img src="/images/html_icon.png" class="icon" alt="View HTML">
+
+	<span class="link_text">
+	View
+	</span>
+	</a>
+</li>
+
+
+
+
+<li>
+  <a href="/chapter/445/pdf">
+  <img src="/images/pdf.png" alt="Download PDF" class="icon">
+  <span class="link_text">
+	  
+		
+		Download
+		
+    
+	</span>
+	</a>
+</li>
+
+
+
+
+	
+	<li>
+		
+			<script>
+				document.write('<span class="save_content link_text" id="chapter:445"><a tabindex="0">Save</a></span>');
+			</script>	
+			<noscript>
+				<span class="link_text"><a class="save_content" href="/account/save/chapter:445/non_js">Save</a></span>
+			</noscript>
+		
+	</li>
+	
+
+
+
+
+</ul>
+  <a href="/chapter/0445" style="display:none" tabindex="-1">contents</a>
+</div>
+
+				
+				
+				
+				
+				</span>
+				
+				</li>
+
+
+										
+										</ol>
+									</div>
+								</div>
+							
+								
+								 
+								
+								<div class="card row small-30 no_image" >
+									<div class="card_text">
+										<ol>
+										
+										<li class="title"><span>PART TWO. Contextual Receptions, Reading Experiences, and Patterns of Response: Four Case Studies</span></li>
+										<li class="pg">pp. 85-86</li>
+										
+										</ol>
+									</div>
+								</div>
+							
+								
+								 
+								
+								<div class="card row small-30 no_image" style="margin-left:30px;">
+									<div class="card_text">
+										<ol>
+										
+											<li class="title"><span><a href="/chapter/6239">Chapter 3. “These Days of Double Dealing”: Informed Response, Reader Appropriation, and the Tales of Poe</a></span></li>
+																						
+											<li class="pg">pp. 87-137</li>
+											<li class="doi"><span>DOI: <a href="https://doi.org/10.1353/chapter.6239">https://doi.org/10.1353/chapter.6239</a></span></li>
+											
+
+
+
+											<li class="interact">
+				<span>
+				
+				
+				
+				
+				<div class="content_action">
+
+<span class="content_access_icon">
+<img src="/images/access/open_access.png" alt="open access"/>
+</span>
+
+<ul class="action_btns">
+
+
+
+<li>
+<a href="/chapter/6239">
+
+	<img src="/images/html_icon.png" class="icon" alt="View HTML">
+
+	<span class="link_text">
+	View
+	</span>
+	</a>
+</li>
+
+
+
+
+<li>
+  <a href="/chapter/6239/pdf">
+  <img src="/images/pdf.png" alt="Download PDF" class="icon">
+  <span class="link_text">
+	  
+		
+		Download
+		
+    
+	</span>
+	</a>
+</li>
+
+
+
+
+	
+	<li>
+		
+			<script>
+				document.write('<span class="save_content link_text" id="chapter:6239"><a tabindex="0">Save</a></span>');
+			</script>	
+			<noscript>
+				<span class="link_text"><a class="save_content" href="/account/save/chapter:6239/non_js">Save</a></span>
+			</noscript>
+		
+	</li>
+	
+
+
+
+
+</ul>
+  <a href="/chapter/06239" style="display:none" tabindex="-1">contents</a>
+</div>
+
+				
+				
+				
+				
+				</span>
+				
+				</li>
+
+
+										
+										</ol>
+									</div>
+								</div>
+							
+								
+								 
+								
+								<div class="card row small-30 no_image" style="margin-left:30px;">
+									<div class="card_text">
+										<ol>
+										
+											<li class="title"><span><a href="/chapter/6240">Chapter 4. Multiple Audiences and Melville’s Fiction: Receptions, Recoveries, and Regressions</a></span></li>
+																						
+											<li class="pg">pp. 138-200</li>
+											<li class="doi"><span>DOI: <a href="https://doi.org/10.1353/chapter.6240">https://doi.org/10.1353/chapter.6240</a></span></li>
+											
+
+
+
+											<li class="interact">
+				<span>
+				
+				
+				
+				
+				<div class="content_action">
+
+<span class="content_access_icon">
+<img src="/images/access/open_access.png" alt="open access"/>
+</span>
+
+<ul class="action_btns">
+
+
+
+<li>
+<a href="/chapter/6240">
+
+	<img src="/images/html_icon.png" class="icon" alt="View HTML">
+
+	<span class="link_text">
+	View
+	</span>
+	</a>
+</li>
+
+
+
+
+<li>
+  <a href="/chapter/6240/pdf">
+  <img src="/images/pdf.png" alt="Download PDF" class="icon">
+  <span class="link_text">
+	  
+		
+		Download
+		
+    
+	</span>
+	</a>
+</li>
+
+
+
+
+	
+	<li>
+		
+			<script>
+				document.write('<span class="save_content link_text" id="chapter:6240"><a tabindex="0">Save</a></span>');
+			</script>	
+			<noscript>
+				<span class="link_text"><a class="save_content" href="/account/save/chapter:6240/non_js">Save</a></span>
+			</noscript>
+		
+	</li>
+	
+
+
+
+
+</ul>
+  <a href="/chapter/06240" style="display:none" tabindex="-1">contents</a>
+</div>
+
+				
+				
+				
+				
+				</span>
+				
+				</li>
+
+
+										
+										</ol>
+									</div>
+								</div>
+							
+								
+								 
+								
+								<div class="card row small-30 no_image" style="margin-left:30px;">
+									<div class="card_text">
+										<ol>
+										
+											<li class="title"><span><a href="/chapter/6241">Chapter 5. Response as (Re)construction: The Reception of Catharine Sedgwick’s Novels</a></span></li>
+																						
+											<li class="pg">pp. 201-255</li>
+											<li class="doi"><span>DOI: <a href="https://doi.org/10.1353/chapter.6241">https://doi.org/10.1353/chapter.6241</a></span></li>
+											
+
+
+
+											<li class="interact">
+				<span>
+				
+				
+				
+				
+				<div class="content_action">
+
+<span class="content_access_icon">
+<img src="/images/access/open_access.png" alt="open access"/>
+</span>
+
+<ul class="action_btns">
+
+
+
+<li>
+<a href="/chapter/6241">
+
+	<img src="/images/html_icon.png" class="icon" alt="View HTML">
+
+	<span class="link_text">
+	View
+	</span>
+	</a>
+</li>
+
+
+
+
+<li>
+  <a href="/chapter/6241/pdf">
+  <img src="/images/pdf.png" alt="Download PDF" class="icon">
+  <span class="link_text">
+	  
+		
+		Download
+		
+    
+	</span>
+	</a>
+</li>
+
+
+
+
+	
+	<li>
+		
+			<script>
+				document.write('<span class="save_content link_text" id="chapter:6241"><a tabindex="0">Save</a></span>');
+			</script>	
+			<noscript>
+				<span class="link_text"><a class="save_content" href="/account/save/chapter:6241/non_js">Save</a></span>
+			</noscript>
+		
+	</li>
+	
+
+
+
+
+</ul>
+  <a href="/chapter/06241" style="display:none" tabindex="-1">contents</a>
+</div>
+
+				
+				
+				
+				
+				</span>
+				
+				</li>
+
+
+										
+										</ol>
+									</div>
+								</div>
+							
+								
+								 
+								
+								<div class="card row small-30 no_image" style="margin-left:30px;">
+									<div class="card_text">
+										<ol>
+										
+											<li class="title"><span><a href="/chapter/6242">Chapter 6. Mercurial Readings: The Making and Unmaking of Caroline Chesebro’</a></span></li>
+																						
+											<li class="pg">pp. 256-298</li>
+											<li class="doi"><span>DOI: <a href="https://doi.org/10.1353/chapter.6242">https://doi.org/10.1353/chapter.6242</a></span></li>
+											
+
+
+
+											<li class="interact">
+				<span>
+				
+				
+				
+				
+				<div class="content_action">
+
+<span class="content_access_icon">
+<img src="/images/access/open_access.png" alt="open access"/>
+</span>
+
+<ul class="action_btns">
+
+
+
+<li>
+<a href="/chapter/6242">
+
+	<img src="/images/html_icon.png" class="icon" alt="View HTML">
+
+	<span class="link_text">
+	View
+	</span>
+	</a>
+</li>
+
+
+
+
+<li>
+  <a href="/chapter/6242/pdf">
+  <img src="/images/pdf.png" alt="Download PDF" class="icon">
+  <span class="link_text">
+	  
+		
+		Download
+		
+    
+	</span>
+	</a>
+</li>
+
+
+
+
+	
+	<li>
+		
+			<script>
+				document.write('<span class="save_content link_text" id="chapter:6242"><a tabindex="0">Save</a></span>');
+			</script>	
+			<noscript>
+				<span class="link_text"><a class="save_content" href="/account/save/chapter:6242/non_js">Save</a></span>
+			</noscript>
+		
+	</li>
+	
+
+
+
+
+</ul>
+  <a href="/chapter/06242" style="display:none" tabindex="-1">contents</a>
+</div>
+
+				
+				
+				
+				
+				</span>
+				
+				</li>
+
+
+										
+										</ol>
+									</div>
+								</div>
+							
+								
+								 
+								
+								<div class="card row small-30 no_image" style="margin-left:30px;">
+									<div class="card_text">
+										<ol>
+										
+											<li class="title"><span><a href="/chapter/6243">Conclusion. American Literary History and the Historical Study of Interpretive Practices</a></span></li>
+																						
+											<li class="pg">pp. 299-320</li>
+											<li class="doi"><span>DOI: <a href="https://doi.org/10.1353/chapter.6243">https://doi.org/10.1353/chapter.6243</a></span></li>
+											
+
+
+
+											<li class="interact">
+				<span>
+				
+				
+				
+				
+				<div class="content_action">
+
+<span class="content_access_icon">
+<img src="/images/access/open_access.png" alt="open access"/>
+</span>
+
+<ul class="action_btns">
+
+
+
+<li>
+<a href="/chapter/6243">
+
+	<img src="/images/html_icon.png" class="icon" alt="View HTML">
+
+	<span class="link_text">
+	View
+	</span>
+	</a>
+</li>
+
+
+
+
+<li>
+  <a href="/chapter/6243/pdf">
+  <img src="/images/pdf.png" alt="Download PDF" class="icon">
+  <span class="link_text">
+	  
+		
+		Download
+		
+    
+	</span>
+	</a>
+</li>
+
+
+
+
+	
+	<li>
+		
+			<script>
+				document.write('<span class="save_content link_text" id="chapter:6243"><a tabindex="0">Save</a></span>');
+			</script>	
+			<noscript>
+				<span class="link_text"><a class="save_content" href="/account/save/chapter:6243/non_js">Save</a></span>
+			</noscript>
+		
+	</li>
+	
+
+
+
+
+</ul>
+  <a href="/chapter/06243" style="display:none" tabindex="-1">contents</a>
+</div>
+
+				
+				
+				
+				
+				</span>
+				
+				</li>
+
+
+										
+										</ol>
+									</div>
+								</div>
+							
+								
+								 
+								
+								<div class="card row small-30 no_image" >
+									<div class="card_text">
+										<ol>
+										
+											<li class="title"><span><a href="/chapter/6244">Notes</a></span></li>
+																						
+											<li class="pg">pp. 321-392</li>
+											<li class="doi"><span>DOI: <a href="https://doi.org/10.1353/chapter.6244">https://doi.org/10.1353/chapter.6244</a></span></li>
+											
+
+
+
+											<li class="interact">
+				<span>
+				
+				
+				
+				
+				<div class="content_action">
+
+<span class="content_access_icon">
+<img src="/images/access/open_access.png" alt="open access"/>
+</span>
+
+<ul class="action_btns">
+
+
+
+<li>
+<a href="/chapter/6244">
+
+	<img src="/images/html_icon.png" class="icon" alt="View HTML">
+
+	<span class="link_text">
+	View
+	</span>
+	</a>
+</li>
+
+
+
+
+<li>
+  <a href="/chapter/6244/pdf">
+  <img src="/images/pdf.png" alt="Download PDF" class="icon">
+  <span class="link_text">
+	  
+		
+		Download
+		
+    
+	</span>
+	</a>
+</li>
+
+
+
+
+	
+	<li>
+		
+			<script>
+				document.write('<span class="save_content link_text" id="chapter:6244"><a tabindex="0">Save</a></span>');
+			</script>	
+			<noscript>
+				<span class="link_text"><a class="save_content" href="/account/save/chapter:6244/non_js">Save</a></span>
+			</noscript>
+		
+	</li>
+	
+
+
+
+
+</ul>
+  <a href="/chapter/06244" style="display:none" tabindex="-1">contents</a>
+</div>
+
+				
+				
+				
+				
+				</span>
+				
+				</li>
+
+
+										
+										</ol>
+									</div>
+								</div>
+							
+								
+								 
+								
+								<div class="card row small-30 no_image" >
+									<div class="card_text">
+										<ol>
+										
+											<li class="title"><span><a href="/chapter/6245">Index</a></span></li>
+																						
+											<li class="pg">pp. 393-403</li>
+											<li class="doi"><span>DOI: <a href="https://doi.org/10.1353/chapter.6245">https://doi.org/10.1353/chapter.6245</a></span></li>
+											
+
+
+
+											<li class="interact">
+				<span>
+				
+				
+				
+				
+				<div class="content_action">
+
+<span class="content_access_icon">
+<img src="/images/access/open_access.png" alt="open access"/>
+</span>
+
+<ul class="action_btns">
+
+
+
+<li>
+<a href="/chapter/6245">
+
+	<img src="/images/html_icon.png" class="icon" alt="View HTML">
+
+	<span class="link_text">
+	View
+	</span>
+	</a>
+</li>
+
+
+
+
+<li>
+  <a href="/chapter/6245/pdf">
+  <img src="/images/pdf.png" alt="Download PDF" class="icon">
+  <span class="link_text">
+	  
+		
+		Download
+		
+    
+	</span>
+	</a>
+</li>
+
+
+
+
+	
+	<li>
+		
+			<script>
+				document.write('<span class="save_content link_text" id="chapter:6245"><a tabindex="0">Save</a></span>');
+			</script>	
+			<noscript>
+				<span class="link_text"><a class="save_content" href="/account/save/chapter:6245/non_js">Save</a></span>
+			</noscript>
+		
+	</li>
+	
+
+
+
+
+</ul>
+  <a href="/chapter/06245" style="display:none" tabindex="-1">contents</a>
+</div>
+
+				
+				
+				
+				
+				</span>
+				
+				</li>
+
+
+										
+										</ol>
+									</div>
+								</div>
+							
+					
+						</div>
+
+					
+					
+					
+					</div>
+				</div>
+<!-- rightnav here -->
+				</div>
+			</div>
+		
+		</div>
+	</div>
+	
+	<div id="info_wrap" class="row wrap">
+	<div class="column full">
+		<div class="title_wrap details">
+			<h3>Additional Information</h3>
+		</div>
+		<div class="details_tbl">		
+			
+			
+							
+			<div class="details_row">
+				<div class="cell label">
+					ISBN
+				</div>
+				<div class="cell">
+					9780801899331
+				</div>
+			</div>
+			
+			
+			<div class="details_row">
+				<div class="cell label">
+					Related ISBN
+				</div>
+				<div class="cell">
+					9780801898747
+				</div>
+			</div>
+			
+			
+			<div class="details_row">
+				<div class="cell label">
+					DOI
+				</div>
+				<div class="cell">
+					<a href="https://doi.org/10.1353/book.42" target="_blank">10.1353/book.42<img src="/images/link_blue.png" alt="external link" style="vertical-align:top;"/></a>
+				</div>
+			</div>
+			
+			
+			<div class="details_row">
+				<div class="cell label">
+					MARC Record
+				</div>
+				<div class="cell">
+					<a href="https://about.muse.jhu.edu/lib/metadata?filename=muse_book_42&no_auth=1&format=marc&content_ids=book:42">Download</a>
+				</div>
+			</div>
+			
+            
+			
+			<div class="details_row">
+				<div class="cell label">
+					OCLC
+				</div>
+				<div class="cell">
+					794700392
+				</div>
+			</div>
+			
+			
+			<div class="details_row">
+				<div class="cell label">
+					Pages
+				</div>
+				<div class="cell">
+					424
+				</div>
+			</div>
+									
+			
+			<div class="details_row">
+				<div class="cell label">
+					Launched on MUSE
+				</div>
+				<div class="cell">
+					2011-07-21
+				</div>
+			</div>
+			
+			
+			
+			<div class="details_row">
+				<div class="cell label">
+					Language
+				</div>
+				<div class="cell">
+					English
+				</div>
+			</div>
+			
+			
+			<div class="details_row">
+				<div class="cell label">
+					Open Access
+				</div>
+				<div class="cell">
+					
+					Yes
+					
+				</div>
+			</div>
+			
+			
+			
+			
+		</div>
+	</div>
+	<div class="column full">
+		
+		<div class="title_wrap">
+			<h3>Purchase</h3>
+		</div>
+		<div class="purchase">
+			<p><a href="http://jhupbooks.press.jhu.edu/ecom/MasterServlet/GetItemDetailsHandler?iN=9780801898747&qty=1&viewMode=1&loggedIN=false&JavaScript=y" target="_blank">
+			
+			<img src="/images/icon_book.png" alt="buy this book (opens new window)" style="margin-right:2px;"/>
+			
+			Buy This Book in Print</a></p>
+		</div>
+		
+		
+
+		
+
+	</div>
+</div>
+
+</div>
+
+<!-- ALTMETRIC embed -->
+<script type="text/javascript" src="https://d1bxh8uas1mnw7.cloudfront.net/assets/embed.js"></script>
+
+		<div id="footer_block" role="contentinfo" aria-label="footer">
+			<div class="content">
+				<div class="wrap row" id="about_wrap">
+					<div id="about">
+						<h2>Project MUSE Mission</h2>
+						<p>Project MUSE promotes the creation and dissemination of essential humanities and social science resources through collaboration with libraries, publishers, and scholars worldwide. Forged from a partnership between a university press and a library, Project MUSE is a trusted part of the academic and scholarly community it serves.</p>
+					</div>
+					<div id="about_logo" class="columns medium-10 show-for-large">
+						<img src="/images/muselogo_notext.png" alt="MUSE logo"/>
+					</div>
+				</div>
+			</div>
+			
+			<div class="footer_main">
+				<div class="footer_item_color wrap">
+					<div class="footer_item_left">
+						<div class="group">
+							<nav class="footer_item_about cont_sub">
+								<div class="foothead">About</div>
+								<ul>
+									<li><a href="https://about.muse.jhu.edu/about/story">MUSE Story</a></li>
+									<li><a href="https://about.muse.jhu.edu/publishers">Publishers</a></li>
+									<li><a href="https://about.muse.jhu.edu/about/discovery-partners/">Discovery Partners</a></li>
+									<li><a href="https://about.muse.jhu.edu/about/advisory-board/">Advisory Board</a></li>
+									<li><a href="https://about.muse.jhu.edu/about/journal-subscribers/">Journal Subscribers</a></li>
+									<li><a href="https://about.muse.jhu.edu/about/book-customers">Book Customers</a></li>
+									<li><a href="https://about.muse.jhu.edu/about/at-conferences/">Conferences</a></li>
+								</ul>
+							</nav>
+							<nav class="footer_item_what cont_sub">
+								<div class="foothead">What's on Muse</div>
+								<ul>
+									<li><a href="https://about.muse.jhu.edu/muse/open-access-overview/">Open Access</a></li>
+									<li><a href="https://about.muse.jhu.edu/muse/journals/all/">Journals</a></li>
+									<li><a href="https://about.muse.jhu.edu/muse/publishers/books/">Books</a></li>
+									<li><a href="https://about.muse.jhu.edu/muse-in-focus/">MUSE in Focus</a></li>
+									<li><a href="https://about.muse.jhu.edu/muse/eliot-prose/">T.S. Eliot Prose</a></li>
+								</ul>
+							</nav>
+							<div class="clear"></div>
+						</div>
+						<div class="group">
+						  <nav class="footer_item_res cont_sub">
+								<div class="foothead">Resources</div>
+								<ul>
+									<li><a href="https://about.muse.jhu.edu/resources/news/">News & Announcements</a></li>
+									<li><a href="https://about.muse.jhu.edu/news/signup/" target="_blank" aria-label="email sign-up link (opens in a new tab)">Email Sign-Up</a></li>
+									<li><a href="https://about.muse.jhu.edu/resources/promotional-materials">Promotional Materials</a></li>
+									<li><a href="https://about.muse.jhu.edu/resources/alerts">Get Alerts</a></li>
+									<li><a href="https://about.muse.jhu.edu/resources/muse-presentations">Presentations</a></li>
+								</ul>
+							</nav>
+							<nav class="footer_item_info cont_sub">
+								<div class="foothead">Information For</div>
+								<ul>
+									<li><a href="https://about.muse.jhu.edu/publishers">Publishers</a></li>
+									<li><a href="https://about.muse.jhu.edu/librarians">Librarians</a></li>
+									<li><a href="https://about.muse.jhu.edu/individuals">Individuals</a></li>
+								  <li><a href="https://about.muse.jhu.edu/instructors">Instructors</a></li>
+								</ul>
+							</nav>
+							<div class="clear"></div>
+						</div>
+					</div>
+					<div class="footer_item_right">
+						<div class="group">
+							<nav class="footer_item_social cont_sub">
+								<div class="foothead">Contact</div>
+								<ul>
+									<li class="clear"><a href="/contact">Contact Us</a></li>
+									<li><a href="https://about.muse.jhu.edu/resources/help-overview">Help</a></li>
+								</ul>
+								<ul>
+									<li>
+										<ol class="social_icons">
+											<li class="list_h"><a href="https://www.facebook.com/ProjectMUSE" target="_blank" aria-label="Facebook link (opens in a new tab)"><img src="/images/footer_icon_fb.png" alt="Facebook" /></a></li>
+											<li class="list_h"><a href="https://www.linkedin.com/company/projectmuse/" target="_blank" aria-label="LinkedIn link (opens in a new tab)"><img src="/images/footer_icon_linkedin.png" alt="Linkedin" /></a></li>
+											<li class="list_h"><a href="https://twitter.com/ProjectMUSE" target="_blank" aria-label="Twitter link (opens in a new tab)"><img src="/images/footer_icon_twitter.png" alt="Twitter" /></a></li>
+										</ol>
+									</li>
+								</ul>
+							</nav>
+							<nav class="footer_item_policy cont_sub">
+								<div class="foothead">Policy & Terms</div>
+								<ul>
+									<li><a href="https://about.muse.jhu.edu/about/accessibility/">Accessibility</a></li>
+									<li><a href="/privacy_policy">Privacy Policy</a></li>
+									<li><a href="/terms_use">Terms of Use</a></li>	
+								</ul>
+							</nav>
+							<div class="clear"></div>
+						</div>
+						<div class="group">
+							<div class="footer_item_addr cont_sub">
+								<p class="address"><span>2715 North Charles Street<br/>Baltimore, Maryland, USA 21218</span></p>
+								<p class="phone"><span><a href="tel:1-410-516-6989">+1 (410) 516-6989</a></span><br>
+								<span><a href="mailto:muse@press.jhu.edu">muse@press.jhu.edu</a></span></p>
+								<p class="footer_text_sm copy color_oxfordblue hide-for-small"><span>&copy;2020 Project MUSE. Produced by Johns Hopkins University Press in collaboration with The Sheridan Libraries.</span></p>
+							</div>
+							<div class="footer_item_logo cont_sub">
+								<p class="show-for-medium"><span class="semiboldit footer_text_sm">Now and Always,<br/>The Trusted Content Your Research Requires</span></p>
+								<p><span><a href="https://muse.jhu.edu">
+								
+								<img class="show-for-medium" src="/images/muselogoblack.png" alt="Project MUSE logo" />
+								
+								<img class="hide-for-medium" src="/images/muselogo.png" alt="Project MUSE logo" /></a></span></p>
+								<p class="hide-for-medium"><span class="semiboldit footer_text_sm">Now and Always, The Trusted Content Your Research Requires</span></p>
+								<p class="hide-for-small"><span class="footer_text_sm">Built on the Johns Hopkins University Campus</span></p>
+							</div>
+							<div class="clear"></div>
+						</div>
+					</div>
+					<div class="clear"></div>
+				</div>
+			</div>
+			<div class="footer_item_sub wrap hide-for-medium">
+				<p><span class="footer_text_sm">Built on the Johns Hopkins University Campus</span></p>		
+				<p class="footer_text_sm copy color_oxfordblue"><span>&copy;2021 Project MUSE. Produced by Johns Hopkins University Press in collaboration with The Sheridan Libraries.</span></p>			
+			</div>		
+		</div>
+		
+		
+		
+		
+		<div id="btn_top">
+			<a href="#top"><span>Back To Top</span></a>
+		</div>
+		
+		
+		
+		  <input type="hidden" name="cookie_acknowledgement_type"  id="cookie_acknowledgement_type" value="cookie_acknowledgement">
+		
+		
+		
+			<div id="cookies_msg">
+				<p>This website uses cookies to ensure you get the best experience on our website. Without cookies your experience may not be seamless.</p>
+				<script>document.writeln('<a href="javascript://" class="btn_accept" id="accept_cookie_msg">Accept</a>');</script>
+				<noscript>	
+						
+								<form method="post" action="/account/set_attribute_no_ajax/cookie_acknowledgement/1">
+						
+						<input type="submit" class="btn_accept" value="accept">
+						</form>
+				</noscript>
+			</div>
+		
+		
+		<script type="text/javascript" src="/js/lightbox.js"></script>
+		<script type="text/javascript" src="/js/jquery.qtip2.min.js"></script>
+		<script type="text/javascript" src="/js/post.js"></script>
+		
+		<script type="text/javascript" src="/js/footnotes.js"></script>
+		
+		
+		<script type="text/javascript" src="/js/references.js"></script>
+		
+		
+	</body>
+</html>

--- a/tests/fixtures/muse_book_63320.html
+++ b/tests/fixtures/muse_book_63320.html
@@ -1,0 +1,346 @@
+
+<style>
+.page404 {
+	display: table;
+	width: 100%;
+	padding: 60px 4em;
+	min-height: 350px;
+}
+.page404 .int {
+	display: table-cell;
+	vertical-align: middle;
+	text-align: left; 
+}
+.page404 h4 {
+	margin-bottom: 10px;
+	font-weight: 700;
+}
+.page404 .logo {
+	display: table-cell;
+	width: 23%;
+	vertical-align: middle;
+	padding-right: 30px;
+}
+.page404 blockquote {
+	border: none;
+	padding-left: 0;
+}
+</style>
+
+
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<!-- Global site tag (gtag.js) - Google Analytics -->
+		<script async src="https://www.googletagmanager.com/gtag/js?id=UA-58347753-2"></script>
+		<script>
+		  window.dataLayer = window.dataLayer || [];
+		  function gtag(){dataLayer.push(arguments);}
+		  gtag('js', new Date());		
+		  gtag('config', 'UA-58347753-2');
+		</script>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+		<meta property="og:image" content="/images/muselogo_blk.png" />
+		
+		
+		
+		<title>Project MUSE</title>
+		<link rel="search" type="application/opensearchdescription+xml" title="Search Project MUSE from your browser's Searchbar" href="/plugins/muse-opensearch.xml" />
+		
+		
+		<link rel="stylesheet" type="text/css" href="/css/normalize.css"/>
+		<link href="/css/jquery.qtip2.css" rel="stylesheet" type="text/css" />
+<!-- 		foundation 6.4.1 custom float/typ/vis 250rem max width 30col float grid -->
+		<link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,600,600i,700,700i" rel="stylesheet">
+		<link rel="stylesheet" type="text/css" href="/css/foundation.min.css"/>
+		<link rel="stylesheet" type="text/css" href="/css/style_home2.css?031820"/>
+		
+		
+		
+		
+		
+
+		<script type="text/javascript" src="/js/jquery3.js"></script>		
+		<script type="text/javascript" src="/js/pre.js"></script>
+		<script type="text/javascript" src="/js/core/head.js?new"></script>
+		
+		<script type="text/javascript" src="https://s7.addthis.com/js/250/addthis_widget.js#pubid=ra-4ecb5479089cb81a"></script>
+
+		
+		
+		
+		<title>Article</title>
+	</head>
+	<body>
+		<a id="skip" href="#skip_target">[Skip to Content]</a>
+		<span id="top" role="none"></span>
+		<div id="header" role="banner" aria-label="header">
+			<div class="row wrap" id="institution_banner">
+				<div class="content">
+					<div id="institution_wrap" class="columns small-15 medium-text-left">
+						<div id="institution" class="img_text_col">
+							<div class="img_contain_left"><img src="/images/institution.png" alt="institution icon" /></div>
+							<div class="text_contain_left"><span class="small"><a href='/account' class='color_white login_status'>Institutional Login</a></span></div>
+						</div>
+					</div>
+					<div id="person_wrap" class="columns small-15">
+						<div id="person" class="img_text_col">
+							<div class="img_contain_right"><img src="/images/person.png" alt="account icon" /></div>
+							<div class="text_contain_right"><span class="small"><a href="/account/" class="color_white login_status" onclick="gtag('event', 'click', {'event_category': 'Account link', 'event_label': 'account name link - header'});"><span class="login_statement_unauthenticated">LOG IN</span></a></span></div>
+						</div>
+					</div>
+				</div>
+			</div>
+			
+			
+			
+			<div class="row wrap" id="search_banner">
+				<div class="content">
+					<div class="medium-4 small-4 columns" id="header_logo_wrap">
+						<div id="header_logo">
+							<a href="/"><img src="/images/muselogo.png" alt="Project MUSE" class="show-for-large"/>
+							<img src="/images/muselogo_notext.png" alt="Project MUSE" class="hide-for-large"/></a>							
+						</div>
+					</div>
+					<div class="medium-21 small-22 columns" id="search_bar_wrap">				
+						<div class="row"> 
+							<div id="browse_button_wrap">
+								<a id="browse_button" href="/browse" onclick="gtag('event', 'click', {'event_category': 'Browse link', 'event_label': 'browse button - header'});"><span class="small">browse</span></a>
+							</div>
+							<div id="or_text_wrap" class="show-for-medium">
+								<div id="or_text">
+									<span class="small">or</span> 
+								</div>
+							</div>
+							<div id="search_input_wrap" class="small-30">
+								<div id="search_input">
+  								
+  								<noscript>
+										<form method="post" action="/search/">
+                    <label for="nojs_search_input_header" class="hide">Search:</label>
+										<input name="no_js_header_query" id="nojs_search_input_header">
+										<input type="hidden" name="action" value="search">
+										<input type="hidden" name="t" value="header">
+										<button id="search_button">
+										<input type="image" src="/images/search_blue.png" alt="Search icon">										
+                    </button>
+										</form>
+									</noscript>
+								
+									<script>document.write('<label for="search_input_header" class="hide">Search:</label><input placeholder="Search..." name="search_input_header" id="search_input_header" aria-label="search input"><button type="button" id="search_button"><img src="/images/search_blue.png" alt="Search icon"/></button>');</script>																		
+								</div>
+							</div>
+						</div>				
+					</div>
+				
+					<div class="medium-5 small-4 columns" id="menu_wrap">
+						<div id="menu" class="menu-btn">
+	<div class="nav-toggle">
+		<div role="button" class="nav-toggle-btn" tabindex="0" aria-expanded="false">
+			<div role="presentation" class="menu-icon-wrap">
+				<span role="presentation" class="icon"></span>
+				<span role="presentation" class="small show-for-large">menu</span>
+			</div>
+		</div>
+		<div class="nav-mobile">
+			<a href="/search">Advanced Search</a>
+			<a href="/browse">Browse</a>
+			<script>
+				document.write('<div class="accordion">');
+			</script>
+			<noscript>
+				<div class="accordion noscript">
+			</noscript>
+				<a href="#" class="acc_trig open"><span>MyMUSE Account</span></a>
+				<div class="acc_block">
+					<a href="/account">Log In / Sign Up</a>
+					<a href="/account/change">Change My Account</a>
+					<a href="/account/user_settings">User Settings</a>
+					<a href="/account/">Access via Institution</a>
+					<a href="/account/saved_items">MyMUSE Library</a>
+					<a href="/account/search_history">Search History</a>
+					<a href="/account/view_history">View History</a>
+					<a href="/account/purchase_history">Purchase History</a>
+					<a href="/account/alerts">MyMUSE Alerts</a>
+																
+				</div>
+			</div>									
+			<div class="nav-mobile-footer">
+				<a href="/contact">Contact Support</a>
+			</div>
+		</div>
+	</div>
+</div>
+		
+ 
+					</div>
+				</div>
+			</div>
+			
+			
+			
+		</div>
+
+
+
+<div class="page404" id="main">
+	<div class="logo">
+		<img src="/images/muselogo_notext.png" alt="MUSE logo">
+	</div>
+	<div class="int">
+		<html><head><title>Error</title></head><body><h4>This book has not launched yet.</h4></body></html>
+
+	</div>
+</div>
+
+
+		<div id="footer_block" role="contentinfo" aria-label="footer">
+			<div class="content">
+				<div class="wrap row" id="about_wrap">
+					<div id="about">
+						<h2>Project MUSE Mission</h2>
+						<p>Project MUSE promotes the creation and dissemination of essential humanities and social science resources through collaboration with libraries, publishers, and scholars worldwide. Forged from a partnership between a university press and a library, Project MUSE is a trusted part of the academic and scholarly community it serves.</p>
+					</div>
+					<div id="about_logo" class="columns medium-10 show-for-large">
+						<img src="/images/muselogo_notext.png" alt="MUSE logo"/>
+					</div>
+				</div>
+			</div>
+			
+			<div class="footer_main">
+				<div class="footer_item_color wrap">
+					<div class="footer_item_left">
+						<div class="group">
+							<nav class="footer_item_about cont_sub">
+								<div class="foothead">About</div>
+								<ul>
+									<li><a href="https://about.muse.jhu.edu/about/story">MUSE Story</a></li>
+									<li><a href="https://about.muse.jhu.edu/publishers">Publishers</a></li>
+									<li><a href="https://about.muse.jhu.edu/about/discovery-partners/">Discovery Partners</a></li>
+									<li><a href="https://about.muse.jhu.edu/about/advisory-board/">Advisory Board</a></li>
+									<li><a href="https://about.muse.jhu.edu/about/journal-subscribers/">Journal Subscribers</a></li>
+									<li><a href="https://about.muse.jhu.edu/about/book-customers">Book Customers</a></li>
+									<li><a href="https://about.muse.jhu.edu/about/at-conferences/">Conferences</a></li>
+								</ul>
+							</nav>
+							<nav class="footer_item_what cont_sub">
+								<div class="foothead">What's on Muse</div>
+								<ul>
+									<li><a href="https://about.muse.jhu.edu/muse/open-access-overview/">Open Access</a></li>
+									<li><a href="https://about.muse.jhu.edu/muse/journals/all/">Journals</a></li>
+									<li><a href="https://about.muse.jhu.edu/muse/publishers/books/">Books</a></li>
+									<li><a href="https://about.muse.jhu.edu/muse-in-focus/">MUSE in Focus</a></li>
+									<li><a href="https://about.muse.jhu.edu/muse/eliot-prose/">T.S. Eliot Prose</a></li>
+								</ul>
+							</nav>
+							<div class="clear"></div>
+						</div>
+						<div class="group">
+						  <nav class="footer_item_res cont_sub">
+								<div class="foothead">Resources</div>
+								<ul>
+									<li><a href="https://about.muse.jhu.edu/resources/news/">News & Announcements</a></li>
+									<li><a href="https://about.muse.jhu.edu/news/signup/" target="_blank" aria-label="email sign-up link (opens in a new tab)">Email Sign-Up</a></li>
+									<li><a href="https://about.muse.jhu.edu/resources/promotional-materials">Promotional Materials</a></li>
+									<li><a href="https://about.muse.jhu.edu/resources/alerts">Get Alerts</a></li>
+									<li><a href="https://about.muse.jhu.edu/resources/muse-presentations">Presentations</a></li>
+								</ul>
+							</nav>
+							<nav class="footer_item_info cont_sub">
+								<div class="foothead">Information For</div>
+								<ul>
+									<li><a href="https://about.muse.jhu.edu/publishers">Publishers</a></li>
+									<li><a href="https://about.muse.jhu.edu/librarians">Librarians</a></li>
+									<li><a href="https://about.muse.jhu.edu/individuals">Individuals</a></li>
+								  <li><a href="https://about.muse.jhu.edu/instructors">Instructors</a></li>
+								</ul>
+							</nav>
+							<div class="clear"></div>
+						</div>
+					</div>
+					<div class="footer_item_right">
+						<div class="group">
+							<nav class="footer_item_social cont_sub">
+								<div class="foothead">Contact</div>
+								<ul>
+									<li class="clear"><a href="/contact">Contact Us</a></li>
+									<li><a href="https://about.muse.jhu.edu/resources/help-overview">Help</a></li>
+								</ul>
+								<ul>
+									<li>
+										<ol class="social_icons">
+											<li class="list_h"><a href="https://www.facebook.com/ProjectMUSE" target="_blank" aria-label="Facebook link (opens in a new tab)"><img src="/images/footer_icon_fb.png" alt="Facebook" /></a></li>
+											<li class="list_h"><a href="https://www.linkedin.com/company/projectmuse/" target="_blank" aria-label="LinkedIn link (opens in a new tab)"><img src="/images/footer_icon_linkedin.png" alt="Linkedin" /></a></li>
+											<li class="list_h"><a href="https://twitter.com/ProjectMUSE" target="_blank" aria-label="Twitter link (opens in a new tab)"><img src="/images/footer_icon_twitter.png" alt="Twitter" /></a></li>
+										</ol>
+									</li>
+								</ul>
+							</nav>
+							<nav class="footer_item_policy cont_sub">
+								<div class="foothead">Policy & Terms</div>
+								<ul>
+									<li><a href="https://about.muse.jhu.edu/about/accessibility/">Accessibility</a></li>
+									<li><a href="/privacy_policy">Privacy Policy</a></li>
+									<li><a href="/terms_use">Terms of Use</a></li>	
+								</ul>
+							</nav>
+							<div class="clear"></div>
+						</div>
+						<div class="group">
+							<div class="footer_item_addr cont_sub">
+								<p class="address"><span>2715 North Charles Street<br/>Baltimore, Maryland, USA 21218</span></p>
+								<p class="phone"><span><a href="tel:1-410-516-6989">+1 (410) 516-6989</a></span><br>
+								<span><a href="mailto:muse@press.jhu.edu">muse@press.jhu.edu</a></span></p>
+								<p class="footer_text_sm copy color_oxfordblue hide-for-small"><span>&copy;2020 Project MUSE. Produced by Johns Hopkins University Press in collaboration with The Sheridan Libraries.</span></p>
+							</div>
+							<div class="footer_item_logo cont_sub">
+								<p class="show-for-medium"><span class="semiboldit footer_text_sm">Now and Always,<br/>The Trusted Content Your Research Requires</span></p>
+								<p><span><a href="https://muse.jhu.edu">
+								
+								<img class="show-for-medium" src="/images/muselogoblack.png" alt="Project MUSE logo" />
+								
+								<img class="hide-for-medium" src="/images/muselogo.png" alt="Project MUSE logo" /></a></span></p>
+								<p class="hide-for-medium"><span class="semiboldit footer_text_sm">Now and Always, The Trusted Content Your Research Requires</span></p>
+								<p class="hide-for-small"><span class="footer_text_sm">Built on the Johns Hopkins University Campus</span></p>
+							</div>
+							<div class="clear"></div>
+						</div>
+					</div>
+					<div class="clear"></div>
+				</div>
+			</div>
+			<div class="footer_item_sub wrap hide-for-medium">
+				<p><span class="footer_text_sm">Built on the Johns Hopkins University Campus</span></p>		
+				<p class="footer_text_sm copy color_oxfordblue"><span>&copy;2021 Project MUSE. Produced by Johns Hopkins University Press in collaboration with The Sheridan Libraries.</span></p>			
+			</div>		
+		</div>
+		
+		
+		
+		
+		<div id="btn_top">
+			<a href="#top"><span>Back To Top</span></a>
+		</div>
+		
+		
+		
+		  <input type="hidden" name="cookie_acknowledgement_type"  id="cookie_acknowledgement_type" value="cookie_acknowledgement">
+		
+		
+		
+		
+		<script type="text/javascript" src="/js/lightbox.js"></script>
+		<script type="text/javascript" src="/js/jquery.qtip2.min.js"></script>
+		<script type="text/javascript" src="/js/post.js"></script>
+		
+		<script type="text/javascript" src="/js/footnotes.js"></script>
+		
+		
+		<script type="text/javascript" src="/js/references.js"></script>
+		
+		
+	</body>
+</html>
+

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -37,7 +37,8 @@ class TestHelpers:
         'API_CLIENT_TOKEN_URL': 'test_api_token_url',
         'GITHUB_API_KEY': 'test_github_key',
         'GITHUB_API_ROOT': 'test_github_url',
-        'BARDO_CCE_API': 'test_cce_url'
+        'BARDO_CCE_API': 'test_cce_url',
+        'MUSE_MARC_URL': 'test_muse_url'
     }
 
     @classmethod

--- a/tests/unit/test_marc_mapping.py
+++ b/tests/unit/test_marc_mapping.py
@@ -1,0 +1,109 @@
+import pytest
+
+from mappings.marc import MARCMapping
+
+
+class TestMARCMapping:
+    @pytest.fixture
+    def testFields(self):
+        return {
+            'title': ('245', '{a}'),
+            'identifiers': [
+                ('020', '{a}|isbn'),
+                ('022', '{a}|issn')
+            ],
+            'is_part_of': ('490', '{a}||volume')
+        }
+
+    @pytest.fixture
+    def testRecord(self, mocker):
+        testRecord = mocker.MagicMock()
+        testRecord.title = ['Test Title', 'Secondary Title']
+        testRecord.identifiers = ['1|muse', '|test', '3|other']
+
+        return testRecord
+
+    @pytest.fixture
+    def testMapper(self, testFields, testRecord):
+        class TestMARC(MARCMapping):
+            def __init__(self, source, mapping, statics):
+                super().__init__(source, statics)
+                self.source = source
+                self.mapping = mapping
+                self.statics = statics
+
+            def createMapping(self):
+                pass
+
+            def initEmptyRecord(self):
+                return testRecord
+
+        return TestMARC({}, testFields, {})
+
+
+    def test_applyMapping(self, testMapper, mocker):
+        mappingMocks = mocker.patch.multiple(MARCMapping,
+            getFieldData=mocker.DEFAULT,
+            applyFormatting=mocker.DEFAULT
+        )
+
+        mappingMocks['getFieldData'].side_effect = [['Test Title'], ['1|isbn'], ['|issn'], IndexError]
+
+        testMapper.applyMapping()
+
+        mappingMocks['applyFormatting'].assert_called_once
+        assert testMapper.record.title == 'Test Title'
+        assert testMapper.record.identifiers == ['1|isbn']
+
+    def test_getFieldData(self, testMapper, mocker):
+        mockGetMARC = mocker.patch.object(MARCMapping, 'getMARCData')
+        mockGetMARC.return_value = 'testMARCData'
+
+        mockSetField = mocker.patch.object(MARCMapping, 'setFieldValues')
+        mockSetField.return_value = ['value1', 'value2']
+
+        testFieldData = testMapper.getFieldData(('000', 'testStruct'))
+
+        assert testFieldData == ['value1', 'value2']
+        mockGetMARC.assert_called_once_with('000')
+        mockSetField.assert_called_once_with('testMARCData', 'testStruct')
+
+    def test_getMARCData_controlField(self, testMapper, mocker):
+        mockControlField = mocker.MagicMock(data='testValue')
+        mockControlField.is_control_field.return_value = True
+
+        testMapper.source = mocker.MagicMock()
+        testMapper.source.get_fields.return_value = [mockControlField]
+
+        testData = testMapper.getMARCData('000')
+
+        assert testData == ['testValue']
+        mockControlField.is_control_field.assert_called_once
+
+    def test_getMARCData_standardField(self, testMapper, mocker):
+        mockField = mocker.MagicMock(subfields=['a', 'aValue', 'b', 'bValue', 'c', 'cValue'])
+        mockField.is_control_field.return_value = False
+
+        testMapper.source = mocker.MagicMock()
+        testMapper.source.get_fields.return_value = [mockField]
+
+        testData = testMapper.getMARCData('000')
+
+        assert testData == [{'a': 'aValue', 'b': 'bValue', 'c': 'cValue'}]
+        mockField.is_control_field.assert_called_once
+
+    def test_setFieldValues(self, testMapper, mocker):
+        mockApply = mocker.patch.object(MARCMapping, 'applyStringFormat')
+        mockApply.side_effect = ['fieldValue', KeyError]
+
+        testValues = [v for v in testMapper.setFieldValues([None, 'marcValue', 'marcValue2'], 'testFormat')]
+
+        assert testValues == ['fieldValue']
+        mockApply.assert_has_calls([mocker.call('marcValue', 'testFormat'), mocker.call('marcValue2', 'testFormat')])
+    
+    def test_applyStringFormat_string(self, testMapper, mocker):
+        assert testMapper.applyStringFormat('Test String    ', '{0}||true') == 'Test String||true'
+    
+    def test_applyStringFormat_dict(self, testMapper, mocker):
+        assert testMapper.applyStringFormat({'a': 'Last,', 'b': 'First', 'c': 'M.I.'}, '{a} {b} {c}||true') == 'Last, First M.I.||true'
+

--- a/tests/unit/test_muse_mapping.py
+++ b/tests/unit/test_muse_mapping.py
@@ -11,6 +11,7 @@ class TestMUSEMapping:
         mockRecord.title = ['Main Title', 'Secondary Title']
         mockRecord.subjects = ['subj1', 'subj2', 'subj3']
         mockRecord.has_part = ['1|testURL|muse|testType|testFlags']
+        mockRecord.languages = ['||lang1', '||lang2']
 
         return mockRecord
 
@@ -28,8 +29,9 @@ class TestMUSEMapping:
 
         assert list(recordMapping.keys()) == [
             'identifiers', 'authors', 'title', 'alternative', 'has_version',
-            'publisher', 'spatial', 'dates', 'extent', 'table_of_contents',
-            'abstract', 'subjects', 'contributors', 'is_part_of', 'has_part'
+            'publisher', 'spatial', 'dates', 'languages', 'extent',
+            'table_of_contents', 'abstract', 'subjects', 'contributors',
+            'is_part_of', 'has_part'
         ]
         assert recordMapping['is_part_of'] == ('490', '{a}|{v}|volume')
 
@@ -38,17 +40,24 @@ class TestMUSEMapping:
         mockCleanSubject = mocker.patch.object(MUSEMapping, 'cleanUpSubjectHead')
         mockCleanSubject.side_effect = [1, 2, 3]
 
+        mockExtractLanguage = mocker.patch.object(MUSEMapping, 'extractLanguage')
+        mockExtractLanguage.side_effect = ['lng1', 'lng2']
+
         testMapping.applyFormatting()
 
         assert testMapping.record.source == 'muse'
         assert testMapping.record.source_id == '1'
         assert testMapping.record.title == 'Main Title'
         assert testMapping.record.subjects == [1, 2, 3]
+        assert testMapping.record.languages == ['lng1', 'lng2']
 
     def test_cleanUpSubjectHead(self, testMapping):
         cleanSubject = testMapping.cleanUpSubjectHead('first -- second. -- -- |||')
 
         assert cleanSubject == 'first -- second|||'
+
+    def test_extractLanguage(self, testMapping):
+        assert testMapping.extractLanguage('||100607s2011    mdu     o      00 0 eng d  z  ') == '||eng'
 
     def test_addHasPartLink(self, testMapping):
         testMapping.addHasPartLink('newURL', 'pdf+json', 'pdfFlags')

--- a/tests/unit/test_muse_mapping.py
+++ b/tests/unit/test_muse_mapping.py
@@ -1,0 +1,56 @@
+import pytest
+
+from mappings.muse import MUSEMapping
+
+
+class TestMUSEMapping:
+    @pytest.fixture
+    def testRecord(self, mocker):
+        mockRecord = mocker.MagicMock()
+        mockRecord.identifiers = ['1|muse', '2|test', '3|other']
+        mockRecord.title = ['Main Title', 'Secondary Title']
+        mockRecord.subjects = ['subj1', 'subj2', 'subj3']
+        mockRecord.has_part = ['1|testURL|muse|testType|testFlags']
+
+        return mockRecord
+
+    @pytest.fixture
+    def testMapping(self, testRecord):
+        class TestMapping(MUSEMapping):
+            def __init__(self):
+                self.mapping = None
+                self.record = testRecord
+        
+        return TestMapping()
+
+    def test_createMapping(self, testMapping):
+        recordMapping = testMapping.createMapping()
+
+        assert list(recordMapping.keys()) == [
+            'identifiers', 'authors', 'title', 'alternative', 'has_version',
+            'publisher', 'spatial', 'dates', 'extent', 'table_of_contents',
+            'abstract', 'subjects', 'contributors', 'is_part_of', 'has_part'
+        ]
+        assert recordMapping['is_part_of'] == ('490', '{a}|{v}|volume')
+
+    def test_applyFormatting(self, testMapping, mocker):
+
+        mockCleanSubject = mocker.patch.object(MUSEMapping, 'cleanUpSubjectHead')
+        mockCleanSubject.side_effect = [1, 2, 3]
+
+        testMapping.applyFormatting()
+
+        assert testMapping.record.source == 'muse'
+        assert testMapping.record.source_id == '1'
+        assert testMapping.record.title == 'Main Title'
+        assert testMapping.record.subjects == [1, 2, 3]
+
+    def test_cleanUpSubjectHead(self, testMapping):
+        cleanSubject = testMapping.cleanUpSubjectHead('first -- second. -- -- |||')
+
+        assert cleanSubject == 'first -- second|||'
+
+    def test_addHasPartLink(self, testMapping):
+        testMapping.addHasPartLink('newURL', 'pdf+json', 'pdfFlags')
+
+        assert testMapping.record.has_part[1] == '2|newURL|muse|pdf+json|pdfFlags'

--- a/tests/unit/test_muse_process.py
+++ b/tests/unit/test_muse_process.py
@@ -199,13 +199,11 @@ class TestMUSEProcess:
         mockPut = mocker.patch.object(MUSEProcess, 'putObjectInBucket')
 
         mockManifest = mocker.MagicMock()
-        mockManifest.links = []
+        mockManifest.links = {'self': {}}
         mockManifest.toJson.return_value = 'testJSON'
 
         testURL = testProcess.createManifestInS3(mockManifest, 1)
 
         assert testURL == 'https://test_aws_bucket.s3.amazonaws.com/manifests/muse/1.json'
-        assert mockManifest.links[0] == {
-            'rel': 'self', 'href': testURL, 'type': 'application/pdf+json'
-        }
+        assert mockManifest.links['self'] == {'href': testURL, 'type': 'application/pdf+json'}
         mockPut.assert_called_once_with(b'testJSON', 'manifests/muse/1.json', 'test_aws_bucket')

--- a/tests/unit/test_muse_process.py
+++ b/tests/unit/test_muse_process.py
@@ -1,0 +1,211 @@
+import pytest
+import requests
+
+from processes import MUSEProcess
+from tests.helper import TestHelpers
+
+
+class TestMUSEProcess:
+    @classmethod
+    def setup_class(cls):
+        TestHelpers.setEnvVars()
+
+    @classmethod
+    def teardown_class(cls):
+        TestHelpers.clearEnvVars()
+
+    @pytest.fixture
+    def testProcess(self):
+        class TestMUSE(MUSEProcess):
+            def __init__(self):
+                self.s3Bucket = 'test_aws_bucket'
+        
+        return TestMUSE()
+
+    @pytest.fixture
+    def testMUSEPage(self):
+        return open('./tests/fixtures/muse_book_42.html', 'r').read()
+
+    def test_runProcess_daily(self, testProcess, mocker):
+        mockImport = mocker.patch.object(MUSEProcess, 'importMARCRecords')
+        mockSave = mocker.patch.object(MUSEProcess, 'saveRecords')
+        mockCommit = mocker.patch.object(MUSEProcess, 'commitChanges')
+
+        testProcess.process = 'daily'
+        testProcess.runProcess()
+
+        mockImport.assert_called_once
+        mockSave.assert_called_once
+        mockCommit.assert_called_once
+
+    def test_runProcess_complete(self, testProcess, mocker):
+        mockImport = mocker.patch.object(MUSEProcess, 'importMARCRecords')
+        mockSave = mocker.patch.object(MUSEProcess, 'saveRecords')
+        mockCommit = mocker.patch.object(MUSEProcess, 'commitChanges')
+
+        testProcess.process = 'complete'
+        testProcess.runProcess()
+
+        mockImport.assert_called_once_with(fullOrPartial=True)
+        mockSave.assert_called_once
+        mockCommit.assert_called_once
+
+    def test_runProcess_custom(self, testProcess, mocker):
+        mockImport = mocker.patch.object(MUSEProcess, 'importMARCRecords')
+        mockSave = mocker.patch.object(MUSEProcess, 'saveRecords')
+        mockCommit = mocker.patch.object(MUSEProcess, 'commitChanges')
+
+        testProcess.process = 'custom'
+        testProcess.ingestPeriod = 'customTimestamp'
+        testProcess.runProcess()
+
+        mockImport.assert_called_once_with(startTimestamp='customTimestamp')
+        mockSave.assert_called_once
+        mockCommit.assert_called_once
+
+    def test_importMARCRecords(self, testProcess, mocker):
+        mockDownload = mocker.patch.object(MUSEProcess, 'downloadMARCRecords')
+        mockDownload.return_value = 'mockFile'
+
+        mockReader = mocker.patch('processes.muse.MARCReader')
+        mockReader.return_value = ['rec1', 'rec2', 'rec3']
+
+        mockParser = mocker.patch.object(MUSEProcess, 'parseMuseRecord')
+
+        testProcess.importMARCRecords()
+
+        mockDownload.assert_called_once
+        mockReader.assert_called_once_with('mockFile')
+        mockParser.assert_has_calls([mocker.call('rec1'), mocker.call('rec2'), mocker.call('rec3')])
+
+    def test_downloadMARCRecords_success(self, testProcess, mocker):
+        mockGet = mocker.patch.object(requests, 'get')
+        mockResp = mocker.MagicMock()
+        mockResp.status_code = 200
+        mockResp.iter_content.return_value = [b'm', b'a', b'r', b'c']
+        mockGet.return_value = mockResp
+
+        testRecords = testProcess.downloadMARCRecords()
+
+        assert testRecords.read() == b'marc'
+        mockGet.assert_called_once_with('test_muse_url', stream=True, timeout=30)
+
+    def test_downloadMARCRecords_failure(self, testProcess, mocker):
+        mockGet = mocker.patch.object(requests, 'get')
+        mockResp = mocker.MagicMock()
+        mockResp.status_code = 500
+        mockGet.return_value = mockResp
+
+        with pytest.raises(Exception):
+            testProcess.downloadMARCRecords()
+
+    def test_parseMuseRecord(self, testProcess, mocker):
+        mockRecord = mocker.MagicMock()
+        mockRecord.source_id = 'muse1'
+        mockRecord.has_part = ['1|testURL|muse|type|flags']
+
+        mockMapping = mocker.MagicMock()
+        mockMapping.record = mockRecord
+        mockMapper = mocker.patch('processes.muse.MUSEMapping')
+        mockMapper.return_value = mockMapping
+
+        processMocks = mocker.patch.multiple(MUSEProcess,
+            constructPDFManifest=mocker.DEFAULT,
+            createManifestInS3=mocker.DEFAULT,
+            addDCDWToUpdateList=mocker.DEFAULT
+        )
+
+        processMocks['constructPDFManifest'].return_value = 'testManifest'
+        processMocks['createManifestInS3'].return_value = 'testS3URL'
+
+        testProcess.parseMuseRecord('testMARC')
+
+        mockMapper.assert_called_once_with('testMARC')
+        mockMapping.applyMapping.assert_called_once
+        processMocks['constructPDFManifest'].assert_called_once_with('testURL', mockRecord)
+        processMocks['createManifestInS3'].assert_called_once_with('testManifest', 'muse1')
+        mockMapping.addHasPartLink.assert_called_once_with(
+            'testS3URL', 'application/pdf+json', '{"reader": true, "download": false, "catalog": false}'
+        )
+        processMocks['addDCDWToUpdateList'].assert_called_once_with(mockMapping)
+
+    def test_constructPDFManifest(self, testProcess, testMUSEPage, mocker):
+        mockLoad = mocker.patch.object(MUSEProcess, 'loadMusePage')
+        mockLoad.return_value = testMUSEPage
+
+        mockManifest = mocker.MagicMock()
+        mockManifestConstructor = mocker.patch('processes.muse.PDFManifest')
+        mockManifestConstructor.return_value = mockManifest
+
+        testManifest = testProcess.constructPDFManifest('testLink', 'testRecord')
+
+        assert testManifest == mockManifest
+
+        mockLoad.assert_called_once_with('testLink')
+        mockManifestConstructor.assert_called_once_with('testLink')
+        mockManifest.addMetadata.assert_called_once_with('testRecord')
+
+        mockManifest.addSection.assert_has_calls([
+            mocker.call('Part One. Reading Reading Historically', ''),
+            mocker.call('PART TWO. Contextual Receptions, Reading Experiences, and Patterns of Response: Four Case Studies', '')
+        ])
+
+        mockManifest.addChapter.assert_has_calls([
+            mocker.call('https://muse.jhu.edu/chapter/440/pdf', 'Cover', None),
+            mocker.call('https://muse.jhu.edu/chapter/2183675/pdf', 'Title Page', 'pp. i-iii'),
+            mocker.call('https://muse.jhu.edu/chapter/2183674/pdf', 'Copyright', 'p. iv'),
+            mocker.call('https://muse.jhu.edu/chapter/2183673/pdf', 'Dedication', 'pp. v-vi'),
+            mocker.call('https://muse.jhu.edu/chapter/441/pdf', 'Contents', 'pp. vii-viii'),
+            mocker.call('https://muse.jhu.edu/chapter/442/pdf', 'Preface', 'pp. ix-xiv'),
+            mocker.call('https://muse.jhu.edu/chapter/444/pdf', 'Chapter 1. Historical Hermeneutics, Reception Theory, and the Social Conditions of Reading in Antebellum America', 'pp. 3-35'),
+            mocker.call('https://muse.jhu.edu/chapter/445/pdf', 'Chapter 2. Interpretive Strategies and Informed Reading in the Antebellum Public Sphere', 'pp. 36-84'),
+            mocker.call('https://muse.jhu.edu/chapter/6239/pdf', 'Chapter 3. “These Days of Double Dealing”: Informed Response, Reader Appropriation, and the Tales of Poe', 'pp. 87-137'),
+            mocker.call('https://muse.jhu.edu/chapter/6240/pdf', 'Chapter 4. Multiple Audiences and Melville’s Fiction: Receptions, Recoveries, and Regressions', 'pp. 138-200'),
+            mocker.call('https://muse.jhu.edu/chapter/6241/pdf', 'Chapter 5. Response as (Re)construction: The Reception of Catharine Sedgwick’s Novels', 'pp. 201-255'),
+            mocker.call('https://muse.jhu.edu/chapter/6242/pdf', 'Chapter 6. Mercurial Readings: The Making and Unmaking of Caroline Chesebro’', 'pp. 256-298'),
+            mocker.call('https://muse.jhu.edu/chapter/6243/pdf', 'Conclusion. American Literary History and the Historical Study of Interpretive Practices', 'pp. 299-320'),
+            mocker.call('https://muse.jhu.edu/chapter/6244/pdf', 'Notes', 'pp. 321-392'),
+            mocker.call('https://muse.jhu.edu/chapter/6245/pdf', 'Index', 'pp. 393-403')
+        ])
+
+        mockManifest.closeSection.assert_has_calls([mocker.call(), mocker.call()])
+
+    def test_constructPDFManifest_error(self, testProcess, mocker):
+        mockLoad = mocker.patch.object(MUSEProcess, 'loadMusePage')
+        mockLoad.side_effect = Exception
+
+        assert testProcess.constructPDFManifest('testLink', 'testRecord') == None
+
+    def test_loadMusePage_success(self, testProcess, mocker):
+        mockGet = mocker.patch.object(requests, 'get')
+        mockResp = mocker.MagicMock()
+        mockResp.status_code = 200
+        mockResp.text = 'testHTML'
+        mockGet.return_value = mockResp
+
+        assert testProcess.loadMusePage('testLink') == 'testHTML'
+        mockGet.assert_called_once_with('testLink', timeout=15, headers={'User-agent': 'Mozilla/5.0'})
+
+    def test_loadMusePage_error(self, testProcess, mocker):
+        mockGet = mocker.patch.object(requests, 'get')
+        mockResp = mocker.MagicMock()
+        mockResp.status_code = 500
+        mockGet.return_value = mockResp
+
+        with pytest.raises(Exception):
+            testProcess.loadMusePage('testLink')
+
+    def test_createManifestInS3(self, testProcess, mocker):
+        mockPut = mocker.patch.object(MUSEProcess, 'putObjectInBucket')
+
+        mockManifest = mocker.MagicMock()
+        mockManifest.links = []
+        mockManifest.toJson.return_value = 'testJSON'
+
+        testURL = testProcess.createManifestInS3(mockManifest, 1)
+
+        assert testURL == 'https://test_aws_bucket.s3.amazonaws.com/manifests/muse/1.json'
+        assert mockManifest.links[0] == {
+            'rel': 'self', 'href': testURL, 'type': 'application/pdf+json'
+        }
+        mockPut.assert_called_once_with(b'testJSON', 'manifests/muse/1.json', 'test_aws_bucket')

--- a/tests/unit/test_pdf_chapter.py
+++ b/tests/unit/test_pdf_chapter.py
@@ -1,0 +1,88 @@
+import pytest
+
+from managers.pdfManifest import PDFChapter
+
+
+class TestPDFChapter:
+    @pytest.fixture
+    def testChapterWithRange(self):
+        return PDFChapter('testLink', 'testTitle', '1-5')
+
+    @pytest.fixture
+    def testChapterWithoutRange(self):
+        return PDFChapter('testLink', 'testTitle', None)
+
+    @pytest.fixture
+    def testChapterWithRomanRange(self):
+        return PDFChapter('testLink', 'testTitle', 'III-LIX')
+
+    def test_initializer(self, testChapterWithRange):
+        assert testChapterWithRange.link == 'testLink'
+        assert testChapterWithRange.title == 'testTitle'
+        assert testChapterWithRange.pageRange == '1-5'
+        assert testChapterWithRange.startPage == None
+        assert testChapterWithRange.endPage == None
+
+    def test_parsePageRange_arabic(self, testChapterWithRange, mocker):
+        mockParse = mocker.patch.object(PDFChapter, 'parseRangeValue')
+        mockParse.side_effect = [1, 5]
+
+        testChapterWithRange.parsePageRange()
+
+        mockParse.assert_has_calls([
+            mocker.call('1'), mocker.call('5')
+        ])
+        assert testChapterWithRange.startPage == 1
+        assert testChapterWithRange.endPage == 5
+
+    def test_parsePageRange_roman(self, testChapterWithRomanRange, mocker):
+        mockParse = mocker.patch.object(PDFChapter, 'parseRangeValue')
+        mockParse.side_effect = [3, 59]
+
+        testChapterWithRomanRange.parsePageRange()
+
+        mockParse.assert_has_calls([
+            mocker.call('III'), mocker.call('LIX')
+        ])
+        assert testChapterWithRomanRange.startPage == 3
+        assert testChapterWithRomanRange.endPage == 59
+
+    def test_parsePageRange_none(self, testChapterWithoutRange, mocker):
+        mockParse = mocker.patch.object(PDFChapter, 'parseRangeValue')
+
+        testChapterWithoutRange.parsePageRange()
+
+        mockParse.assert_not_called
+        assert testChapterWithoutRange.startPage == None
+        assert testChapterWithoutRange.endPage == None
+
+    def test_parseRangeValue_int_str(self, mocker):
+        mockTranslateRoman = mocker.patch.object(PDFChapter, 'translateRomanNumeral')
+
+        assert PDFChapter.parseRangeValue('1') == 1
+        mockTranslateRoman.assert_not_called
+
+    def test_parseRangeValue_char_str(self, mocker):
+        mockTranslateRoman = mocker.patch.object(PDFChapter, 'translateRomanNumeral')
+        mockTranslateRoman.return_value = 1
+
+        assert PDFChapter.parseRangeValue('iii') == 1
+        mockTranslateRoman.assert_called_once_with('iii')
+
+    def test_translateRomanNumeral_simple(self):
+        assert PDFChapter.translateRomanNumeral('V') == 5
+
+    def test_translateRomanNumeral_complex(self):
+        assert PDFChapter.translateRomanNumeral('mcmxciv') == 1994
+
+    def test_translateRomanNumeral_invalid(self):
+        assert PDFChapter.translateRomanNumeral('hello') == None
+
+    def test_toDict(self, testChapterWithRange):
+        testChapterWithRange.startPage = 1
+        testChapterWithRange.endPage = 5
+
+        assert testChapterWithRange.toDict() == {
+            'href': 'testLink', 'title': 'testTitle',
+            'pageStart': 1, 'pageEnd': 5
+        }

--- a/tests/unit/test_pdf_manifest.py
+++ b/tests/unit/test_pdf_manifest.py
@@ -1,0 +1,125 @@
+import json
+import pytest
+
+from tests.helper import TestHelpers
+from managers import PDFManifest
+
+class TestPDFManifest:
+    @classmethod
+    def setup_class(cls):
+        TestHelpers.setEnvVars()
+
+    @classmethod
+    def teardown_class(cls):
+        TestHelpers.clearEnvVars()
+
+    @pytest.fixture
+    def testManifest(self):
+        return PDFManifest('testSource')
+
+    def test_initializer(self, testManifest):
+        assert testManifest.metadata == {'@type': 'https://schema.org/Book'}
+        assert testManifest.links == [{'rel': 'alternate', 'href': 'testSource', 'type': 'text/html'}]
+        assert testManifest.components == []
+        assert testManifest.tableOfContents == []
+        assert testManifest.openSection is None
+
+    def test_addMetadata(self, testManifest, mocker):
+        mockRecord = mocker.MagicMock()
+        mockRecord.title = 'Test Record'
+        mockRecord.authors = ['Author 1|||true', 'Author 2|||false']
+        mockRecord.identifiers = ['id1|test', 'id2|isbn']
+
+        testManifest.addMetadata(mockRecord)
+
+        assert testManifest.metadata == {
+            '@type': 'https://schema.org/Book', 'title': 'Test Record',
+            'author': 'Author 1', 'identifier': 'urn:isbn:id2'
+        }
+
+    def test_addSection_no_existing(self, testManifest):
+        testManifest.addSection('New Section', 'sectionURL')
+
+        assert testManifest.openSection == {
+            'href': 'sectionURL', 'title': 'New Section', 'children': []
+        }
+
+    def test_addSection_existing(self, testManifest):
+        section1 = {
+            'href': 'sectionURL_1', 'title': 'Section 1', 'children': []
+        }
+        testManifest.openSection = section1
+
+        testManifest.addSection('Section 2', 'sectionURL_2')
+
+        assert testManifest.tableOfContents[0] == section1
+        assert testManifest.openSection == {
+            'href': 'sectionURL_2', 'title': 'Section 2', 'children': []
+        }
+
+    def test_closeSection(self, testManifest):
+        testSection = {
+            'href': 'sectionURL', 'title': 'Test Section', 'children': []
+        }
+        testManifest.openSection = testSection
+
+        testManifest.closeSection()
+
+        assert testManifest.openSection is None
+        assert testManifest.tableOfContents[0] == testSection
+
+    def test_addChapter_direct_no_subsections(self, testManifest, mocker):
+        mockChapter = mocker.MagicMock()
+        mockManager = mocker.patch('managers.pdfManifest.PDFChapter')
+        mockManager.return_value = mockChapter
+
+        testManifest.addChapter('testLink', 'testTitle', '1-5')
+
+        mockManager.assert_called_once_with('testLink', 'testTitle', '1-5')
+        mockChapter.parsepageRange.assert_called_once
+        assert testManifest.tableOfContents[0] == {'href': 'testLink', 'title': 'testTitle', 'pages': '1-5'}
+        assert testManifest.components[0] == mockChapter
+
+    def test_addChapter_parent_section_no_subsections(self, testManifest, mocker):
+        mockChapter = mocker.MagicMock()
+        mockManager = mocker.patch('managers.pdfManifest.PDFChapter')
+        mockManager.return_value = mockChapter
+
+        testManifest.openSection = {
+            'href': 'testSection', 'title': 'Section 1', 'children': []
+        }
+
+        testManifest.addChapter('testLink', 'testTitle', '1-5')
+
+        mockManager.assert_called_once_with('testLink', 'testTitle', '1-5')
+        mockChapter.parsepageRange.assert_called_once
+        assert testManifest.openSection['children'][0] == {'href': 'testLink', 'title': 'testTitle', 'pages': '1-5'}
+        assert testManifest.components[0] == mockChapter
+
+    def test_addChapter_direct_w_subsections(self, testManifest, mocker):
+        mockChapter = mocker.MagicMock()
+        mockManager = mocker.patch('managers.pdfManifest.PDFChapter')
+        mockManager.return_value = mockChapter
+
+        testManifest.addChapter('testLink', 'testTitle', '1-5', subsections=[1, 2, 3])
+        mockManager.assert_called_once_with('testLink', 'testTitle', '1-5')
+        mockChapter.parsepageRange.assert_called_once
+        assert testManifest.tableOfContents[0] == {
+            'href': 'testLink', 'title': 'testTitle', 'pages': '1-5', 'children': [1, 2, 3]
+        }
+        assert testManifest.components[0] == mockChapter
+
+    def test_toDict(self, testManifest):
+        assert testManifest.toDict() == {
+            'context': 'https://test_aws_bucket-s3.amazonaws.com/manifests/context.jsonld',
+            'media_type': 'application/pdf+json',
+            'metadata': {'@type': 'https://schema.org/Book'},
+            'links': [{'rel': 'alternate', 'href': 'testSource', 'type': 'text/html'}],
+            'components': [],
+            'table_of_contents': []
+        }
+
+    def test_toJson(self, testManifest):
+        jsonManifest = testManifest.toJson()
+        assert isinstance(jsonManifest, str)
+        assert json.loads(jsonManifest)['context'] == 'https://test_aws_bucket-s3.amazonaws.com/manifests/context.jsonld'

--- a/tests/unit/test_pdf_manifest.py
+++ b/tests/unit/test_pdf_manifest.py
@@ -19,7 +19,10 @@ class TestPDFManifest:
 
     def test_initializer(self, testManifest):
         assert testManifest.metadata == {'@type': 'https://schema.org/Book'}
-        assert testManifest.links == [{'rel': 'alternate', 'href': 'testSource', 'type': 'text/html'}]
+        assert testManifest.links == {
+            'self': {},
+            'alternate': [{'href': 'testSource', 'type': 'text/html'}]
+        }
         assert testManifest.components == []
         assert testManifest.tableOfContents == []
         assert testManifest.openSection is None
@@ -114,7 +117,7 @@ class TestPDFManifest:
             'context': 'https://test_aws_bucket-s3.amazonaws.com/manifests/context.jsonld',
             'media_type': 'application/pdf+json',
             'metadata': {'@type': 'https://schema.org/Book'},
-            'links': [{'rel': 'alternate', 'href': 'testSource', 'type': 'text/html'}],
+            'links': {'self': {}, 'alternate': [{'href': 'testSource', 'type': 'text/html'}]},
             'components': [],
             'table_of_contents': []
         }


### PR DESCRIPTION
This adds a process for ingesting Project MUSE records into the DRB database. This fetches MARC records for open access books available on Project MUSE. As these books are largely available as chapter-segmented PDF files, a manifest is constructed for each book that is used to provide access directly to the book content.

This process also adds a new mapping model for `MARC` records. This mapping assumes that the source records have already been parsed by `pymarc` or a similar library, the responsibility for which lies with individual processes. This is because MARC records are generally parsed as a batch, with some difficulty lying in the separation of individual records (hence the use of an external dependency).

To construct these PDF manifests the structure is inferred from the structure of HTML pages on Project MUSE that represent these books. They are parsed using `BeautifulSoup4` and reflect the section/chapter structure as present on those pages. A new manager to generate the manifests is also included in this PR.