### PR TITLE
NOREF DOAB ePub Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## unreleased -- v0.2.2
+### Fixed
+- Standardized timeout values and handling of related errors in DOAB
+- Better handle HTTP redirect `Location` values
+- Fix paths to ePub files in s3 (allow for uppercase characters)
+- Add handling for DOI paths in DeGruyter DOAB records
+
 ## 2021-02-01 -- v0.2.1
 ### Added
 - Endpoint at `/` to verify API status

--- a/managers/doabParser.py
+++ b/managers/doabParser.py
@@ -1,6 +1,7 @@
 import inspect
 import json
 import requests
+import re
 from requests.exceptions import ConnectionError, InvalidURL, MissingSchema, ReadTimeout 
 
 import managers.parsers as parsers
@@ -71,19 +72,24 @@ class DOABLinkManager:
     def findFinalURI(uri, mediaType):
         try:
             uriHeader = requests.head(uri, allow_redirects=False, verify=False, timeout=15)
-            headers = uriHeader.headers
-        except(MissingSchema, ConnectionError, InvalidURL, ReadTimeout):
+            headers = dict((key.lower(), value) for key, value in uriHeader.headers.items())
+        except(MissingSchema, ConnectionError, InvalidURL, ReadTimeout) as e:
             raise LinkError('Invalid has_part URI')
 
         try:
-            contentHeader = headers['Content-Type']
+            contentHeader = headers['content-type']
             mediaType = list(contentHeader.split(';'))[0].strip()
         except KeyError:
-            pass
+            contentHeader = None
 
         if uriHeader.status_code in [301, 302, 307, 308]\
-            and headers.get('Content-Type', None) not in ['application/pdf', 'application/epub+zip']:
-            redirectURI = headers['Location']
+            and contentHeader not in ['application/pdf', 'application/epub+zip']:
+            redirectURI = headers['location']
+
+            if redirectURI[0] == '/':
+                uriRoot = re.split(r'(?<![\/:])\/{1}', uri)[0]
+                redirectURI = '{}{}'.format(uriRoot, redirectURI)
+
             return DOABLinkManager.findFinalURI(redirectURI, mediaType)
         
         return (uri, mediaType)

--- a/managers/doabParser.py
+++ b/managers/doabParser.py
@@ -70,7 +70,7 @@ class DOABLinkManager:
     @staticmethod
     def findFinalURI(uri, mediaType):
         try:
-            uriHeader = requests.head(uri, allow_redirects=False, verify=False, timeout=5)
+            uriHeader = requests.head(uri, allow_redirects=False, verify=False, timeout=15)
             headers = uriHeader.headers
         except(MissingSchema, ConnectionError, InvalidURL, ReadTimeout):
             raise LinkError('Invalid has_part URI')

--- a/managers/doabParser.py
+++ b/managers/doabParser.py
@@ -73,7 +73,7 @@ class DOABLinkManager:
         try:
             uriHeader = requests.head(uri, allow_redirects=False, verify=False, timeout=15)
             headers = dict((key.lower(), value) for key, value in uriHeader.headers.items())
-        except(MissingSchema, ConnectionError, InvalidURL, ReadTimeout) as e:
+        except(MissingSchema, ConnectionError, InvalidURL, ReadTimeout, UnicodeDecodeError):
             raise LinkError('Invalid has_part URI')
 
         try:

--- a/managers/parsers/abstractParser.py
+++ b/managers/parsers/abstractParser.py
@@ -5,6 +5,8 @@ import re
 from managers.pdfManifest import PDFManifest
 
 class AbstractParser(ABC):
+    TIMEOUT = 15
+
     @abstractmethod
     def __init__(self, uri, mediaType, record):
         self.uri = uri

--- a/managers/parsers/defaultParser.py
+++ b/managers/parsers/defaultParser.py
@@ -33,7 +33,7 @@ class DefaultParser(AbstractParser):
             ePubDownloadPath = 'epubs/{}/{}.epub'.format(self.source, self.identifier)
             ePubDownloadURI = '{}{}'.format(s3Root, ePubDownloadPath)
 
-            ePubReadPath = 'epubs/{}/{}/meta-inf/container.xml'.format(self.source, self.identifier)
+            ePubReadPath = 'epubs/{}/{}/META-INF/container.xml'.format(self.source, self.identifier)
             ePubReadURI = '{}{}'.format(s3Root, ePubReadPath)
 
             return [

--- a/managers/parsers/degruyterParser.py
+++ b/managers/parsers/degruyterParser.py
@@ -20,36 +20,30 @@ class DeGruyterParser(AbstractParser):
     def createLinks(self):
         s3Root = self.generateS3Root()
 
-        isbnMatch = re.search(r'(978[0-9]+)', self.uri)
+        titleMatch = re.search(r'\/title\/([0-9]+)(?:$|\?)', self.uri)
+        isbnMatch = re.search(r'\/(document\/doi\/10\.[0-9]+\/([0-9]+))\/html', self.uri)
 
-        if isbnMatch is not None:
-            degISBN = isbnMatch.group(1)
-            isbnPath = '/'.join([degISBN] * 3)
-            self.uri = 'https://www.degruyter.com/view/books/{}.xml'.format(isbnPath)
+        if titleMatch:
+            self.uriIdentifier = titleMatch.group(1)
+            ePubSourceURI = 'https://www.degruyter.com/downloadepub/title/{}'.format(self.uriIdentifier)
+            pdfSourceURI = 'https://www.degruyter.com/downloadpdf/title/{}'.format(self.uriIdentifier)
+        elif isbnMatch:
+            rootPath = isbnMatch.group(1)
+            self.uriIdentifier = isbnMatch.group(2)
+            ePubSourceURI = 'https://www.degruyter.com/{}/epub'.format(rootPath)
+            pdfSourceURI = 'https://www.degruyter.com/{}/pdf'.format(rootPath)
 
-            uriStatus, uriHeaders = DeGruyterParser.makeHeadQuery(self.uri)
-
-            if uriStatus == 301:
-                self.uri = uriHeaders['Location']
-
-        idMatch = re.search(r'\/title\/([0-9]+)(?:$|\?)', self.uri)
-
-        if idMatch:
-            self.uriIdentifier = idMatch.group(1)
-
-            pdfLink = self.generatePDFLinks(s3Root)
-
-            ePubLinks = self.generateEpubLinks(s3Root)
+        if titleMatch or isbnMatch:
+            pdfLink = self.generatePDFLinks(s3Root, pdfSourceURI)
+            ePubLinks = self.generateEpubLinks(s3Root, ePubSourceURI)
 
             return list(filter(None, [*pdfLink, *ePubLinks]))
 
         return super().createLinks()
         
-    def generateEpubLinks(self, s3Root):
-        ePubSourceURI = 'https://www.degruyter.com/downloadepub/title/{}'.format(self.uriIdentifier)
-
+    def generateEpubLinks(self, s3Root, ePubSourceURI):
         ePubHeadStatus, _ = DeGruyterParser.makeHeadQuery(ePubSourceURI)
-        
+
         if ePubHeadStatus != 200:
             return [None]
 
@@ -64,8 +58,7 @@ class DeGruyterParser(AbstractParser):
             (ePubDownloadURI, {'download': True}, 'application/epub+zip', None, (ePubDownloadPath, ePubSourceURI)),
         ]
 
-    def generatePDFLinks(self, s3Root):
-        pdfSourceURI = 'https://www.degruyter.com/downloadpdf/title/{}'.format(self.uriIdentifier)
+    def generatePDFLinks(self, s3Root, pdfSourceURI):
         manifestPath = 'manifests/degruyter/{}.json'.format(self.uriIdentifier)
         manifestURI = '{}{}'.format(s3Root, manifestPath)
         manifestJSON = self.generateManifest(pdfSourceURI, manifestURI)

--- a/managers/parsers/degruyterParser.py
+++ b/managers/parsers/degruyterParser.py
@@ -50,7 +50,7 @@ class DeGruyterParser(AbstractParser):
         ePubDownloadPath = 'epubs/degruyter/{}.epub'.format(self.uriIdentifier)
         ePubDownloadURI = '{}{}'.format(s3Root, ePubDownloadPath)
 
-        ePubReadPath = 'epubs/degruyter/{}/meta-inf/container.xml'.format(self.uriIdentifier)
+        ePubReadPath = 'epubs/degruyter/{}/META-INF/container.xml'.format(self.uriIdentifier)
         ePubReadURI = '{}{}'.format(s3Root, ePubReadPath)
 
         return [

--- a/managers/parsers/degruyterParser.py
+++ b/managers/parsers/degruyterParser.py
@@ -83,6 +83,9 @@ class DeGruyterParser(AbstractParser):
 
     @staticmethod
     def makeHeadQuery(uri):
-        headResp = requests.head(uri, timeout=5, headers={'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5)'})
+        headResp = requests.head(
+            uri, timeout=DeGruyterParser.TIMEOUT,
+            headers={'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5)'}
+        )
 
         return (headResp.status_code, headResp.headers)

--- a/managers/parsers/frontierParser.py
+++ b/managers/parsers/frontierParser.py
@@ -48,7 +48,7 @@ class FrontierParser(AbstractParser):
         ePubDownloadPath = 'epubs/frontier/{}_{}.epub'.format(self.uriIdentifier, filename)
         ePubDownloadURI = '{}{}'.format(s3Root, ePubDownloadPath)
 
-        ePubReadPath = 'epubs/frontier/{}_{}/meta-inf/container.xml'.format(self.uriIdentifier, filename)
+        ePubReadPath = 'epubs/frontier/{}_{}/META-INF/container.xml'.format(self.uriIdentifier, filename)
         ePubReadURI = '{}{}'.format(s3Root, ePubReadPath)
 
         return [

--- a/managers/parsers/frontierParser.py
+++ b/managers/parsers/frontierParser.py
@@ -76,7 +76,12 @@ class FrontierParser(AbstractParser):
     @staticmethod
     def checkAvailability(uri):
         try:
-            headResp = requests.head(uri, timeout=10, headers={'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5)'})
+            headResp = requests.head(
+                uri,
+                timeout=FrontierParser.TIMEOUT,
+                headers={'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5)'}
+            )
+
             return (headResp.status_code, headResp.headers)
         except ReadTimeout:
             return (0, None)

--- a/managers/parsers/openEditionParser.py
+++ b/managers/parsers/openEditionParser.py
@@ -1,6 +1,7 @@
 from bs4 import BeautifulSoup
 import re
 import requests
+from requests.exceptions import ReadTimeout
 
 from managers.parsers.abstractParser import AbstractParser
 from managers.pdfManifest import PDFManifest
@@ -77,7 +78,10 @@ class OpenEditionParser(AbstractParser):
         ]
 
     def loadEbookLinks(self):
-        oeResp = requests.get(self.uri, timeout=10)
+        try:
+            oeResp = requests.get(self.uri, timeout=self.TIMEOUT)
+        except ReadTimeout:
+            return []
         
         if oeResp.status_code != 200: return []
 

--- a/managers/parsers/openEditionParser.py
+++ b/managers/parsers/openEditionParser.py
@@ -69,7 +69,7 @@ class OpenEditionParser(AbstractParser):
         ePubDownloadPath = 'epubs/doab/{}_{}.epub'.format(self.publisher, self.uriIdentifier)
         ePubDownloadURI = '{}{}'.format(s3Root, ePubDownloadPath)
 
-        ePubReadPath = 'epubs/doab/{}_{}/meta-inf/container.xml'.format(self.publisher, self.uriIdentifier)
+        ePubReadPath = 'epubs/doab/{}_{}/META-INF/container.xml'.format(self.publisher, self.uriIdentifier)
         ePubReadURI = '{}{}'.format(s3Root, ePubReadPath)
 
         return [

--- a/managers/parsers/springerParser.py
+++ b/managers/parsers/springerParser.py
@@ -1,6 +1,7 @@
 from bs4 import BeautifulSoup
 import re
 import requests
+from requests.exceptions import ReadTimeout
 
 from managers.parsers.abstractParser import AbstractParser
 
@@ -40,24 +41,28 @@ class SpringerParser(AbstractParser):
         if redirectMatch:
             self.uri = redirectMatch.group(1)
 
-            redirectHeader = requests.head(self.uri, timeout=5)
             try:
+                redirectHeader = requests.head(self.uri, timeout=self.TIMEOUT)
+
                 self.uri = redirectHeader.headers['Location']
                 return self.validateURI()
-            except KeyError:
+            except (KeyError, ReadTimeout):
                 pass
         
         return False
 
     def findOALink(self):
-        storeResp = requests.get(self.uri, timeout=5)
+        try:
+            storeResp = requests.get(self.uri, timeout=self.TIMEOUT)
 
-        if storeResp.status_code == 200:
-            storePage = BeautifulSoup(storeResp.text, 'html.parser')
+            if storeResp.status_code == 200:
+                storePage = BeautifulSoup(storeResp.text, 'html.parser')
 
-            accessLink = storePage.find(class_='openaccess')
+                accessLink = storePage.find(class_='openaccess')
 
-            if accessLink: self.uri = accessLink.get('href')
+                if accessLink: self.uri = accessLink.get('href')
+        except ReadTimeout:
+            pass
 
     def createLinks(self):
         s3Root = self.generateS3Root()
@@ -111,7 +116,14 @@ class SpringerParser(AbstractParser):
 
     @staticmethod
     def checkAvailability(uri):
-        headResp = requests.head(uri, timeout=5, headers={'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5)'})
+        try:
+            headResp = requests.head(
+                uri,
+                timeout=SpringerParser.TIMEOUT,
+                headers={'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5)'}
+            )
+        except ReadTimeout:
+            return False
 
         return headResp.status_code == 200
         

--- a/managers/parsers/springerParser.py
+++ b/managers/parsers/springerParser.py
@@ -98,7 +98,7 @@ class SpringerParser(AbstractParser):
             self.code.replace('.', '-'), self.uriIdentifier
         )
         ePubDownloadURI = '{}{}'.format(s3Root, ePubDownloadPath)
-        ePubReadPath = 'epubs/springer/{}_{}/meta-inf/container.xml'.format(
+        ePubReadPath = 'epubs/springer/{}_{}/META-INF/container.xml'.format(
             self.code.replace('.', '-'), self.uriIdentifier
         )
         ePubReadURI = '{}{}'.format(s3Root, ePubReadPath)

--- a/managers/s3.py
+++ b/managers/s3.py
@@ -68,7 +68,7 @@ class S3Manager:
         with ZipFile(BytesIO(obj), 'r') as epubZip:
             for component in epubZip.namelist():
                 componentObj = epubZip.open(component).read()
-                componentKey = '{}/{}'.format(keyRoot, component).lower()
+                componentKey = '{}/{}'.format(keyRoot, component)
                 self.putObjectInBucket(componentObj, componentKey, bucket)
 
     def getObjectFromBucket(self, objKey, bucket, md5Hash=None):

--- a/model/postgres/link.py
+++ b/model/postgres/link.py
@@ -38,6 +38,6 @@ class Link(Base, Core):
     @staticmethod
     def httpRegexSub(url):
         if isinstance(url, str):
-            return re.sub(r'^http(?:s)?:\/\/', '', url.lower())
+            return re.sub(r'^http(?:s)?:\/\/', '', url)
 
         return url

--- a/processes/gutenberg.py
+++ b/processes/gutenberg.py
@@ -110,7 +110,7 @@ class GutenbergProcess(CoreProcess):
             if flags['download'] is True:
                 bucketLocation = 'epubs/{}/{}_{}.epub'.format(source, gutenbergID, gutenbergType)
             else:
-                bucketLocation = 'epubs/{}/{}_{}/meta-inf/content.xml'.format(source, gutenbergID, gutenbergType)
+                bucketLocation = 'epubs/{}/{}_{}/META-INF/content.xml'.format(source, gutenbergID, gutenbergType)
                 mediaType = 'application/epub+xml'
 
             s3URL = 'https://{}.s3.amazonaws.com/{}'.format(self.s3Bucket, bucketLocation)

--- a/tests/unit/test_doab_link_manager.py
+++ b/tests/unit/test_doab_link_manager.py
@@ -89,7 +89,7 @@ class TestDOABLinkManager:
 
         assert testURI == 'testURI'
         assert testType == 'text/html'
-        mockHead.assert_called_once_with('testURI', allow_redirects=False, verify=False, timeout=5)
+        mockHead.assert_called_once_with('testURI', allow_redirects=False, verify=False, timeout=15)
 
     def test_findFinalURI_error(self, mocker):
         mockHead = mocker.patch.object(requests, 'head')
@@ -115,6 +115,6 @@ class TestDOABLinkManager:
         assert testURI == 'sourceURI'
         assert testType == 'application/test'
         mockHead.assert_has_calls([
-            mocker.call('testURI', allow_redirects=False, verify=False, timeout=5),
-            mocker.call('sourceURI', allow_redirects=False, verify=False, timeout=5)
+            mocker.call('testURI', allow_redirects=False, verify=False, timeout=15),
+            mocker.call('sourceURI', allow_redirects=False, verify=False, timeout=15)
         ])

--- a/tests/unit/test_gutenberg_process.py
+++ b/tests/unit/test_gutenberg_process.py
@@ -173,7 +173,7 @@ class TestGutenbergProcess:
         ])
         assert mockRecord.record.has_part == [
             '1|https://test_aws_bucket.s3.amazonaws.com/epubs/gutenberg/1_images.epub|gutenberg|application/epub+zip|{"download": true}',
-            '1|https://test_aws_bucket.s3.amazonaws.com/epubs/gutenberg/1_images/meta-inf/content.xml|gutenberg|application/epub+xml|{"download": false}',
+            '1|https://test_aws_bucket.s3.amazonaws.com/epubs/gutenberg/1_images/META-INF/content.xml|gutenberg|application/epub+xml|{"download": false}',
             '2|https://test_aws_bucket.s3.amazonaws.com/epubs/gutenberg/2_noimages.epub|gutenberg|application/epub+zip|{"download": true}',
         ]
 

--- a/tests/unit/test_parser_default.py
+++ b/tests/unit/test_parser_default.py
@@ -53,7 +53,7 @@ class TestDefaultParser:
         testLinks = testParser.createLinks()
 
         assert testLinks == [
-            ('testRoot/epubs/testSource/1/meta-inf/container.xml', {'reader': True}, 'application/epub+xml', None, None),
+            ('testRoot/epubs/testSource/1/META-INF/container.xml', {'reader': True}, 'application/epub+xml', None, None),
             ('testRoot/epubs/testSource/1.epub', {'download': True}, 'application/epub+zip', None, ('epubs/testSource/1.epub', 'http://testURI'))
         ]
         mockGenerate.assert_called_once()

--- a/tests/unit/test_parser_degruyter.py
+++ b/tests/unit/test_parser_degruyter.py
@@ -27,25 +27,26 @@ class TestDeGruyterParser:
     def test_createLinks_isbn_match(self, testParser, mocker):
         parserMocks = mocker.patch.multiple(DeGruyterParser,
             generateS3Root=mocker.DEFAULT,
-            makeHeadQuery=mocker.DEFAULT,
             generatePDFLinks=mocker.DEFAULT,
             generateEpubLinks=mocker.DEFAULT
         )
 
         parserMocks['generateS3Root'].return_value = 'testRoot/'
-        parserMocks['makeHeadQuery'].return_value = (301, {'Location': 'degruyter.com/title/1'})
         parserMocks['generatePDFLinks'].return_value = ['pdf1', None]
         parserMocks['generateEpubLinks'].return_value = ['epub1', 'epub2']
 
-        testParser.uri = 'degruyter.com/9781234567890'
+        testParser.uri = 'degruyter.com/document/doi/10.000/9781234567890/html'
 
         testLinks = testParser.createLinks()
 
         assert testLinks == ['pdf1', 'epub1', 'epub2']
         parserMocks['generateS3Root'].assert_called_once()
-        parserMocks['makeHeadQuery'].assert_called_once_with('https://www.degruyter.com/view/books/9781234567890/9781234567890/9781234567890.xml')
-        parserMocks['generatePDFLinks'].assert_called_once_with('testRoot/')
-        parserMocks['generateEpubLinks'].assert_called_once_with('testRoot/')
+        parserMocks['generatePDFLinks'].assert_called_once_with(
+            'testRoot/', 'https://www.degruyter.com/document/doi/10.000/9781234567890/pdf'
+        )
+        parserMocks['generateEpubLinks'].assert_called_once_with(
+            'testRoot/', 'https://www.degruyter.com/document/doi/10.000/9781234567890/epub'
+        )
 
     def test_createLinks_title_match(self, testParser, mocker):
         parserMocks = mocker.patch.multiple(DeGruyterParser,
@@ -64,8 +65,12 @@ class TestDeGruyterParser:
 
         assert testLinks == ['pdf1', 'epub1', 'epub2']
         parserMocks['generateS3Root'].assert_called_once()
-        parserMocks['generatePDFLinks'].assert_called_once_with('testRoot/')
-        parserMocks['generateEpubLinks'].assert_called_once_with('testRoot/')
+        parserMocks['generatePDFLinks'].assert_called_once_with(
+            'testRoot/', 'https://www.degruyter.com/downloadpdf/title/1'
+        )
+        parserMocks['generateEpubLinks'].assert_called_once_with(
+            'testRoot/', 'https://www.degruyter.com/downloadepub/title/1'
+        )
 
     def test_createLinks_no_match(self, testParser, mocker):
         mockGenerate = mocker.patch.object(DeGruyterParser, 'generateS3Root')
@@ -85,34 +90,34 @@ class TestDeGruyterParser:
         mockHead.return_value = (200, 'mockHeader')
 
         testParser.uriIdentifier = 1
-        testLinks = testParser.generateEpubLinks('testRoot/')
+        testLinks = testParser.generateEpubLinks('testRoot/', 'epubSourceURI')
 
         assert testLinks == [
-            ('testRoot/epubs/degruyter/1/meta-inf/container.xml', {'reader': True}, 'application/epub+xml', None, None),
-            ('testRoot/epubs/degruyter/1.epub', {'download': True}, 'application/epub+zip', None, ('epubs/degruyter/1.epub', 'https://www.degruyter.com/downloadepub/title/1'))
+            ('testRoot/epubs/degruyter/1/META-INF/container.xml', {'reader': True}, 'application/epub+xml', None, None),
+            ('testRoot/epubs/degruyter/1.epub', {'download': True}, 'application/epub+zip', None, ('epubs/degruyter/1.epub', 'epubSourceURI'))
         ]
-        mockHead.assert_called_once_with('https://www.degruyter.com/downloadepub/title/1')
+        mockHead.assert_called_once_with('epubSourceURI')
 
     def test_generateEpubLinks_error(self, testParser, mocker):
         mockHead = mocker.patch.object(DeGruyterParser, 'makeHeadQuery')
         mockHead.return_value = (500, 'mockHeader')
 
         testParser.uriIdentifier = 1
-        testLinks = testParser.generateEpubLinks('testRoot/')
+        testLinks = testParser.generateEpubLinks('testRoot/', 'epubSourceURI')
 
         assert testLinks == [None]
-        mockHead.assert_called_once_with('https://www.degruyter.com/downloadepub/title/1')
+        mockHead.assert_called_once_with('epubSourceURI')
 
     def test_generatePDFLinks(self, testParser, mocker):
         mockGenerate = mocker.patch.object(DeGruyterParser, 'generateManifest')
         mockGenerate.return_value = 'testManifestJSON'
 
         testParser.uriIdentifier = 1
-        testLinks = testParser.generatePDFLinks('testRoot/')
+        testLinks = testParser.generatePDFLinks('testRoot/', 'pdfSourceURI')
 
         assert testLinks == [
             ('testRoot/manifests/degruyter/1.json', {'reader': True}, 'application/pdf+json', ('manifests/degruyter/1.json', 'testManifestJSON'), None),
-            ('https://www.degruyter.com/downloadpdf/title/1', {'download': True}, 'application/pdf', None, None)
+            ('pdfSourceURI', {'download': True}, 'application/pdf', None, None)
         ]
 
     def test_generateManifest(self, testParser, mocker):

--- a/tests/unit/test_parser_degruyter.py
+++ b/tests/unit/test_parser_degruyter.py
@@ -139,5 +139,5 @@ class TestDeGruyterParser:
 
         assert DeGruyterParser.makeHeadQuery('testURI') == (200, 'testHeaders')
         mockHead.assert_called_once_with(
-            'testURI', timeout=5, headers={'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5)'}
+            'testURI', timeout=15, headers={'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5)'}
         )

--- a/tests/unit/test_parser_frontier.py
+++ b/tests/unit/test_parser_frontier.py
@@ -52,7 +52,7 @@ class TestFrontierParser:
         testLinks = testParser.generateEpubLinks('testRoot/')
 
         assert testLinks == [
-            ('testRoot/epubs/frontier/1_title/meta-inf/container.xml', {'reader': True}, 'application/epub+xml', None, None),
+            ('testRoot/epubs/frontier/1_title/META-INF/container.xml', {'reader': True}, 'application/epub+xml', None, None),
             ('testRoot/epubs/frontier/1_title.epub', {'download': True}, 'application/epub+zip', None, ('epubs/frontier/1_title.epub', 'https://www.frontiersin.org/research-topics/1/epub'))
         ]
         mockCheck.assert_called_once_with('https://www.frontiersin.org/research-topics/1/epub')

--- a/tests/unit/test_parser_openedition.py
+++ b/tests/unit/test_parser_openedition.py
@@ -85,7 +85,7 @@ class TestOpenEditionParser:
         testLinks = testParser.createEpubLink('sourceURI', 'application/epub+xml', {'reader': True})
 
         assert testLinks == [
-            ('testRoot/epubs/doab/pub_1/meta-inf/container.xml', {'reader': True}, 'application/epub+xml', None, None),
+            ('testRoot/epubs/doab/pub_1/META-INF/container.xml', {'reader': True}, 'application/epub+xml', None, None),
             ('testRoot/epubs/doab/pub_1.epub', {'download': True}, 'application/epub+zip', None, ('epubs/doab/pub_1.epub', 'sourceURI'))
         ]
 

--- a/tests/unit/test_parser_springer.py
+++ b/tests/unit/test_parser_springer.py
@@ -53,7 +53,7 @@ class TestSpringerParser:
 
         assert testParser.validateAltLinkFormats() is True
         assert testParser.uri == 'http://finalURI'
-        mockHead.assert_called_once_with('http://link.springer.com/book/10.007/1', timeout=5)
+        mockHead.assert_called_once_with('http://link.springer.com/book/10.007/1', timeout=15)
         parserMocks['findOALink'].assert_not_called()
         parserMocks['validateURI'].assert_called_once()
 
@@ -69,7 +69,7 @@ class TestSpringerParser:
         mockHead.return_value = mockResp
 
         assert testParser.validateAltLinkFormats() is False
-        mockHead.assert_called_once_with('http://link.springer.com/book/10.007/1', timeout=5)
+        mockHead.assert_called_once_with('http://link.springer.com/book/10.007/1', timeout=15)
         parserMocks['findOALink'].assert_not_called()
         parserMocks['validateURI'].assert_not_called()
 

--- a/tests/unit/test_parser_springer.py
+++ b/tests/unit/test_parser_springer.py
@@ -150,7 +150,7 @@ class TestSpringerParser:
         testLinks = testParser.createEPubLinks('testRoot/')
 
         assert testLinks == [
-            ('testRoot/epubs/springer/10-007_1/meta-inf/container.xml', {'reader': True}, 'application/epub+zip', None, None),
+            ('testRoot/epubs/springer/10-007_1/META-INF/container.xml', {'reader': True}, 'application/epub+zip', None, None),
             ('testRoot/epubs/springer/10-007_1.epub', {'download': True}, 'application/epub+xml', None, ('epubs/springer/10-007_1.epub', 'https://link.springer.com/download/epub/10.007/1.epub')),
         ]
         mockCheck.assert_called_once_with('https://link.springer.com/download/epub/10.007/1.epub')

--- a/tests/unit/test_s3_manager.py
+++ b/tests/unit/test_s3_manager.py
@@ -133,8 +133,8 @@ class TestS3Manager:
         testInstance.putExplodedEpubComponentsInBucket(b'testObj', 'testKey.epub', 'testBucket')
 
         mockPut.assert_has_calls([
-            mocker.call('compBytes1', 'testkey/comp1', 'testBucket'),
-            mocker.call('compBytes2', 'testkey/comp2', 'testBucket')
+            mocker.call('compBytes1', 'testKey/comp1', 'testBucket'),
+            mocker.call('compBytes2', 'testKey/comp2', 'testBucket')
         ])
 
     def test_getObjectFromBucket_success(self, testInstance, mocker):


### PR DESCRIPTION
This implements a number of necessary fixes for how files are fetched and stored from DOAB (some of these changes indirectly affect the Project Gutenberg ingest process). These updates are:

- Standardize the timeout value across DOAB sources
- Better handle timeout errors from DOAB sources
- Handle instances when `301` redirects only provide URL paths instead of full URLs
- Handle DOI based URLs from DeGruyter
- Allow s3 URLs to contain uppercase characters (necessary to match internal structure of ePub files) 