### PR TITLE
NOREF Update OCLC Catalog link handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Updated API to serve app on port 80 to work with ECS environment
 - Improve logging to reflect debug/info/warning statements in ECS console
 - Update ElasticSearch manager to avoid bug in urllib3 with AWS VPC URL
+- Update OCLCCatalog link parsing process to exclude invalid links
 
 ## 2021-02-01 -- v0.2.1
 ### Added

--- a/tests/unit/test_oclcCatalog_mapping.py
+++ b/tests/unit/test_oclcCatalog_mapping.py
@@ -1,4 +1,6 @@
 import pytest
+import requests
+from requests.exceptions import HTTPError
 
 from mappings.oclcCatalog import CatalogMapping
 
@@ -22,7 +24,8 @@ class TestCatalogMapping:
     def testRecord_standard(self, mocker):
         return mocker.MagicMock(
             identifiers=['1|oclc', '2|test'],
-            languages=['||820305s1991####nyu###########001#0#eng##|']
+            languages=['||820305s1991####nyu###########001#0#eng##|'],
+            has_part=['1|uri|test|text/html|{}', '1|uri|bad|text/html|{}']
         )
 
     def test_createMapping(self, testMapping):
@@ -35,7 +38,9 @@ class TestCatalogMapping:
         ]
         assert recordMapping['title'] == ('//oclc:datafield[@tag=\'245\']/oclc:subfield[@code=\'a\' or @code=\'b\']/text()', '{0} {1}')
 
-    def test_applyFormatting(self, testMapping, testRecord_standard):
+    def test_applyFormatting(self, testMapping, testRecord_standard, mocker):
+        mockParseLink = mocker.patch.object(CatalogMapping, 'parseLink')
+        mockParseLink.side_effect = ['testLink', None]
         testMapping.record = testRecord_standard
 
         testMapping.applyFormatting()
@@ -44,3 +49,58 @@ class TestCatalogMapping:
         assert testMapping.record.source_id == '1|oclc'
         assert testMapping.record.frbr_status == 'complete'
         assert testMapping.record.languages == ['||eng']
+        assert testMapping.record.has_part == ['testLink']
+
+    def test_parseLink_gutenberg(self, testMapping, mocker):
+        mockRecord = mocker.MagicMock(identifiers=[])
+        testMapping.record = mockRecord
+
+        testLink = testMapping.parseLink('1|gutenberg.org/ebooks/1|test|text/html|{"marcInd1": "4"}')
+        assert testLink == '1|gutenberg.org/ebooks/1|test|text/html|{}'
+        assert testMapping.record.identifiers[0] == '1|gutenberg'
+
+    def test_parseLink_internetarchive_unavailable(self, testMapping, mocker):
+        mockCheckIA = mocker.patch.object(CatalogMapping, 'checkIAReadability')
+        mockCheckIA.return_value = False
+
+        assert (
+            testMapping.parseLink('|archive.org/details/1|test|text/html|{"marcInd1": "4"}')
+            == None
+        )
+
+    def test_parseLink_other(self, testMapping):
+        assert (
+            testMapping.parseLink('|other.org/1|test|text/html|{"marcInd1": "4"}')
+            == None
+        )
+
+    def test_parseLink_non_external_url(self, testMapping):
+        assert (
+            testMapping.parseLink('|other.org/1|test|text/html|{"marcInd1": "0"}')
+            == None
+        )
+
+    def test_checkIAReadability_true(self, testMapping, mocker):
+        mockResp = mocker.MagicMock()
+        mockResp.json.return_value = {'metadata': {'access-restricted-item': 'false'}}
+        mockGet = mocker.patch.object(requests, 'get')
+        mockGet.return_value = mockResp
+
+        assert testMapping.checkIAReadability('archive.org/1') == True
+
+    def test_checkIAReadability_false(self, testMapping, mocker):
+        mockResp = mocker.MagicMock()
+        mockResp.json.return_value = {'metadata': {'access-restricted-item': 'true'}}
+        mockGet = mocker.patch.object(requests, 'get')
+        mockGet.return_value = mockResp
+
+        assert testMapping.checkIAReadability('archive.org/1') == False
+
+    def test_checkIAReadability_error(self, testMapping, mocker):
+        mockResp = mocker.MagicMock()
+        mockResp.raise_for_status.side_effect = HTTPError
+        mockGet = mocker.patch.object(requests, 'get')
+        mockGet.return_value = mockResp
+
+        assert testMapping.checkIAReadability('archive.org/1') == False
+        


### PR DESCRIPTION
The OCLC Catalog mapping included a few bugs and had a few places where improvements could be made.

First, it was looking in the wrong subfield for the external resource URI (it needs to be set to subfield `u`). Second, it was not checking the first indicator for a value of `4` which denotes a reference to a resource.

The improvements are in the checking of validity of the links. This implements a new method to only allow Gutenberg, HathiTrust and InternetArchive links to be imported. Further this checks the IA links to be sure that they point to items that do not have restricted access. This method should be extended to further parse the Gutenberg and HathiTrust links as well, though that is less pressing.