### PR TITLE
SFR-985 Fix s3 Processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## unreleased -- v0.2.0
+### Added
+- md5 check for records stored in AWS s3
+### Fixed
+- File chunk size for file streaming to AWS s3
+
 ## 2021-01-14 -- v0.1.0
 ### Added
 - Mapping for parsing `MARC` records

--- a/processes/s3Files.py
+++ b/processes/s3Files.py
@@ -60,16 +60,17 @@ class S3Process(CoreProcess):
                 storageManager.putObjectInBucket(epubB, filePath, bucket)
                 rabbitManager.acknowledgeMessageProcessed(msgProps.delivery_tag)
                 print('Sending Tag {} for {}'.format(fileURL, msgProps.delivery_tag))
+                del epubB
             except Exception as e:
                 print(e)
 
     @staticmethod
     def getFileContents(epubURL):
-        timeout = 120 
+        timeout = 15
         epubResp = requests.get(epubURL, stream=True, timeout=timeout)
         if epubResp.status_code == 200:
             content = bytes()
-            for byteChunk in epubResp.iter_content(1024):
+            for byteChunk in epubResp.iter_content(1024 * 250):
                 content += byteChunk
 
             return content

--- a/tests/unit/test_s3_manager.py
+++ b/tests/unit/test_s3_manager.py
@@ -62,7 +62,8 @@ class TestS3Manager:
         managerMocks['getObjectFromBucket'].assert_called_once_with('testKey.epub', 'testBucket', md5Hash='testMd5Hash')
         managerMocks['putExplodedEpubComponentsInBucket'].assert_called_once_with('testObj', 'testKey.epub', 'testBucket') 
         testInstance.s3Client.put_object.assert_called_once_with(
-            ACL='public-read', Body='testObj', Bucket='testBucket', Key='testKey.epub'
+            ACL='public-read', Body='testObj', Bucket='testBucket', Key='testKey.epub',
+            ContentMD5='testMd5Hash', Metadata={'md5Checksum': 'testMd5Hash'}
         )
 
     def test_putObjectInBucket_existing_outdated(self, testInstance, mocker):
@@ -87,7 +88,8 @@ class TestS3Manager:
         managerMocks['getObjectFromBucket'].assert_called_once_with('testKey.epub', 'testBucket', md5Hash='testMd5Hash')
         managerMocks['putExplodedEpubComponentsInBucket'].assert_called_once_with('testObj', 'testKey.epub', 'testBucket') 
         testInstance.s3Client.put_object.assert_called_once_with(
-            ACL='public-read', Body='testObj', Bucket='testBucket', Key='testKey.epub'
+            ACL='public-read', Body='testObj', Bucket='testBucket', Key='testKey.epub',
+            ContentMD5='testMd5Hash', Metadata={'md5Checksum': 'testMd5Hash'}
         )
 
     def test_putObjectInBucket_existing_unmodified(self, testInstance, mocker):

--- a/tests/unit/test_sfrFile_process.py
+++ b/tests/unit/test_sfrFile_process.py
@@ -101,7 +101,7 @@ class TestS3Process:
         testEpubFile = testInstance.getFileContents('testURL')
 
         assert testEpubFile == b'epub'
-        mockGet.assert_called_once_with('testURL', stream=True, timeout=120)
+        mockGet.assert_called_once_with('testURL', stream=True, timeout=15)
         
     def test_getFileContents_error(self, testInstance, mocker):
         mockGet = mocker.patch.object(requests, 'get')


### PR DESCRIPTION
This implements two significant fixes for the s3 storage processes:

- First it implements a custom `Metadata` header on all files stored in s3 and uses this calculated value to check if the file has changed since it last changed. This makes it possible to skip uploads of unchaged files when records are reprocessed for metadata reasons
- Second a change to the size of the `byte_chunk`s that are used to upload these files. This was originally sent to 1024 bytes, which resulted in a huge number of chunks being processed and throttling the download/upload process. This has been increased to `1024 * 25` (250kb) which in testing proved to give good performance for both large and small files