### PR TITLE
NOREF Ingest Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## unreleased -- v0.0.6
+### Fixed
+- Fix timeout issues with RabbitMQ during long running processes
+- Handle odd record formatting in NYPL MARC records
+
 ## 2021-01-06 -- v0.0.5
 ### Added
 - Added multiprocessing to S3FileProcess

--- a/mappings/nypl.py
+++ b/mappings/nypl.py
@@ -79,16 +79,16 @@ class NYPLMapping(SQLMapping):
         self.source = dict(self.source)
         for value in self.source['var_fields']:
             marcField = {
-                'ind1': value['ind1'],
-                'ind2': value['ind2'],
-                'content': value['content']
+                'ind1': value.get('ind1', None),
+                'ind2': value.get('ind2', None),
+                'content': value.get('content', None)
             }
             try:
                 for sub in value['subfields']:
-                    marcField[sub['tag']] = sub['content']
-            except TypeError:
+                    marcField[sub['tag']] = sub.get('content', None)
+            except (KeyError, TypeError):
                 continue
-            self.source[value['marcTag']] = marcField
+            self.source[value.get('marcTag', 'XXX')] = marcField
     
     def applyFormatting(self):
         self.record.source = 'nypl'

--- a/processes/nypl.py
+++ b/processes/nypl.py
@@ -50,10 +50,10 @@ class NYPLProcess(CoreProcess):
             bib['nypl_source'], bib['id']
         ))
 
-        return True if bibStatus['isResearch'] is True else False
+        return True if bibStatus.get('isResearch', False) is True else False
 
     def getCopyrightStatus(self, varFields):
-        lccnData = list(filter(lambda x: x['marcTag'] == '010', varFields))
+        lccnData = list(filter(lambda x: x.get('marcTag', None) == '010', varFields))
         if not len(lccnData) == 1:
             return False
 

--- a/processes/s3Files.py
+++ b/processes/s3Files.py
@@ -1,8 +1,8 @@
 import json
-from multiprocessing import Process, Queue
+from multiprocessing import Process
 import os
 import requests
-from time import sleep, time
+from time import sleep
 
 from .core import CoreProcess
 from managers import S3Manager, RabbitMQManager
@@ -65,14 +65,11 @@ class S3Process(CoreProcess):
 
     @staticmethod
     def getFileContents(epubURL):
-        start = time()
         timeout = 120 
         epubResp = requests.get(epubURL, stream=True, timeout=timeout)
         if epubResp.status_code == 200:
             content = bytes()
             for byteChunk in epubResp.iter_content(1024):
-                if time() - start > timeout:
-                    raise TimeoutError('Unable to process {} in time'.format(epubURL))
                 content += byteChunk
 
             return content

--- a/tests/unit/test_rabbitmq_manager.py
+++ b/tests/unit/test_rabbitmq_manager.py
@@ -22,7 +22,7 @@ class TestRabbitMQManager:
         testInstance.createRabbitConnection()
 
         assert testInstance.rabbitConn == 'testConnection'
-        mockParams.assert_called_once_with(host='host', port='port')
+        mockParams.assert_called_once_with(host='host', port='port', heartbeat=600)
         mockConn.assert_called_once_with('testParams')
 
     def test_closeRabbitConnection(self, testInstance, mocker):


### PR DESCRIPTION
This PR fixes to issues uncovered while testing the ingest process:

1) The rabbitMQ process was timing out during long running processes (large file uploads, etc.). This adds a `heartbeat` parameter to the rabbitMQ client to hold it open while processes execute
2) The NYPL ingest process was encountering errors when processing edge cases in the MARC metadata attached to these records. These cases have been handled by providing default values when expected fields are missing.