### PR TITLE
SFR-952 DOAB file fetch fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Fixed
 - Update README with progress
 - Refactored environment variable configuration to be more understandable
+- DOAB ePub file ingest error handling and checking
 
 ## 2021-01-28 -- v0.2.0
 ### Added

--- a/processes/doab.py
+++ b/processes/doab.py
@@ -89,9 +89,7 @@ class DOABProcess(CoreProcess):
 
             resumptionToken = self.getResumptionToken(oaiFile)
 
-            print(recordsProcessed, self.ingestOffset, self.ingestLimit)
             if recordsProcessed < self.ingestOffset:
-                print('SKIPPING BATCH')
                 recordsProcessed += 100
                 continue
             
@@ -108,7 +106,6 @@ class DOABProcess(CoreProcess):
             recordsProcessed += 100
 
             if not resumptionToken or recordsProcessed >= self.ingestLimit:
-                print('BREAKING')
                 break
 
     def getResumptionToken(self, oaiFile):
@@ -133,7 +130,6 @@ class DOABProcess(CoreProcess):
 
         doabURL = '{}{}'.format(doabURL, urlParams)
             
-        print(doabURL, resumptionToken)
         doabResponse = requests.get(doabURL, stream=True, timeout=30, verify=False)
 
         if doabResponse.status_code == 200:

--- a/processes/s3Files.py
+++ b/processes/s3Files.py
@@ -56,6 +56,7 @@ class S3Process(CoreProcess):
             filePath = fileMeta['bucketPath']
 
             try:
+                print(fileURL)
                 epubB = S3Process.getFileContents(fileURL)
                 storageManager.putObjectInBucket(epubB, filePath, bucket)
                 rabbitManager.acknowledgeMessageProcessed(msgProps.delivery_tag)
@@ -67,7 +68,13 @@ class S3Process(CoreProcess):
     @staticmethod
     def getFileContents(epubURL):
         timeout = 15
-        epubResp = requests.get(epubURL, stream=True, timeout=timeout)
+        epubResp = requests.get(
+            epubURL,
+            stream=True,
+            timeout=timeout,
+            headers={'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5)'}
+        )
+
         if epubResp.status_code == 200:
             content = bytes()
             for byteChunk in epubResp.iter_content(1024 * 250):

--- a/tests/unit/test_parser_springer.py
+++ b/tests/unit/test_parser_springer.py
@@ -129,8 +129,8 @@ class TestSpringerParser:
         testLinks = testParser.createPDFLinks('testRoot/')
 
         assert testLinks == [
-            ('testRoot/epubs/springer/10-007_1/meta-inf/container.xml', {'reader': True}, 'application/epub+zip', None, None),
-            ('testRoot/epubs/springer/10-007_1.epub', {'download': True}, 'application/epub+xml', None, ('epubs/springer/10-007_1.epub', 'https://link.springer.com/download/epub/10.007/1.epub')),
+            ('testRoot/manifests/springer/10-007_1.json', {'reader': True}, 'application/pdf+json', ('manifests/springer/10-007_1.json', 'testManifestJSON'), None),
+            ('https://link.springer.com/content/pdf/10.007/1.pdf', {'download': True}, 'application/pdf', None, None)
         ]
         parserMocks['generateManifest'].assert_called_once_with('https://link.springer.com/content/pdf/10.007/1.pdf', 'testRoot/manifests/springer/10-007_1.json')
         parserMocks['checkAvailability'].assert_called_once_with('https://link.springer.com/content/pdf/10.007/1.pdf')
@@ -150,10 +150,10 @@ class TestSpringerParser:
         testLinks = testParser.createEPubLinks('testRoot/')
 
         assert testLinks == [
-            ('testRoot/manifests/springer/10-007_1.json', {'reader': True}, 'application/pdf+json', ('manifests/springer/10-007_1.json', 'testManifestJSON'), None),
-            ('https://link.springer.com/content/pdf/10.007/1.pdf', {'download': True}, 'application/pdf', None, None)
+            ('testRoot/epubs/springer/10-007_1/meta-inf/container.xml', {'reader': True}, 'application/epub+zip', None, None),
+            ('testRoot/epubs/springer/10-007_1.epub', {'download': True}, 'application/epub+xml', None, ('epubs/springer/10-007_1.epub', 'https://link.springer.com/download/epub/10.007/1.epub')),
         ]
-        mockCheck.assert_called_once_with('https://link.springer.com/content/pdf/10.007/1.epub')
+        mockCheck.assert_called_once_with('https://link.springer.com/download/epub/10.007/1.epub')
 
     def test_createEPubLinks_missing(self, testParser, mocker):
         mockCheck = mocker.patch.object(SpringerParser, 'checkAvailability')
@@ -176,7 +176,8 @@ class TestSpringerParser:
         mockAbstractGenerate.assert_called_once()
 
     def test_checkAvailability(self, mocker):
+        mockResp = mocker.MagicMock(status_code=200)
         mockHead = mocker.patch.object(requests, 'head')
-        mockHead.return_value = 200
+        mockHead.return_value = mockResp
 
         assert SpringerParser.checkAvailability('testURL') == True

--- a/tests/unit/test_parser_springer.py
+++ b/tests/unit/test_parser_springer.py
@@ -102,23 +102,64 @@ class TestSpringerParser:
     def test_createLinks(self, testParser, mocker):
         parserMocks = mocker.patch.multiple(SpringerParser,
             generateS3Root=mocker.DEFAULT,
-            generateManifest=mocker.DEFAULT
+            createPDFLinks=mocker.DEFAULT,
+            createEPubLinks=mocker.DEFAULT
         )
         parserMocks['generateS3Root'].return_value = 'testRoot/'
+        parserMocks['createPDFLinks'].return_value = ['pdf1', 'pdf2']
+        parserMocks['createEPubLinks'].return_value = ['epub1', 'epub2']
+
+        testLinks = testParser.createLinks()
+
+        assert testLinks == ['pdf1', 'pdf2', 'epub1', 'epub2']
+        parserMocks['generateS3Root'].assert_called_once()
+        parserMocks['createPDFLinks'].assert_called_once_with('testRoot/')
+        parserMocks['createEPubLinks'].assert_called_once_with('testRoot/')
+
+    def test_createPDFLinks(self, testParser, mocker):
+        parserMocks = mocker.patch.multiple(SpringerParser,
+            generateManifest=mocker.DEFAULT,
+            checkAvailability=mocker.DEFAULT
+        )
         parserMocks['generateManifest'].return_value = 'testManifestJSON'
+        parserMocks['checkAvailability'].return_value = True
 
         testParser.code = '10.007'
         testParser.uriIdentifier = '1'
-        testLinks = testParser.createLinks()
+        testLinks = testParser.createPDFLinks('testRoot/')
 
         assert testLinks == [
             ('testRoot/epubs/springer/10-007_1/meta-inf/container.xml', {'reader': True}, 'application/epub+zip', None, None),
             ('testRoot/epubs/springer/10-007_1.epub', {'download': True}, 'application/epub+xml', None, ('epubs/springer/10-007_1.epub', 'https://link.springer.com/download/epub/10.007/1.epub')),
+        ]
+        parserMocks['generateManifest'].assert_called_once_with('https://link.springer.com/content/pdf/10.007/1.pdf', 'testRoot/manifests/springer/10-007_1.json')
+        parserMocks['checkAvailability'].assert_called_once_with('https://link.springer.com/content/pdf/10.007/1.pdf')
+
+    def test_createPDFLinks_missing(self, testParser, mocker):
+        mockCheck = mocker.patch.object(SpringerParser, 'checkAvailability')
+        mockCheck.return_value = False
+
+        assert testParser.createPDFLinks('testRoot/') == []
+
+    def test_createEPubLinks(self, testParser, mocker):
+        mockCheck = mocker.patch.object(SpringerParser, 'checkAvailability')
+        mockCheck.return_value = True
+
+        testParser.code = '10.007'
+        testParser.uriIdentifier = '1'
+        testLinks = testParser.createEPubLinks('testRoot/')
+
+        assert testLinks == [
             ('testRoot/manifests/springer/10-007_1.json', {'reader': True}, 'application/pdf+json', ('manifests/springer/10-007_1.json', 'testManifestJSON'), None),
             ('https://link.springer.com/content/pdf/10.007/1.pdf', {'download': True}, 'application/pdf', None, None)
         ]
-        parserMocks['generateS3Root'].assert_called_once()
-        parserMocks['generateManifest'].assert_called_once_with('https://link.springer.com/content/pdf/10.007/1.pdf', 'testRoot/manifests/springer/10-007_1.json')
+        mockCheck.assert_called_once_with('https://link.springer.com/content/pdf/10.007/1.epub')
+
+    def test_createEPubLinks_missing(self, testParser, mocker):
+        mockCheck = mocker.patch.object(SpringerParser, 'checkAvailability')
+        mockCheck.return_value = False
+
+        assert testParser.createEPubLinks('testRoot/') == []
 
     def test_generateManifest(self, testParser, mocker):
         mockAbstractManifest = mocker.patch('managers.parsers.abstractParser.AbstractParser.generateManifest')
@@ -133,3 +174,9 @@ class TestSpringerParser:
 
         assert testParser.generateS3Root() == 'testRoot'
         mockAbstractGenerate.assert_called_once()
+
+    def test_checkAvailability(self, mocker):
+        mockHead = mocker.patch.object(requests, 'head')
+        mockHead.return_value = 200
+
+        assert SpringerParser.checkAvailability('testURL') == True

--- a/tests/unit/test_sfrFile_process.py
+++ b/tests/unit/test_sfrFile_process.py
@@ -101,7 +101,12 @@ class TestS3Process:
         testEpubFile = testInstance.getFileContents('testURL')
 
         assert testEpubFile == b'epub'
-        mockGet.assert_called_once_with('testURL', stream=True, timeout=15)
+        mockGet.assert_called_once_with(
+            'testURL',
+            stream=True,
+            timeout=15,
+            headers={'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5)'}
+        )
         
     def test_getFileContents_error(self, testInstance, mocker):
         mockGet = mocker.patch.object(requests, 'get')


### PR DESCRIPTION
This implements several minor fixes for the DOAB ingest process, mainly to how ePub files are fetched from different publishers. These fixes are:

- Add an `User-Agent` header when fetching ePub files for s3 as some publishers expect it to be present
- Improve the Springer ingest by verifying that PDF and/or ePub files are present before attempting to store them
- Improve the Frontier parser by gracefully handling timeout errors
- Remove extraneous `print` statements and other QoL improvements