### PR TITLE
SFR-958 Deployment Extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # CHANGELOG
 
 ## unreleased -- v0.2.1
+### Added
+- Endpoint at `/` to verify API status
 ### Fixed
 - Update README with progress
 - Refactored environment variable configuration to be more understandable
+- Fixed bug that could cause collisions in redis cache
 
 ## 2021-01-28 -- v0.2.0
 ### Added

--- a/api/app.py
+++ b/api/app.py
@@ -5,7 +5,7 @@ import os
 from waitress import serve
 
 from model import Work
-from .blueprints import search, work
+from .blueprints import search, work, info
 
 
 class FlaskAPI:
@@ -15,6 +15,7 @@ class FlaskAPI:
         self.app.config['ES_CLIENT'] = client
         self.app.config['DB_CLIENT'] = dbEngine
 
+        self.app.register_blueprint(info)
         self.app.register_blueprint(search)
         self.app.register_blueprint(work)
 

--- a/api/blueprints/__init__.py
+++ b/api/blueprints/__init__.py
@@ -1,2 +1,3 @@
+from .drbInfo import info
 from .drbSearch import search
 from .drbWork import work

--- a/api/blueprints/drbInfo.py
+++ b/api/blueprints/drbInfo.py
@@ -1,0 +1,11 @@
+from flask import Blueprint, jsonify
+import os
+
+info = Blueprint('info', __name__, url_prefix='/')
+
+@info.route('/', methods=['GET'])
+def apiInfo():
+    return (
+        jsonify({'environment': os.environ['ENVIRONMENT'], 'status': 'RUNNING'}),
+        200
+    )

--- a/managers/redis.py
+++ b/managers/redis.py
@@ -8,6 +8,7 @@ class RedisManager:
         super(RedisManager, self).__init__()
         self.redisHost = host or os.environ['REDIS_HOST']
         self.redisPort = port or os.environ['REDIS_PORT']
+        self.environment = os.environ['ENVIRONMENT']
     
     def createRedisClient(self):
         self.redisClient = Redis(
@@ -32,7 +33,7 @@ class RedisManager:
     
     def setRedis(self, service, identifier, idenType, presentTime, expirationTime=60*60*24*7):
         self.redisClient.set(
-            '{}/{}/{}'.format(service, identifier, idenType),
+            '{}/{}/{}/{}'.format(self.environment, service, identifier, idenType),
             presentTime.strftime('%Y-%m-%dT%H:%M:%S'),
             ex=expirationTime
         )

--- a/tests/unit/test_api_info_blueprint.py
+++ b/tests/unit/test_api_info_blueprint.py
@@ -1,0 +1,16 @@
+from flask import Flask
+import pytest
+
+from api.blueprints.drbInfo import apiInfo
+
+
+class TestInfoBlueprint:
+    def test_apiInfo(self, mocker):
+        mocker.patch.dict('os.environ', {'ENVIRONMENT': 'test'})
+
+        flaskApp = Flask('test')
+
+        with flaskApp.test_request_context('/?testing=true'):
+            apiResp, _ = apiInfo()
+            assert apiResp.status_code == 200
+            assert apiResp.get_json() == {'environment': 'test', 'status': 'RUNNING'}

--- a/tests/unit/test_redis_manager.py
+++ b/tests/unit/test_redis_manager.py
@@ -7,7 +7,9 @@ from managers import RedisManager
 class TestRedisManager:
     @pytest.fixture
     def testInstance(self, mocker):
-        mocker.patch.dict('os.environ', {'REDIS_HOST': 'host', 'REDIS_PORT': 'port'})
+        mocker.patch.dict('os.environ', {
+            'REDIS_HOST': 'host', 'REDIS_PORT': 'port', 'ENVIRONMENT': 'testEnv'
+        })
         return RedisManager()
 
     def test_initializer(self, testInstance):
@@ -61,5 +63,5 @@ class TestRedisManager:
         testInstance.setRedis('test', 1, 'test', datetime(1900, 1, 1))
 
         testInstance.redisClient.set.assert_called_once_with(
-            'test/1/test', '1900-01-01T00:00:00', ex=604800
+            'testEnv/test/1/test', '1900-01-01T00:00:00', ex=604800
         )


### PR DESCRIPTION
This extends the API with a very basic status response object that verifies that the API is running and in what environment. This is useful when testing deployments and is probably good to have in general. It should be updated to include the current application version in the future.

Additionally, as the deployed versions of this application may share a redis cluster the keys that they generate should be specific to each environment (to avoid collisions). To do so each key is prefixed with the current environment which should avoid any issues.