### PR TITLE
SFR-1006 ECS Memory Management Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Fixed
 - Update RabbitMQ client to work with credentials, virtual hosts and non-default exchanges
 - Update environment variable loading in some managers to handle irrelevant env vars
+- Resolve memory consumption issues in the NYPL, HathiTrust, DOAB and MUSE processes
 
 ## 2021-02-09 -- v0.2.2
 ### Added

--- a/api/blueprints/drbSearch.py
+++ b/api/blueprints/drbSearch.py
@@ -1,6 +1,4 @@
-from flask import (
-    Blueprint, request, session, url_for, redirect, current_app, jsonify
-)
+from flask import Blueprint, request, current_app
 from ..elastic import ElasticClient
 from ..db import DBClient
 from ..utils import APIUtils
@@ -25,7 +23,7 @@ def standardQuery():
     searchPage = searchParams.get('page', [0])[0]
     searchSize = searchParams.get('size', [10])[0]
 
-    logger.info('Executing Query {} with filters {}'.format(searchParams, filterTerms))
+    logger.info('Executing ES Query {} with filters {}'.format(searchParams, filterTerms))
 
     searchResult = esClient.searchQuery(queryTerms, sortTerms, filterTerms, page=searchPage, perPage=searchSize)
 
@@ -33,6 +31,8 @@ def standardQuery():
         (r.uuid, [e.edition_id for e in r.meta.inner_hits.editions.hits])
         for r in searchResult.hits
     ]
+
+    logger.info('Executing DB Query for {} editions'.format(len(resultIds)))
 
     works = dbClient.fetchSearchedWorks(resultIds)
     facets = APIUtils.formatAggregationResult(searchResult.aggregations.to_dict())

--- a/api/db.py
+++ b/api/db.py
@@ -14,15 +14,17 @@ class DBClient():
 
         session = sessionmaker(bind=self.engine)()
 
-        return session.query(Work)\
+        query = session.query(Work)\
             .join(Edition)\
-            .outerjoin(Item, ITEM_LINKS, Link)\
-            .filter(Work.uuid.in_(uuids), Edition.id.in_(editionIds)).all()
+            .join(Item, ITEM_LINKS, Link)\
+            .filter(Edition.id.in_(editionIds))
+
+        return query.all()
 
     def fetchSingleWork(self, uuid):
         session = sessionmaker(bind=self.engine)()
 
         return session.query(Work)\
             .join(Edition)\
-            .outerjoin(Item, ITEM_LINKS, Link)\
+            .join(Item, ITEM_LINKS, Link)\
             .filter(Work.uuid == uuid).first()

--- a/api/utils.py
+++ b/api/utils.py
@@ -27,6 +27,8 @@ class APIUtils():
 
     @staticmethod
     def formatPagingOptions(hits):
+        if len(hits) == 0: return {}
+
         return {
             'prevPageSort': list(hits[0].meta.sort),
             'nextPageSort': list(hits[-1].meta.sort)

--- a/managers/coverFetchers/contentCafeFetcher.py
+++ b/managers/coverFetchers/contentCafeFetcher.py
@@ -51,7 +51,6 @@ class ContentCafeFetcher(AbstractFetcher):
         return False
 
     def isNoCoverImage(self, rawBytes):
-        print(hashlib.md5(rawBytes).hexdigest())
         return hashlib.md5(rawBytes).hexdigest() == self.NO_COVER_HASH
 
     def downloadCoverFile(self):

--- a/managers/coverFetchers/openLibraryFetcher.py
+++ b/managers/coverFetchers/openLibraryFetcher.py
@@ -35,7 +35,7 @@ class OpenLibraryFetcher(AbstractFetcher):
         coverRow = self.session.query(OpenLibraryCover)\
             .filter(OpenLibraryCover.name == source)\
             .filter(OpenLibraryCover.value == value)\
-            .one_or_none()
+            .first()
 
         if coverRow:
             self.setCoverPageURL(coverRow.cover_id)

--- a/managers/db.py
+++ b/managers/db.py
@@ -56,6 +56,8 @@ class DBManager:
     
     def bulkSaveObjects(self, objects, onlyChanged=True):
         self.session.bulk_save_objects(objects, update_changed_only=onlyChanged)
+        self.session.commit()
+        self.session.flush()
 
     @staticmethod
     def decryptEnvVar(envVar):

--- a/managers/kMeans.py
+++ b/managers/kMeans.py
@@ -247,15 +247,14 @@ class KMeansManager:
         distances = []
         denominator = sqrt((y2 - y1)**2 + (x2 - x1)**2)
         for i in range(len(wcss)):
-            x0 = i + 1
+            x0 = i + 2
             y0 = wcss[i][0]
 
             numerator = abs((y2 - y1)*x0 - (x2 - x1)*y0 + x2*y1 - y2*x1)
-            distances.append(numerator/denominator)
+            distances.append((numerator/denominator, wcss[i][1]))
         
-        finalStart = 1 if start < 2 else start + 1 
-        self.k = distances.index(max(distances)) + finalStart
-        return None
+        distances.sort(key=lambda x: x[0], reverse=True)
+        self.k = distances[0][1]
     
     def cluster(self, k, score=False):
         self.currentK = k

--- a/managers/sfrRecord.py
+++ b/managers/sfrRecord.py
@@ -478,9 +478,10 @@ class SFRRecordManager:
     def normalizeDates(self, dates):
         outDates = set()
         for date in dates:
+            dateValue, dateType = tuple(date.split('|'))
             try:
-                cleanDate = re.search(r'\d+.*\d+', date).group()
-                outDates.add(cleanDate)
+                cleanDate = re.search(r'\d+.*\d+', dateValue).group()
+                outDates.add('{}|{}'.format(cleanDate, dateType))
             except AttributeError:
                 pass
 

--- a/managers/sfrRecord.py
+++ b/managers/sfrRecord.py
@@ -360,7 +360,7 @@ class SFRRecordManager:
 
         # Set Links
         newEd.links = SFRRecordManager.setPipeDelimitedData(
-            edition['links'], ['url', 'media_type', 'flags'], Link, dparser=SFRRecordManager.parseLinkFlags
+            edition['links'], ['url', 'media_type', 'flags'], Link, dParser=SFRRecordManager.parseLinkFlags
         )
 
         # Add Items
@@ -380,7 +380,7 @@ class SFRRecordManager:
 
         # Set Links
         newItem.links = SFRRecordManager.setPipeDelimitedData(
-            links, ['url', 'media_type', 'flags'], Link, dparser=SFRRecordManager.parseLinkFlags
+            links, ['url', 'media_type', 'flags'], Link, dParser=SFRRecordManager.parseLinkFlags
         )
         
         # Set Identifiers
@@ -390,7 +390,7 @@ class SFRRecordManager:
 
         # Set Rights
         newItem.rights = SFRRecordManager.setPipeDelimitedData(
-            [rights], ['source', 'license', 'rights_reason', 'rights_statement', 'rights_date'], Rights
+            [rights], ['source', 'license', 'rights_reason', 'rights_statement'], Rights
         )
 
         # Set Contributors
@@ -430,7 +430,10 @@ class SFRRecordManager:
 
     @staticmethod
     def parseLinkFlags(linkData):
-        linkData['flags'] = json.loads(linkData['flags'])
+        try:
+            linkData['flags'] = json.loads(linkData['flags'])
+        except json.decoder.JSONDecodeError:
+            linkData['flags'] = {}
 
         return linkData
 
@@ -475,8 +478,11 @@ class SFRRecordManager:
     def normalizeDates(self, dates):
         outDates = set()
         for date in dates:
-            cleanDate = re.search(r'\d+.*\d+', date).group()
-            outDates.add(cleanDate)
+            try:
+                cleanDate = re.search(r'\d+.*\d+', date).group()
+                outDates.add(cleanDate)
+            except AttributeError:
+                pass
 
         return list(outDates)
 

--- a/processes/core.py
+++ b/processes/core.py
@@ -25,7 +25,7 @@ class CoreProcess(DBManager, NyplApiManager, RabbitMQManager, RedisManager, Stat
             print('NEW', rec.record)
             self.records.append(rec.record)
         
-        if len(self.records) >= 2500:
+        if len(self.records) >= 1000:
             self.saveRecords()
             self.records = []
     

--- a/processes/core.py
+++ b/processes/core.py
@@ -25,7 +25,7 @@ class CoreProcess(DBManager, NyplApiManager, RabbitMQManager, RedisManager, Stat
             print('NEW', rec.record)
             self.records.append(rec.record)
         
-        if len(self.records) >= 10000:
+        if len(self.records) >= 2500:
             self.saveRecords()
             self.records = []
     

--- a/processes/covers.py
+++ b/processes/covers.py
@@ -21,8 +21,6 @@ class CoverProcess(CoreProcess):
     def runProcess(self):
         coverQuery = self.generateQuery()
 
-        print(coverQuery)
-
         self.fetchEditionCovers(coverQuery)
 
         self.saveRecords()
@@ -31,7 +29,7 @@ class CoverProcess(CoreProcess):
     def generateQuery(self):
         baseQuery = self.session.query(Edition)
 
-        subQuery = self.session.query(Edition.id)\
+        subQuery = self.session.query('edition_id')\
             .select_from(EDITION_LINKS).join(Link)\
             .filter(Link.flags['cover'] == 'true')
 
@@ -43,7 +41,6 @@ class CoverProcess(CoreProcess):
             else:
                 startDate = datetime.utcnow() - timedelta(hours=24)
 
-            print(startDate)
             filters.append(Edition.date_modified >= startDate)
 
         return baseQuery.filter(*filters)
@@ -61,7 +58,7 @@ class CoverProcess(CoreProcess):
             manager.fetchCoverFile()
             manager.resizeCoverFile()
 
-            return manager
+            return manager if manager.coverContent else None
 
     def storeFoundCover(self, manager, edition):
         coverPath = 'covers/{}/{}.{}'.format(

--- a/processes/muse.py
+++ b/processes/muse.py
@@ -106,7 +106,10 @@ class MUSEProcess(CoreProcess):
             logger.debug(e)
             raise Exception('Unable to load Project MUSE CSV file')
 
-        csvReader = csv.reader(StringIO(csvResponse.text), dialect='excel')
+        csvReader = csv.reader(
+            csvResponse.iter_lines(decode_unicode=True),
+            skipinitialspace=True,
+        )
 
         for _ in range(4): next(csvReader, None) # Skip 4 header rows
 

--- a/processes/nypl.py
+++ b/processes/nypl.py
@@ -111,7 +111,7 @@ class NYPLProcess(CoreProcess):
             nyplBibQuery += ' LIMIT {}'.format(self.ingestLimit)
         
         with self.bibDBConnection.engine.connect() as conn:
-            bibResults = conn.execute(nyplBibQuery)
+            bibResults = conn.execution_options(stream_results=True).execute(nyplBibQuery)
             for bib in bibResults:
                 if bib['var_fields'] is None: continue
 

--- a/processes/s3Files.py
+++ b/processes/s3Files.py
@@ -32,9 +32,10 @@ class S3Process(CoreProcess):
         storageManager.createS3Client()
 
         fileQueue = os.environ['FILE_QUEUE']
+        fileRoute = os.environ['FILE_ROUTING_KEY']
         rabbitManager = RabbitMQManager()
         rabbitManager.createRabbitConnection()
-        rabbitManager.createOrConnectQueue(fileQueue)
+        rabbitManager.createOrConnectQueue(fileQueue, fileRoute)
 
         bucket = os.environ['FILE_BUCKET']
 

--- a/processes/sfrCluster.py
+++ b/processes/sfrCluster.py
@@ -100,10 +100,10 @@ class ClusterProcess(CoreProcess):
         return recordManager.work
     
     def queryIdens(self, idens, matchedIDs):
-        checkIdens = list(filter(None, [
+        checkIdens = list(set(filter(None, [
             i if self.checkSetRedis('cluster', i, 'all') is False else None
             for i in idens
-        ]))
+        ])))
 
         if len(checkIdens) < 1:
             return matchedIDs

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -45,6 +45,7 @@ class TestHelpers:
         'GITHUB_API_ROOT': 'test_github_url',
         'BARDO_CCE_API': 'test_cce_url',
         'MUSE_MARC_URL': 'test_muse_url',
+        'MUSE_CSV_URL': 'test_muse_csv',
         'DOAB_OAI_URL': 'test_doab_url'
     }
 

--- a/tests/unit/test_api_db.py
+++ b/tests/unit/test_api_db.py
@@ -21,7 +21,7 @@ class TestDBClient:
         mockMaker.return_value = mockCreator
         mockSession = mocker.MagicMock()
         mockCreator.return_value = mockSession
-        mockSession.query().join().outerjoin().filter().all.return_value = ['work1', 'work3']
+        mockSession.query().join().join().filter().all.return_value = ['work1', 'work3']
 
         mockFlatten = mocker.patch.object(APIUtils, 'flatten')
         mockFlatten.return_value = [1, 2, 3]
@@ -41,7 +41,7 @@ class TestDBClient:
         mockMaker.return_value = mockCreator
         mockSession = mocker.MagicMock()
         mockCreator.return_value = mockSession
-        mockSession.query().join().outerjoin().filter().first.return_value = 'testWork'
+        mockSession.query().join().join().filter().first.return_value = 'testWork'
 
         workResult = testInstance.fetchSingleWork('uuid')
 

--- a/tests/unit/test_core_process.py
+++ b/tests/unit/test_core_process.py
@@ -72,7 +72,7 @@ class TestCoreProcess:
         assert coreInstance.records[0] == mockDocument
 
     def test_addDCDWToUpdateList_new_save_records(self, coreInstance, mocker):
-        coreInstance.records = ['record{}'.format(i) for i in range(2499)]
+        coreInstance.records = ['record{}'.format(i) for i in range(999)]
 
         mockSession = mocker.MagicMock()
         mockSession.query().filter().first.return_value = None

--- a/tests/unit/test_core_process.py
+++ b/tests/unit/test_core_process.py
@@ -72,7 +72,7 @@ class TestCoreProcess:
         assert coreInstance.records[0] == mockDocument
 
     def test_addDCDWToUpdateList_new_save_records(self, coreInstance, mocker):
-        coreInstance.records = ['record{}'.format(i) for i in range(9999)]
+        coreInstance.records = ['record{}'.format(i) for i in range(2499)]
 
         mockSession = mocker.MagicMock()
         mockSession.query().filter().first.return_value = None

--- a/tests/unit/test_cover_process.py
+++ b/tests/unit/test_cover_process.py
@@ -46,7 +46,7 @@ class TestCoverProcess:
         assert testQuery == 'testQuery'
         assert mockQuery.filter.call_args[0][0].compare(~Edition.id.in_('subQuery'))
         testProcess.session.query.assert_has_calls([
-            mocker.call(Edition), mocker.call(Edition.id)
+            mocker.call(Edition), mocker.call('edition_id')
         ])
         mockSubQuery.select_from().join().filter.call_args[0][0].compare(Link.flags['cover'] == 'true')
 

--- a/tests/unit/test_db_manager.py
+++ b/tests/unit/test_db_manager.py
@@ -130,6 +130,8 @@ class TestDBManager:
         testInstance.session.bulk_save_objects.assert_called_once_with(
             [1, 2, 3], update_changed_only=True
         )
+        testInstance.session.commit.assert_called_once()
+        testInstance.session.flush.assert_called_once()
 
     def test_bulkSaveObjects_onlyChanged_false(self, testInstance, mocker):
         testInstance.session = mocker.MagicMock()

--- a/tests/unit/test_fetcher_openlibrary.py
+++ b/tests/unit/test_fetcher_openlibrary.py
@@ -34,7 +34,7 @@ class TestOpenLibraryFetcher:
         mockSetCover = mocker.patch.object(OpenLibraryFetcher, 'setCoverPageURL')
 
         mockRow = mocker.MagicMock(cover_id=1)
-        testFetcher.session.query().filter().filter().one_or_none.return_value = mockRow
+        testFetcher.session.query().filter().filter().first.return_value = mockRow
 
         assert testFetcher.fetchVolumeCover(1, 'test') == True
         mockSetCover.assert_called_once_with(1)
@@ -45,7 +45,7 @@ class TestOpenLibraryFetcher:
     def test_fetchVolumeCover_failure(self, testFetcher, mocker):
         mockSetCover = mocker.patch.object(OpenLibraryFetcher, 'setCoverPageURL')
 
-        testFetcher.session.query().filter().filter().one_or_none.return_value = None
+        testFetcher.session.query().filter().filter().first.return_value = None
 
         assert testFetcher.fetchVolumeCover(1, 'test') == False
         mockSetCover.assert_not_called()

--- a/tests/unit/test_muse_process.py
+++ b/tests/unit/test_muse_process.py
@@ -186,7 +186,8 @@ class TestMUSEProcess:
 
     def test_downloadRecordUpdates_success(self, testProcess, testBookCSV, mocker):
         mockGet = mocker.patch.object(requests, 'get')
-        mockResp = mocker.MagicMock(text='testCSV')
+        mockResp = mocker.MagicMock()
+        mockResp.iter_lines.return_value = 'testFile'
         mockGet.return_value = mockResp
 
         mockCSV = mocker.patch.object(csv, 'reader')
@@ -196,7 +197,8 @@ class TestMUSEProcess:
 
         assert testProcess.updateDates == {'row1': datetime(2020, 1, 1), 'row3': datetime(2020, 1, 1)}
         mockGet.assert_called_once_with('test_muse_csv', stream=True, timeout=30)
-        mockCSV.assert_called_once()
+        mockResp.iter_lines.assert_called_once_with(decode_unicode=True)
+        mockCSV.assert_called_once_with('testFile', skipinitialspace=True)
 
     def test_downloadRecordUpdates_failure(self, testProcess, mocker):
         mockGet = mocker.patch.object(requests, 'get')

--- a/tests/unit/test_muse_process.py
+++ b/tests/unit/test_muse_process.py
@@ -1,5 +1,8 @@
+import csv
+from datetime import datetime
 import pytest
 import requests
+from requests.exceptions import HTTPError
 
 from processes.muse import MUSEProcess, MUSEError
 from tests.helper import TestHelpers
@@ -30,6 +33,18 @@ class TestMUSEProcess:
     def testMUSEPageUnreleased(self):
         return open('./tests/fixtures/muse_book_63320.html', 'r').read()
 
+    @pytest.fixture
+    def testBookCSV(self):
+        return [
+            ['Header 1'],
+            ['Header 2'],
+            ['Header 3'],
+            ['Header 4'],
+            [0, 1, 2, 3, 4, 5, 6, 'row1', 8, 9, '2020-01-01'],
+            [0, 1, 2, 3, 4, 5, 6, 'row2', 8, 9],
+            [0, 1, 2, 3, 4, 5, 6, 'row3', 8, 9, '2020-01-01'],
+        ]
+
     def test_runProcess_daily(self, testProcess, mocker):
         mockImport = mocker.patch.object(MUSEProcess, 'importMARCRecords')
         mockSave = mocker.patch.object(MUSEProcess, 'saveRecords')
@@ -50,7 +65,7 @@ class TestMUSEProcess:
         testProcess.process = 'complete'
         testProcess.runProcess()
 
-        mockImport.assert_called_once_with(fullOrPartial=True)
+        mockImport.assert_called_once_with(full=True)
         mockSave.assert_called_once
         mockCommit.assert_called_once
 
@@ -67,26 +82,91 @@ class TestMUSEProcess:
         mockSave.assert_called_once
         mockCommit.assert_called_once
 
-    def test_importMARCRecords(self, testProcess, mocker):
-        mockDownload = mocker.patch.object(MUSEProcess, 'downloadMARCRecords')
-        mockDownload.return_value = 'mockFile'
+    def test_importMARCRecords_daily(self, testProcess, mocker):
+        processMocks = mocker.patch.multiple(MUSEProcess,
+            downloadRecordUpdates=mocker.DEFAULT,
+            downloadMARCRecords=mocker.DEFAULT,
+            recordToBeUpdated=mocker.DEFAULT,
+            parseMuseRecord=mocker.DEFAULT,
+        )
+        processMocks['recordToBeUpdated'].side_effect = [True, False, True, True]
+        processMocks['downloadMARCRecords'].return_value = 'mockFile'
+        processMocks['parseMuseRecord'].side_effect = [None, MUSEError('test'), None]
+
+        mockDatetime = mocker.patch('processes.muse.datetime')
+        mockDatetime.utcnow.return_value = datetime(1900, 1, 2, 12, 0, 0)
 
         mockReader = mocker.patch('processes.muse.MARCReader')
-        mockReader.return_value = ['rec1', 'rec2', 'rec3']
-
-        mockParser = mocker.patch.object(MUSEProcess, 'parseMuseRecord')
-        mockParser.side_effect = [None, MUSEError('test'), None]
+        mockReader.return_value = ['rec1', 'rec2', 'rec3', 'rec4']
 
         testProcess.importMARCRecords()
 
-        mockDownload.assert_called_once
+        processMocks['downloadRecordUpdates'].assert_called_once()
+        processMocks['downloadMARCRecords'].assert_called_once()
         mockReader.assert_called_once_with('mockFile')
-        mockParser.assert_has_calls([mocker.call('rec1'), mocker.call('rec2'), mocker.call('rec3')])
+        testDate = datetime(1900, 1, 1, 12, 0, 0)
+        processMocks['recordToBeUpdated'].assert_has_calls([
+            mocker.call('rec1', testDate), mocker.call('rec2', testDate),
+            mocker.call('rec3', testDate), mocker.call('rec4', testDate), 
+        ])
+        processMocks['parseMuseRecord'].assert_has_calls([
+            mocker.call('rec1'), mocker.call('rec3'), mocker.call('rec4')
+        ])
+
+    def test_importMARCRecords_custom(self, testProcess, mocker):
+        processMocks = mocker.patch.multiple(MUSEProcess,
+            downloadRecordUpdates=mocker.DEFAULT,
+            downloadMARCRecords=mocker.DEFAULT,
+            recordToBeUpdated=mocker.DEFAULT,
+            parseMuseRecord=mocker.DEFAULT,
+        )
+        processMocks['recordToBeUpdated'].side_effect = [True, False, True, True]
+        processMocks['downloadMARCRecords'].return_value = 'mockFile'
+        processMocks['parseMuseRecord'].side_effect = [None, MUSEError('test'), None]
+
+        mockReader = mocker.patch('processes.muse.MARCReader')
+        mockReader.return_value = ['rec1', 'rec2', 'rec3', 'rec4']
+
+        testProcess.importMARCRecords(startTimestamp='2020-01-01')
+
+        processMocks['downloadRecordUpdates'].assert_called_once()
+        processMocks['downloadMARCRecords'].assert_called_once()
+        mockReader.assert_called_once_with('mockFile')
+        testDate = datetime(2020, 1, 1)
+        processMocks['recordToBeUpdated'].assert_has_calls([
+            mocker.call('rec1', testDate), mocker.call('rec2', testDate),
+            mocker.call('rec3', testDate), mocker.call('rec4', testDate), 
+        ])
+        processMocks['parseMuseRecord'].assert_has_calls([
+            mocker.call('rec1'), mocker.call('rec3'), mocker.call('rec4')
+        ])
+
+    def test_importMARCRecords_full(self, testProcess, mocker):
+        processMocks = mocker.patch.multiple(MUSEProcess,
+            downloadRecordUpdates=mocker.DEFAULT,
+            downloadMARCRecords=mocker.DEFAULT,
+            recordToBeUpdated=mocker.DEFAULT,
+            parseMuseRecord=mocker.DEFAULT,
+        )
+        processMocks['downloadMARCRecords'].return_value = 'mockFile'
+        processMocks['parseMuseRecord'].side_effect = [None, MUSEError('test'), None, None]
+
+        mockReader = mocker.patch('processes.muse.MARCReader')
+        mockReader.return_value = ['rec1', 'rec2', 'rec3', 'rec4']
+
+        testProcess.importMARCRecords(full=True)
+
+        processMocks['downloadRecordUpdates'].assert_called_once()
+        processMocks['downloadMARCRecords'].assert_called_once()
+        mockReader.assert_called_once_with('mockFile')
+        processMocks['recordToBeUpdated'].assert_not_called()
+        processMocks['parseMuseRecord'].assert_has_calls([
+            mocker.call('rec1'), mocker.call('rec2'), mocker.call('rec3'), mocker.call('rec4')
+        ])
 
     def test_downloadMARCRecords_success(self, testProcess, mocker):
         mockGet = mocker.patch.object(requests, 'get')
         mockResp = mocker.MagicMock()
-        mockResp.status_code = 200
         mockResp.iter_content.return_value = [b'm', b'a', b'r', b'c']
         mockGet.return_value = mockResp
 
@@ -98,11 +178,50 @@ class TestMUSEProcess:
     def test_downloadMARCRecords_failure(self, testProcess, mocker):
         mockGet = mocker.patch.object(requests, 'get')
         mockResp = mocker.MagicMock()
-        mockResp.status_code = 500
+        mockResp.raise_for_status.side_effect = HTTPError
         mockGet.return_value = mockResp
 
         with pytest.raises(Exception):
             testProcess.downloadMARCRecords()
+
+    def test_downloadRecordUpdates_success(self, testProcess, testBookCSV, mocker):
+        mockGet = mocker.patch.object(requests, 'get')
+        mockResp = mocker.MagicMock(text='testCSV')
+        mockGet.return_value = mockResp
+
+        mockCSV = mocker.patch.object(csv, 'reader')
+        mockCSV.return_value = iter(testBookCSV)
+
+        testProcess.downloadRecordUpdates()
+
+        assert testProcess.updateDates == {'row1': datetime(2020, 1, 1), 'row3': datetime(2020, 1, 1)}
+        mockGet.assert_called_once_with('test_muse_csv', stream=True, timeout=30)
+        mockCSV.assert_called_once()
+
+    def test_downloadRecordUpdates_failure(self, testProcess, mocker):
+        mockGet = mocker.patch.object(requests, 'get')
+        mockResp = mocker.MagicMock()
+        mockResp.raise_for_status.side_effect = HTTPError
+        mockGet.return_value = mockResp
+
+        with pytest.raises(Exception):
+            testProcess.downloadRecordUpdates()
+
+    def test_recordToBeUpdated_true(self, testProcess, mocker):
+        mockRecord = mocker.MagicMock()
+        mockRecord.get_fields.return_value = [{'u': 'testURL/'}]
+
+        testProcess.updateDates = {'testURL': datetime(2020, 1, 1)}
+
+        assert testProcess.recordToBeUpdated(mockRecord, datetime(1900, 1, 1)) == True
+
+    def test_recordToBeUpdated_false(self, testProcess, mocker):
+        mockRecord = mocker.MagicMock()
+        mockRecord.get_fields.return_value = [{'u': 'testURL/'}]
+
+        testProcess.updateDates = {'testURL': datetime(1900, 1, 1)}
+
+        assert testProcess.recordToBeUpdated(mockRecord, datetime(2020, 1, 1)) == False
 
     def test_parseMuseRecord(self, testProcess, mocker):
         mockRecord = mocker.MagicMock()

--- a/tests/unit/test_nypl_process.py
+++ b/tests/unit/test_nypl_process.py
@@ -239,7 +239,7 @@ class TestNYPLProcess:
         mockParse = mocker.patch.object(NYPLProcess, 'parseNYPLDataRow')
 
         mockConn = mocker.MagicMock(name='Mock Connection')
-        mockConn.execute.return_value = [
+        mockConn.execution_options().execute.return_value = [
             {'var_fields': 'bib1'},
             {'var_fields': None},
             {'var_fields': 'bib3'}
@@ -250,7 +250,7 @@ class TestNYPLProcess:
         testInstance.importBibRecords()
 
         mockDatetime.utcnow.assert_called_once
-        mockConn.execute.assert_called_once_with(
+        mockConn.execution_options().execute.assert_called_once_with(
             'SELECT * FROM bib WHERE updated_date > \'1900-01-01T12:00:00\''
         )
         mockParse.assert_has_calls([mocker.call({'var_fields': 'bib1'}), mocker.call({'var_fields': 'bib3'})])
@@ -262,7 +262,7 @@ class TestNYPLProcess:
         mockParse = mocker.patch.object(NYPLProcess, 'parseNYPLDataRow')
 
         mockConn = mocker.MagicMock(name='Mock Connection')
-        mockConn.execute.return_value = [
+        mockConn.execution_options().execute.return_value = [
             {'var_fields': 'bib1'},
             {'var_fields': None},
             {'var_fields': 'bib3'}
@@ -273,7 +273,7 @@ class TestNYPLProcess:
         testInstance.importBibRecords(startTimestamp='customTimestamp')
 
         mockDatetime.utcnow.assert_not_called
-        mockConn.execute.assert_called_once_with(
+        mockConn.execution_options().execute.assert_called_once_with(
             'SELECT * FROM bib WHERE updated_date > \'customTimestamp\''
         )
         mockParse.assert_has_calls([mocker.call({'var_fields': 'bib1'}), mocker.call({'var_fields': 'bib3'})])
@@ -284,7 +284,7 @@ class TestNYPLProcess:
         mockParse = mocker.patch.object(NYPLProcess, 'parseNYPLDataRow')
 
         mockConn = mocker.MagicMock(name='Mock Connection')
-        mockConn.execute.return_value = [
+        mockConn.execution_options().execute.return_value = [
             {'var_fields': 'bib1'},
             {'var_fields': None},
             {'var_fields': 'bib3'}
@@ -295,7 +295,7 @@ class TestNYPLProcess:
         testInstance.importBibRecords(fullOrPartial=True)
 
         mockDatetime.utcnow.assert_not_called
-        mockConn.execute.assert_called_once_with(
+        mockConn.execution_options().execute.assert_called_once_with(
             'SELECT * FROM bib'
         )
         mockParse.assert_has_calls([mocker.call({'var_fields': 'bib1'}), mocker.call({'var_fields': 'bib3'})])
@@ -306,7 +306,7 @@ class TestNYPLProcess:
         mockParse = mocker.patch.object(NYPLProcess, 'parseNYPLDataRow')
 
         mockConn = mocker.MagicMock(name='Mock Connection')
-        mockConn.execute.return_value = [
+        mockConn.execution_options().execute.return_value = [
             {'var_fields': 'bib1'},
             {'var_fields': 'bib2'},
             {'var_fields': None}
@@ -318,7 +318,7 @@ class TestNYPLProcess:
         testInstance.importBibRecords(fullOrPartial=True)
 
         mockDatetime.utcnow.assert_not_called
-        mockConn.execute.assert_called_once_with(
+        mockConn.execution_options().execute.assert_called_once_with(
             'SELECT * FROM bib OFFSET 1000 LIMIT 1000'
         )
         mockParse.assert_has_calls([mocker.call({'var_fields': 'bib1'}), mocker.call({'var_fields': 'bib2'})])

--- a/tests/unit/test_redis_manager.py
+++ b/tests/unit/test_redis_manager.py
@@ -34,7 +34,7 @@ class TestRedisManager:
         mockSet = mocker.patch.object(RedisManager, 'setRedis')
 
         assert testInstance.checkSetRedis('test', 1, 'test') is True
-        testInstance.redisClient.get.assert_called_once_with('test/1/test')
+        testInstance.redisClient.get.assert_called_once_with('testEnv/test/1/test')
         mockSet.assert_not_called
 
     def test_checkSetRedis_key_found_old(self, testInstance, mocker):
@@ -44,7 +44,7 @@ class TestRedisManager:
         mockSet = mocker.patch.object(RedisManager, 'setRedis')
 
         assert testInstance.checkSetRedis('test', 1, 'test') is False
-        testInstance.redisClient.get.assert_called_once_with('test/1/test')
+        testInstance.redisClient.get.assert_called_once_with('testEnv/test/1/test')
         mockSet.assert_called_once
 
     def test_checkSetRedis_key_not_found(self, testInstance, mocker):
@@ -54,14 +54,14 @@ class TestRedisManager:
         mockSet = mocker.patch.object(RedisManager, 'setRedis')
 
         assert testInstance.checkSetRedis('test', 1, 'test') is False
-        testInstance.redisClient.get.assert_called_once_with('test/1/test')
+        testInstance.redisClient.get.assert_called_once_with('testEnv/test/1/test')
         mockSet.assert_called_once
 
     def test_setRedis(self, testInstance, mocker):
         testInstance.redisClient = mocker.MagicMock()
 
-        testInstance.setRedis('test', 1, 'test', datetime(1900, 1, 1))
+        testInstance.setRedis('test', 1, 'test', )
 
         testInstance.redisClient.set.assert_called_once_with(
-            'testEnv/test/1/test', '1900-01-01T00:00:00', ex=604800
+            'testEnv/test/1/test', testInstance.presentTime.strftime('%Y-%m-%dT%H:%M:%S'), ex=604800
         )

--- a/tests/unit/test_sfrRecord_manager.py
+++ b/tests/unit/test_sfrRecord_manager.py
@@ -368,6 +368,6 @@ class TestSFRRecordManager:
         assert testInstance.work.sort_title == 'kplagh: batleth handbook'
 
     def test_normalizeDates(self, testInstance):
-        testDates = testInstance.normalizeDates(['1999.', '2000', 'sometime 1900-12 [pub]'])
+        testDates = testInstance.normalizeDates(['1999.|test', '2000|other', 'sometime 1900-12 [pub]|other'])
 
-        assert sorted(testDates) == sorted(['1999', '2000', '1900-12'])
+        assert sorted(testDates) == sorted(['1999|test', '2000|other', '1900-12|other'])


### PR DESCRIPTION
Running these processes on ECS means that they run in an environment where the containers have strict memory limits (controlled by the CloudFormation template for the stack). Several of the processes were found to exceed these limits for various reasons. Both for stability and performance these issues needed to be resolved. The individual fixes implemented are:

- An update in the NYPL process to allow for a database query to be streamed in chunks, rather than loaded all at once
- A change generally to the database layer to write updates more frequently and fully commit/flush the session more frequently
- Load HathiTrust CSV files without loading them to a temp file on disk, instead streaming them directly to a process
- Filter Project MUSE records for only records that need to be updated
- Resolve minor bug in the s3 files storage process