### PR TITLE
NOREF Fix ElasticSearch manager when using AWS ES Service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add handling for DOI paths in DeGruyter DOAB records
 - Updated API to serve app on port 80 to work with ECS environment
 - Improve logging to reflect debug/info/warning statements in ECS console
+- Update ElasticSearch manager to avoid bug in urllib3 with AWS VPC URL
 
 ## 2021-02-01 -- v0.2.1
 ### Added

--- a/managers/elasticsearch.py
+++ b/managers/elasticsearch.py
@@ -14,17 +14,17 @@ from model import ESWork
 
 class ElasticsearchManager:
     def __init__(self):
-        self.index = os.environ['ELASTICSEARCH_INDEX']
+        self.index = os.environ.get('ELASTICSEARCH_INDEX', None)
         self.client = None
 
     def createElasticConnection(self):
-        host = os.environ['ELASTICSEARCH_HOST']
-        port = os.environ['ELASTICSEARCH_PORT']
-        timeout = int(os.environ['ELASTICSEARCH_TIMEOUT'])
+        host = os.environ.get('ELASTICSEARCH_HOST', None)
+        port = os.environ.get('ELASTICSEARCH_PORT', None)
+        timeout = int(os.environ.get('ELASTICSEARCH_TIMEOUT', 5))
         try:
             self.client = Elasticsearch(
-                hosts=[{'host': host, 'port': port}],
-                timeout=timeout
+               hosts=['{}:{}'.format(host, port)],
+               timeout = timeout
             )
         except ConnectionError as err:
             raise err

--- a/tests/unit/test_es_manager.py
+++ b/tests/unit/test_es_manager.py
@@ -35,7 +35,7 @@ class TestElasticsearchManager:
         assert mockConnection.connections._conns['default'] == mockClient
 
         mockES.assert_called_once_with(
-            hosts=[{'host': 'host', 'port': 'port'}], timeout=1000
+            hosts=['host:port'], timeout=1000
         )
 
     def test_createElasticConnection_error(self, testInstance, mocker):


### PR DESCRIPTION
This resolves a bug where the default python `urllib3` library is unable to parse AWS VPC URLs due to their length/unusual construction. By passing these parameters as a constructed string those checks can be bypassed and allow this manager to interact with those resources. (Which is necessary for the functioning of this cluster)