### PR TITLE
SFR-984 NYPL API Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+### unreleased -- v0.2.0
+### Fixed
+- Token expiration bug in NYPL API manager
+
 ## 2021-01-14 -- v0.1.0
 ### Added
 - Mapping for parsing `MARC` records


### PR DESCRIPTION
The recommended method of obtaining `refresh_token`s from the OAUTH server does not appear to work with the NYPL server (the tokens are not returned).

With no clear way to obtain these tokens a workaround is put in place here to:

1) Catch expired token errors
2) Fetch a new token from the token endpoint
3) Use that token to re-create the API client, retry the current query and store the new client for future calls

This also includes a performance improvement that blocks the manager from repeatedly creating new clients when not necessary.