### PR TITLE
SFR-986 Update Gutenberg process to handle new media type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unreleased -- v0.2.0
+### Fixed
+- Added `application/epub+xml` media type for ePub XML files to Gutenberg process
+
 ## 2021-01-14 -- v0.1.0
 ### Added
 - Mapping for parsing `MARC` records

--- a/mappings/gutenberg.py
+++ b/mappings/gutenberg.py
@@ -97,7 +97,7 @@ class GutenbergMapping(XMLMapping):
                 i + 1,
                 'https://gutenberg.org/ebooks/{}.epub{}'.format(gutenbergID, extension),
                 'gutenberg',
-                'application/epub',
+                'application/epub+zip',
                 json.dumps({'reader': True, 'download': False, 'catalog': False})
             )
 

--- a/processes/gutenberg.py
+++ b/processes/gutenberg.py
@@ -89,7 +89,11 @@ class GutenbergProcess(CoreProcess):
             gutenbergRec.applyMapping()
 
             self.storeEpubsInS3(gutenbergRec)
-            self.addCoverAndStoreInS3(gutenbergRec, gutenbergYAML)
+
+            try:
+                self.addCoverAndStoreInS3(gutenbergRec, gutenbergYAML)
+            except AttributeError:
+                print('Unable to store cover for {}'.format(gutenbergRec.source_id))
             
             self.addDCDWToUpdateList(gutenbergRec)
 
@@ -106,7 +110,8 @@ class GutenbergProcess(CoreProcess):
             if flags['download'] is True:
                 bucketLocation = 'epubs/{}/{}_{}.epub'.format(source, gutenbergID, gutenbergType)
             else:
-                bucketLocation = 'epubs/{}/{}_{}/oebps/content.opf'.format(source, gutenbergID, gutenbergType)
+                bucketLocation = 'epubs/{}/{}_{}/meta-inf/content.xml'.format(source, gutenbergID, gutenbergType)
+                mediaType = 'application/epub+xml'
 
             s3URL = 'https://{}.s3.amazonaws.com/{}'.format(self.s3Bucket, bucketLocation)
 
@@ -122,7 +127,7 @@ class GutenbergProcess(CoreProcess):
             mimeType, _ = mimetypes.guess_type(coverData['image_path'])
             gutenbergID = yamlData['identifiers']['gutenberg']
 
-            fileExt = re.search(r'(\.[a-z0-9]+)$', coverData['image_path']).group(1)
+            fileExt = re.search(r'(\.[a-zA-Z0-9]+)$', coverData['image_path']).group(1)
             bucketLocation = 'covers/gutenberg/{}{}'.format(gutenbergID, fileExt)
 
             s3URL = 'https://{}.s3.amazonaws.com/{}'.format(self.s3Bucket, bucketLocation)

--- a/tests/unit/test_gutenberg_mapping.py
+++ b/tests/unit/test_gutenberg_mapping.py
@@ -57,7 +57,7 @@ class TestGutenbergMapping:
         assert testMapping.record.authors == ['Author1 (1950-2020)|||true', 'Author2|||false']
         assert testMapping.record.has_part == [
             '1|https://gutenberg.org/ebooks/1.epub.images|gutenberg|application/epub+zip|{"reader": false, "download": true, "catalog": false}',
-            '1|https://gutenberg.org/ebooks/1.epub.images|gutenberg|application/epub|{"reader": true, "download": false, "catalog": false}',
+            '1|https://gutenberg.org/ebooks/1.epub.images|gutenberg|application/epub+zip|{"reader": true, "download": false, "catalog": false}',
             '2|https://gutenberg.org/ebooks/1.epub.noimages|gutenberg|application/epub+zip|{"reader": false, "download": true, "catalog": false}',
-            '2|https://gutenberg.org/ebooks/1.epub.noimages|gutenberg|application/epub|{"reader": true, "download": false, "catalog": false}'
+            '2|https://gutenberg.org/ebooks/1.epub.noimages|gutenberg|application/epub+zip|{"reader": true, "download": false, "catalog": false}'
         ]

--- a/tests/unit/test_gutenberg_process.py
+++ b/tests/unit/test_gutenberg_process.py
@@ -173,7 +173,7 @@ class TestGutenbergProcess:
         ])
         assert mockRecord.record.has_part == [
             '1|https://test_aws_bucket.s3.amazonaws.com/epubs/gutenberg/1_images.epub|gutenberg|application/epub+zip|{"download": true}',
-            '1|https://test_aws_bucket.s3.amazonaws.com/epubs/gutenberg/1_images/oebps/content.opf|gutenberg|application/epub|{"download": false}',
+            '1|https://test_aws_bucket.s3.amazonaws.com/epubs/gutenberg/1_images/meta-inf/content.xml|gutenberg|application/epub+xml|{"download": false}',
             '2|https://test_aws_bucket.s3.amazonaws.com/epubs/gutenberg/2_noimages.epub|gutenberg|application/epub+zip|{"download": true}',
         ]
 


### PR DESCRIPTION
The new reader will not use the old JSON flags provided with each URI but instead use the media types attached as they are both easier to understand and a standard field. To support this we have settled on the `application/epub+xml` media type for the `container.xml` files that provide access to the structure of ePubs. This simply updates the Project Gutenberg process to match this new standard.