### PR TITLE
SFR-975 API quality of life improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Update README with progress
 - Refactored environment variable configuration to be more understandable
 - DOAB ePub file ingest error handling and checking
+- Fixed handling of `showAll` and standardized for all endpoints
+- Removed any snake_case parameters from API
 
 ## 2021-01-28 -- v0.2.0
 ### Added

--- a/api/blueprints/drbSearch.py
+++ b/api/blueprints/drbSearch.py
@@ -15,7 +15,9 @@ def standardQuery():
     searchParams = APIUtils.normalizeQueryParams(request.args)
     queryTerms = APIUtils.extractParamPairs(searchParams.get('query', []))
     sortTerms = APIUtils.extractParamPairs(searchParams.get('sort', []))
+
     filterTerms = APIUtils.extractParamPairs(searchParams.get('filter', []))
+    filterTerms.extend(APIUtils.extractParamPairs('showAll', []))
 
     searchPage = searchParams.get('page', [0])[0]
     searchSize = searchParams.get('size', [10])[0]

--- a/api/blueprints/drbWork.py
+++ b/api/blueprints/drbWork.py
@@ -11,7 +11,7 @@ def workFetch(uuid):
     dbClient = DBClient(current_app.config['DB_CLIENT'])
 
     searchParams = APIUtils.normalizeQueryParams(request.args)
-    showAll = False if searchParams.get('showAll', ['true'])[0].lower() == 'false' else True
+    showAll = searchParams.get('showAll', ['true'])[0].lower() != 'false'
 
     work = dbClient.fetchSingleWork(uuid)
 

--- a/api/elastic.py
+++ b/api/elastic.py
@@ -139,7 +139,7 @@ class ElasticClient():
         dateFilters = list(filter(lambda x: 'year' in x[0].lower(), filterParams))
         languageFilters = list(filter(lambda x: x[0] == 'language', filterParams))
         formatFilters = list(filter(lambda x: x[0] == 'format', filterParams))
-        displayFilters = list(filter(lambda x: x[0] == 'show_all', filterParams))
+        displayFilters = list(filter(lambda x: x[0] == 'showAll', filterParams))
 
         dateFilter, dateAggregation = (None, None)
         formatFilter, formatAggregation = (None, None)
@@ -155,7 +155,7 @@ class ElasticClient():
             formatFilter = Q('terms', instances__formats=formats)
             formatAggregation = A('filter', **{'terms': {'editions.formats': formats}})
 
-        if len(displayFilters) > 0:
+        if len(displayFilters) > 0 and displayFilters[0][1] == 'true':
             displayFilter = None
             displayAggregation = None
         

--- a/api/utils.py
+++ b/api/utils.py
@@ -28,8 +28,8 @@ class APIUtils():
     @staticmethod
     def formatPagingOptions(hits):
         return {
-            'prev_page_sort': list(hits[0].meta.sort),
-            'next_page_sort': list(hits[-1].meta.sort)
+            'prevPageSort': list(hits[0].meta.sort),
+            'nextPageSort': list(hits[-1].meta.sort)
         }
 
     @classmethod

--- a/tests/unit/test_api_es.py
+++ b/tests/unit/test_api_es.py
@@ -479,7 +479,7 @@ class TestElasticClient:
         mockApply.return_value = mockSearch
         mockApplyAggs = mocker.patch.object(ElasticClient, 'applyAggregations')
 
-        filtersAndAggs = ElasticClient.addFilterClausesAndAggregations(mockSearch, [('show_all', 'true')])
+        filtersAndAggs = ElasticClient.addFilterClausesAndAggregations(mockSearch, [('showAll', 'true')])
 
         mockQuery.assert_has_calls([
             mocker.call('exists', field='editions.formats'),

--- a/tests/unit/test_api_search_blueprint.py
+++ b/tests/unit/test_api_search_blueprint.py
@@ -67,7 +67,7 @@ class TestSearchBlueprint:
             'query': ['q1', 'q2'], 'sort': ['s1'], 'size': [5]
         }
         mockUtils['extractParamPairs'].side_effect = [
-            'testQueryTerms', 'testSortTerms', 'testFilterTerms'
+            ['testQueryTerms'], ['testSortTerms'], ['testFilterTerms'], ['testShowAll']
         ]
         mockUtils['formatAggregationResult'].return_value = 'testFacets'
         mockUtils['formatPagingOptions'].return_value = 'testPaging'
@@ -97,7 +97,8 @@ class TestSearchBlueprint:
                 mocker.call(['q1', 'q2']), mocker.call(['s1']), mocker.call([])
             ])
             mockES.searchQuery.assert_called_once_with(
-                'testQueryTerms', 'testSortTerms', 'testFilterTerms', page=0, perPage=5
+                ['testQueryTerms'], ['testSortTerms'], ['testFilterTerms', 'testShowAll'],
+                page=0, perPage=5
             )
             mockDB.fetchSearchedWorks.assert_called_once_with([
                 ('uuid1', ['ed1', 'ed2']), ('uuid2', ['ed3']),

--- a/tests/unit/test_api_utils.py
+++ b/tests/unit/test_api_utils.py
@@ -80,7 +80,7 @@ class TestAPIUtils:
     def test_formatPagingOptions(self, testHitObject):
         testPagingOptions = APIUtils.formatPagingOptions(testHitObject)
 
-        assert testPagingOptions == {'prev_page_sort': ['firstSort'], 'next_page_sort': ['lastSort']}
+        assert testPagingOptions == {'prevPageSort': ['firstSort'], 'nextPageSort': ['lastSort']}
 
     def test_formatWorkOutput_single_work(self, mocker):
         mockFormat = mocker.patch.object(APIUtils, 'formatWork')


### PR DESCRIPTION
This implements a number of improvements around the `showAll` filter option. These are:

- Standardize the paramater between the `search` and `work` endpoints: Use camelCase as a standalone parameter for both
- Extend the handling of the parameter in `elasticsearch` to ensure that it properly handles cases when the param is explicitly set to `false`
- Related test suite updates

This also generally ensures that all query and response parameters use `camelCase` instead of `snake_case` for consistency reasons.