### PR TITLE
NOREF Container debugging

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+config/local*
+.github/*
+.pytest_cache/*
+.vscode/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Fixed
 - Update RabbitMQ client to work with credentials, virtual hosts and non-default exchanges
 - Update environment variable loading in some managers to handle irrelevant env vars
+- Update Gutenberg process to allow invocation without offset and limit settings
 
 ## 2021-02-09 -- v0.2.2
 ### Added

--- a/processes/gutenberg.py
+++ b/processes/gutenberg.py
@@ -22,8 +22,8 @@ class GutenbergProcess(CoreProcess):
     def __init__(self, *args):
         super(GutenbergProcess, self).__init__(*args[:4])
 
-        self.ingestOffset = int(args[5]) or 0
-        self.ingestLimit = (int(args[4]) + self.ingestOffset) or 5000
+        self.ingestOffset = int(args[5] or 0)
+        self.ingestLimit = (int(args[4]) + self.ingestOffset) if args[4] else 5000
 
         # Connect to database
         self.generateEngine()


### PR DESCRIPTION
This updates the Gutenberg process to handle invocations where a ingest limit and offset are not set (They default to `None` and a `TypeError` was being thrown).

This also adds a `.dockerignore` file to make the container build process somewhat cleaner