### PR TITLE
SFR-960 Update Production Port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix paths to ePub files in s3 (allow for uppercase characters)
 - Add handling for DOI paths in DeGruyter DOAB records
 - Updated API to serve app on port 80 to work with ECS environment
+- Improve logging to reflect debug/info/warning statements in ECS console
 
 ## 2021-02-01 -- v0.2.1
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Better handle HTTP redirect `Location` values
 - Fix paths to ePub files in s3 (allow for uppercase characters)
 - Add handling for DOI paths in DeGruyter DOAB records
+- Updated API to serve app on port 80 to work with ECS environment
 
 ## 2021-02-01 -- v0.2.1
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,6 @@ WORKDIR /src
 
 RUN pip install -r requirements.txt
 
-ENTRYPOINT [ "python",  "/src/main.py" ]
+EXPOSE 80
 
+ENTRYPOINT [ "python",  "/src/main.py" ]

--- a/api/app.py
+++ b/api/app.py
@@ -4,8 +4,11 @@ from flask_cors import CORS
 import os
 from waitress import serve
 
+from logger import createLog
 from model import Work
 from .blueprints import search, work, info
+
+logger = createLog(__name__)
 
 
 class FlaskAPI:
@@ -21,6 +24,12 @@ class FlaskAPI:
 
     def run(self):
         if os.environ['ENVIRONMENT'] == 'local':
+            logger.debug('Starting dev server on port 5000')
+
+            self.app.config['ENV'] = 'development'
+            self.app.config['DEBUG'] = True
             self.app.run()
         else:
+            logger.debug('Starting production server on port 80')
+
             serve(self.app, host='0.0.0.0', port=80)

--- a/api/app.py
+++ b/api/app.py
@@ -23,4 +23,4 @@ class FlaskAPI:
         if os.environ['ENVIRONMENT'] == 'local':
             self.app.run()
         else:
-            serve(self.app, host='0.0.0.0', port=5000)
+            serve(self.app, host='0.0.0.0', port=80)

--- a/api/blueprints/drbInfo.py
+++ b/api/blueprints/drbInfo.py
@@ -1,10 +1,17 @@
 from flask import Blueprint, jsonify
 import os
 
+from logger import createLog
+
+logger = createLog(__name__)
+
+
 info = Blueprint('info', __name__, url_prefix='/')
 
 @info.route('/', methods=['GET'])
 def apiInfo():
+    logger.debug('Status check 200 OK on /')
+
     return (
         jsonify({'environment': os.environ['ENVIRONMENT'], 'status': 'RUNNING'}),
         200

--- a/api/blueprints/drbSearch.py
+++ b/api/blueprints/drbSearch.py
@@ -4,6 +4,9 @@ from flask import (
 from ..elastic import ElasticClient
 from ..db import DBClient
 from ..utils import APIUtils
+from logger import createLog
+
+logger = createLog(__name__)
 
 search = Blueprint('search', __name__, url_prefix='/search')
 
@@ -17,10 +20,12 @@ def standardQuery():
     sortTerms = APIUtils.extractParamPairs(searchParams.get('sort', []))
 
     filterTerms = APIUtils.extractParamPairs(searchParams.get('filter', []))
-    filterTerms.extend(APIUtils.extractParamPairs('showAll', []))
+    filterTerms.extend(APIUtils.extractParamPairs(searchParams.get('showAll', [])))
 
     searchPage = searchParams.get('page', [0])[0]
     searchSize = searchParams.get('size', [10])[0]
+
+    logger.info('Executing Query {} with filters {}'.format(searchParams, filterTerms))
 
     searchResult = esClient.searchQuery(queryTerms, sortTerms, filterTerms, page=searchPage, perPage=searchSize)
 
@@ -39,5 +44,7 @@ def standardQuery():
         'paging': paging,
         'facets': facets
     }
+
+    logger.debug('Search Query 200 on /search')
 
     return APIUtils.formatResponseObject(200, 'searchResponse', dataBlock)

--- a/api/blueprints/drbWork.py
+++ b/api/blueprints/drbWork.py
@@ -3,11 +3,16 @@ from flask import (
 )
 from ..db import DBClient
 from ..utils import APIUtils
+from logger import createLog
+
+logger = createLog(__name__)
 
 work = Blueprint('work', __name__, url_prefix='/work')
 
 @work.route('/<uuid>', methods=['GET'])
 def workFetch(uuid):
+    logger.info('Fetching Work {}'.format(uuid))
+
     dbClient = DBClient(current_app.config['DB_CLIENT'])
 
     searchParams = APIUtils.normalizeQueryParams(request.args)
@@ -16,12 +21,16 @@ def workFetch(uuid):
     work = dbClient.fetchSingleWork(uuid)
 
     if work:
+        logger.debug('Work Fetch 200 on /work/{}'.format(uuid))
+
         return APIUtils.formatResponseObject(
             200,
             'singleWork',
             APIUtils.formatWorkOutput(work, showAll=showAll)
         )
     else:
+        logger.warning('Work Fetch 404 on /work/{}'.format(uuid))
+
         return APIUtils.formatResponseObject(
             404,
             'singleWork',

--- a/logger.py
+++ b/logger.py
@@ -1,0 +1,28 @@
+import logging
+import os
+
+
+levels = {
+    'debug': logging.DEBUG,
+    'info': logging.INFO,
+    'warning': logging.WARNING,
+    'error': logging.ERROR,
+    'critical': logging.CRITICAL
+}
+
+
+def createLog(module):
+    logger = logging.getLogger(module)
+    consoleLog = logging.StreamHandler()
+
+    logLevel = os.environ.get('LOG_LEVEL', 'warning').lower()
+
+    logger.setLevel(levels[logLevel])
+    consoleLog.setLevel(levels[logLevel])
+
+    formatter = logging.Formatter('%(asctime)s | %(name)s | %(levelname)s: %(message)s')  # noqa: E501
+    consoleLog.setFormatter(formatter)
+
+    logger.addHandler(consoleLog)
+
+    return logger

--- a/main.py
+++ b/main.py
@@ -1,10 +1,15 @@
 import argparse
 import inspect
 import os
-import sys
 import yaml
 
+from logger import createLog
+
+
 def main(args):
+    logger = createLog(__name__)
+
+    environment = args.environment
     process = args.process
     procType = args.ingestType
     customFile = args.inputFile
@@ -12,6 +17,11 @@ def main(args):
     singleRecord = args.singleRecord
     limit = args.limit
     offset = args.offset
+
+    logger.info('Staring Process {} in {}'.format(process, environment))
+    logger.debug('Process Args Type: {}, Limit: {}, Offset: {}, Date: {}, File: {}, Record: {}'.format(
+        procType, limit, offset, startDate, customFile, singleRecord
+    ))
 
     availableProcesses = registerProcesses()
 

--- a/processes/api.py
+++ b/processes/api.py
@@ -1,5 +1,8 @@
 from .core import CoreProcess
 from api.app import FlaskAPI
+from logger import createLog
+
+logger = createLog(__name__)
 
 
 class APIProcess(CoreProcess):
@@ -11,4 +14,6 @@ class APIProcess(CoreProcess):
         self.api = FlaskAPI(self.client, self.engine)
 
     def runProcess(self):
+        logger.info('Starting API...')
+
         self.api.run()

--- a/tests/unit/test_api_app.py
+++ b/tests/unit/test_api_app.py
@@ -27,5 +27,5 @@ class TestFlaskAPI:
         testInstance.run()
 
         mockServe.assert_called_once_with(
-            testInstance.app, host='0.0.0.0', port=5000
+            testInstance.app, host='0.0.0.0', port=80
         )


### PR DESCRIPTION
This moves the port at which the Flask application to `80` from the development port of `5000`. This works better with the ECS configuration and is likely the expected value.

This also adds an `EXPOSE` line to the Dockerfile, which is also necessary. When running the API localy it can still be access by passing `-p 5000:5000` to access the API.