### PR TITLE
SFR-1012 Postgres Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## unreleased -- v0.2.4
+### Fixed
+- Race conditions in OCLC Classify fetching process
+- Missing CASCADE constraints on several database tables
+- Missing indexes on several database tables
+
 ## 2021-02-23 -- v0.2.3
 ### Fixed
 - Update RabbitMQ client to work with credentials, virtual hosts and non-default exchanges

--- a/api/db.py
+++ b/api/db.py
@@ -10,14 +10,14 @@ class DBClient():
 
     def fetchSearchedWorks(self, ids):
         uuids = [i[0] for i in ids]
-        editionIds = list(APIUtils.flatten([i[1] for i in ids]))
+        editionIds = list(set(APIUtils.flatten([i[1] for i in ids])))
 
         session = sessionmaker(bind=self.engine)()
 
         query = session.query(Work)\
             .join(Edition)\
             .join(Item, ITEM_LINKS, Link)\
-            .filter(Edition.id.in_(editionIds))
+            .filter(Work.uuid.in_(uuids), Edition.id.in_(editionIds))
 
         return query.all()
 

--- a/managers/coverFetchers/googleBooksFetcher.py
+++ b/managers/coverFetchers/googleBooksFetcher.py
@@ -49,7 +49,7 @@ class GoogleBooksFetcher(AbstractFetcher):
 
         try:
             coverLinks = volumeResp['volumeInfo']['imageLinks']
-        except (KeyError, AttributeError):
+        except (KeyError, AttributeError, TypeError):
             return False
 
         for imageSize in self.IMAGE_SIZES:

--- a/managers/kMeans.py
+++ b/managers/kMeans.py
@@ -74,7 +74,7 @@ class KMeansManager:
                     ngram_range=(1,3))
                 )
             ])),
-            'pubDate': ('date', Pipeline([
+            'pubDate': ('pubDate', Pipeline([
                 ('selector', NumberSelector(key='pubDate')),
                 ('scaler', MinMaxScaler())
             ]))
@@ -84,7 +84,7 @@ class KMeansManager:
             'place': 0.5,
             'publisher': 1.0,
             'edition': 0.75,
-            'date': 2.0 
+            'pubDate': 2.0 
         }
 
         return Pipeline([

--- a/managers/kMeans.py
+++ b/managers/kMeans.py
@@ -80,15 +80,17 @@ class KMeansManager:
             ]))
         }
 
+        pipelineWeights = {
+            'place': 0.5,
+            'publisher': 1.0,
+            'edition': 0.75,
+            'date': 2.0 
+        }
+
         return Pipeline([
             ('union', FeatureUnion(
                 transformer_list=[pipelineComponents[t] for t in transformers],
-                transformer_weights={
-                    'place': 0.5,
-                    'publisher': 1.0,
-                    'edition': 0.75,
-                    'date': 2.0 
-                }
+                transformer_weights={t: pipelineWeights[t] for t in transformers}
             )),
             ('kmeans', KMeans(n_clusters=self.currentK))
         ])

--- a/model/postgres/edition.py
+++ b/model/postgres/edition.py
@@ -5,18 +5,18 @@ from sqlalchemy.orm import relationship
 from .base import Base, Core
 
 EDITION_IDENTIFIERS = Table('edition_identifiers', Base.metadata,
-    Column('edition_id', Integer, ForeignKey('editions.id')),
-    Column('identifier_id', Integer, ForeignKey('identifiers.id'))
+    Column('edition_id', Integer, ForeignKey('editions.id', ondelete='CASCADE')),
+    Column('identifier_id', Integer, ForeignKey('identifiers.id', ondelete='CASCADE'))
 )
 
 EDITION_LINKS = Table('edition_links', Base.metadata,
-    Column('edition_id', Integer, ForeignKey('editions.id')),
-    Column('link_id', Integer, ForeignKey('links.id'))
+    Column('edition_id', Integer, ForeignKey('editions.id', ondelete='CASCADE')),
+    Column('link_id', Integer, ForeignKey('links.id', ondelete='CASCADE'))
 )
 
 EDITION_RIGHTS = Table('edition_rights', Base.metadata,
-    Column('edition_id', Integer, ForeignKey('editions.id')),
-    Column('rights_id', Integer, ForeignKey('rights.id'))
+    Column('edition_id', Integer, ForeignKey('editions.id', ondelete='CASCADE')),
+    Column('rights_id', Integer, ForeignKey('rights.id', ondelete='CASCADE'))
 )
 
 class Edition(Base, Core):
@@ -44,9 +44,9 @@ class Edition(Base, Core):
     work_id = Column(Integer, ForeignKey('works.id'))
     items = relationship('Item', backref='edition', cascade='all, delete-orphan')
 
-    identifiers = relationship('Identifier', secondary=EDITION_IDENTIFIERS, backref='editions')
-    links = relationship('Link', secondary=EDITION_LINKS, backref='editions')
-    rights = relationship('Rights', secondary=EDITION_RIGHTS, backref='editions')
+    identifiers = relationship('Identifier', secondary=EDITION_IDENTIFIERS, backref='editions', cascade='all, delete')
+    links = relationship('Link', secondary=EDITION_LINKS, backref='editions', cascade='all, delete')
+    rights = relationship('Rights', secondary=EDITION_RIGHTS, backref='editions', cascade='all, delete')
 
     def __repr__(self):
         return '<Edition(place={}, date={}, publisher={})>'.format(

--- a/model/postgres/edition.py
+++ b/model/postgres/edition.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Date, Unicode, Integer, Column, Table, ForeignKey
+from sqlalchemy import Date, Unicode, Integer, Column, Table, ForeignKey, Index
 from sqlalchemy.dialects.postgresql import JSONB, ARRAY, UUID
 from sqlalchemy.orm import relationship
 
@@ -41,12 +41,14 @@ class Edition(Base, Core):
     languages = Column(JSONB)
     dcdw_uuids = Column(ARRAY(UUID, dimensions=1))
 
-    work_id = Column(Integer, ForeignKey('works.id'))
+    work_id = Column(Integer, ForeignKey('works.id', ondelete='CASCADE'), index=True)
     items = relationship('Item', backref='edition', cascade='all, delete-orphan')
 
     identifiers = relationship('Identifier', secondary=EDITION_IDENTIFIERS, backref='editions', cascade='all, delete')
     links = relationship('Link', secondary=EDITION_LINKS, backref='editions', cascade='all, delete')
     rights = relationship('Rights', secondary=EDITION_RIGHTS, backref='editions', cascade='all, delete')
+
+    __tableargs__ = (Index('ix_editions_dcdw_uuids', dcdw_uuids, postgresql_using="gin"))
 
     def __repr__(self):
         return '<Edition(place={}, date={}, publisher={})>'.format(

--- a/model/postgres/item.py
+++ b/model/postgres/item.py
@@ -5,18 +5,18 @@ from sqlalchemy.orm import relationship
 from .base import Base, Core
 
 ITEM_IDENTIFIERS = Table('item_identifiers', Base.metadata,
-    Column('item_id', Integer, ForeignKey('items.id')),
-    Column('identifier_id', Integer, ForeignKey('identifiers.id'))
+    Column('item_id', Integer, ForeignKey('items.id'), ondelete='CASCADE'),
+    Column('identifier_id', Integer, ForeignKey('identifiers.id'), ondelete='CASCADE')
 )
 
 ITEM_LINKS = Table('item_links', Base.metadata,
-    Column('item_id', Integer, ForeignKey('items.id')),
-    Column('link_id', Integer, ForeignKey('links.id'))
+    Column('item_id', Integer, ForeignKey('items.id'), ondelete='CASCADE'),
+    Column('link_id', Integer, ForeignKey('links.id'), ondelete='CASCADE')
 )
 
 ITEM_RIGHTS = Table('item_rights', Base.metadata,
-    Column('item_id', Integer, ForeignKey('items.id')),
-    Column('rights_id', Integer, ForeignKey('rights.id'))
+    Column('item_id', Integer, ForeignKey('items.id'), ondelete='CASCADE'),
+    Column('rights_id', Integer, ForeignKey('rights.id'), ondelete='CASCADE')
 )
 
 class Item(Base, Core):
@@ -31,11 +31,11 @@ class Item(Base, Core):
     measurements = Column(JSONB)
     physical_location = Column(JSONB)
 
-    edition_id = Column(Integer, ForeignKey('editions.id'))
+    edition_id = Column(Integer, ForeignKey('editions.id'), index=True)
 
-    identifiers = relationship('Identifier', secondary=ITEM_IDENTIFIERS, backref='items')
-    links = relationship('Link', secondary=ITEM_LINKS, backref='items')
-    rights = relationship('Rights', secondary=ITEM_RIGHTS, backref='items')
+    identifiers = relationship('Identifier', secondary=ITEM_IDENTIFIERS, backref='items', cascade='all, delete')
+    links = relationship('Link', secondary=ITEM_LINKS, backref='items', cascade='all, delete')
+    rights = relationship('Rights', secondary=ITEM_RIGHTS, backref='items', cascade='all, delete')
 
     def __repr__(self):
         return '<Item(source={}, content_type={})>'.format(

--- a/model/postgres/item.py
+++ b/model/postgres/item.py
@@ -5,18 +5,18 @@ from sqlalchemy.orm import relationship
 from .base import Base, Core
 
 ITEM_IDENTIFIERS = Table('item_identifiers', Base.metadata,
-    Column('item_id', Integer, ForeignKey('items.id'), ondelete='CASCADE'),
-    Column('identifier_id', Integer, ForeignKey('identifiers.id'), ondelete='CASCADE')
+    Column('item_id', Integer, ForeignKey('items.id', ondelete='CASCADE')),
+    Column('identifier_id', Integer, ForeignKey('identifiers.id', ondelete='CASCADE'))
 )
 
 ITEM_LINKS = Table('item_links', Base.metadata,
-    Column('item_id', Integer, ForeignKey('items.id'), ondelete='CASCADE'),
-    Column('link_id', Integer, ForeignKey('links.id'), ondelete='CASCADE')
+    Column('item_id', Integer, ForeignKey('items.id', ondelete='CASCADE')),
+    Column('link_id', Integer, ForeignKey('links.id', ondelete='CASCADE'))
 )
 
 ITEM_RIGHTS = Table('item_rights', Base.metadata,
-    Column('item_id', Integer, ForeignKey('items.id'), ondelete='CASCADE'),
-    Column('rights_id', Integer, ForeignKey('rights.id'), ondelete='CASCADE')
+    Column('item_id', Integer, ForeignKey('items.id', ondelete='CASCADE')),
+    Column('rights_id', Integer, ForeignKey('rights.id', ondelete='CASCADE'))
 )
 
 class Item(Base, Core):

--- a/model/postgres/item.py
+++ b/model/postgres/item.py
@@ -31,7 +31,7 @@ class Item(Base, Core):
     measurements = Column(JSONB)
     physical_location = Column(JSONB)
 
-    edition_id = Column(Integer, ForeignKey('editions.id'), index=True)
+    edition_id = Column(Integer, ForeignKey('editions.id', ondelete='CASCADE'), index=True)
 
     identifiers = relationship('Identifier', secondary=ITEM_IDENTIFIERS, backref='items', cascade='all, delete')
     links = relationship('Link', secondary=ITEM_LINKS, backref='items', cascade='all, delete')

--- a/model/postgres/record.py
+++ b/model/postgres/record.py
@@ -1,16 +1,5 @@
-from datetime import datetime
-from sqlalchemy import (
-    Column,
-    DateTime,
-    ForeignKey,
-    Integer,
-    String,
-    Unicode,
-    Table,
-    Boolean,
-    Index
-)
-from sqlalchemy.dialects.postgresql import JSON, ARRAY, UUID, ENUM
+from sqlalchemy import Column, DateTime, Integer, Unicode, Boolean, Index
+from sqlalchemy.dialects.postgresql import ARRAY, UUID, ENUM
 
 from .base import Base, Core
 
@@ -49,8 +38,6 @@ class Record(Base, Core):
     abstract = Column(Unicode) # dc:abstract, Non-Repeating
     has_part = Column(ARRAY(Unicode, dimensions=1)) # dc:hasPart, Repeating, Format "itemNo|uri|source|type|flags"
     coverage = Column(ARRAY(Unicode, dimensions=1)) # dc:coverage, non-Repeating, Format "locationCode|locationName|itemNo"
-
-    # edition_id = Column(Integer, ForeignKey('editions.id'))
 
     __tableargs__ = (Index('ix_record_identifiers', identifiers, postgresql_using="gin"))
 

--- a/model/postgres/work.py
+++ b/model/postgres/work.py
@@ -1,28 +1,17 @@
-from datetime import datetime
-from sqlalchemy import (
-    Column,
-    DateTime,
-    ForeignKey,
-    Integer,
-    String,
-    Unicode,
-    Table,
-    Boolean,
-    Index
-)
-from sqlalchemy.dialects.postgresql import JSONB, ARRAY, UUID, ENUM
+from sqlalchemy import Column, ForeignKey, Integer, Unicode, Table
+from sqlalchemy.dialects.postgresql import JSONB, ARRAY, UUID
 from sqlalchemy.orm import relationship
 
 from .base import Base, Core
 
 WORK_IDENTIFIERS = Table('work_identifiers', Base.metadata,
-    Column('work_id', Integer, ForeignKey('works.id')),
-    Column('identifier_id', Integer, ForeignKey('identifiers.id'))
+    Column('work_id', Integer, ForeignKey('works.id', ondelete='CASCADE')),
+    Column('identifier_id', Integer, ForeignKey('identifiers.id', ondelete='CASCADE'))
 )
 
 WORK_RIGHTS = Table('work_rights', Base.metadata,
-    Column('work_id', Integer, ForeignKey('works.id')),
-    Column('rights_id', Integer, ForeignKey('rights.id'))
+    Column('work_id', Integer, ForeignKey('works.id', ondelete='CASCADE')),
+    Column('rights_id', Integer, ForeignKey('rights.id', ondelete='CASCADE'))
 )
 
 class Work(Base, Core):

--- a/processes/core.py
+++ b/processes/core.py
@@ -5,13 +5,14 @@ from static.manager import StaticManager
 
 class CoreProcess(DBManager, NyplApiManager, RabbitMQManager, RedisManager, StaticManager,
                   ElasticsearchManager, S3Manager):
-    def __init__(self, process, customFile, ingestPeriod, singleRecord):
+    def __init__(self, process, customFile, ingestPeriod, singleRecord, batchSize=500):
         super(CoreProcess, self).__init__()
         self.process = process
         self.customFile = customFile
         self.ingestPeriod = ingestPeriod
         self.singleRecord = singleRecord
 
+        self.batchSize = batchSize
         self.records = set()
     
     def addDCDWToUpdateList(self, rec):
@@ -31,9 +32,33 @@ class CoreProcess(DBManager, NyplApiManager, RabbitMQManager, RedisManager, Stat
             print('NEW', rec.record)
             self.records.add(rec.record)
         
-        if len(self.records) >= 500:
+        if len(self.records) >= self.batchSize:
             self.saveRecords()
             self.records = set()
+    
+    def windowedQuery(self, table, query, windowSize=100):
+        singleEntity = query.is_single_entity
+        query = query.add_column(table.id).order_by(table.id)
+
+        lastID = None
+        totalFetched = 0
+
+        while True:
+            subQuery = query
+
+            if lastID is not None:
+                subQuery = subQuery.filter(table.id > lastID)
+
+            queryChunk = subQuery.limit(windowSize).all()
+            totalFetched += windowSize
+
+            if not queryChunk or (self.ingestLimit and totalFetched > self.ingestLimit):
+                break
+
+            lastID = queryChunk[-1][-1]
+
+            for row in queryChunk:
+                yield row[0] if singleEntity else row[0:-1]
     
     def saveRecords(self):
         self.bulkSaveObjects(self.records)

--- a/processes/covers.py
+++ b/processes/covers.py
@@ -81,7 +81,6 @@ class CoverProcess(CoreProcess):
 
         edition.links.append(coverLink)
         self.records.add(edition)
-        print(self.records)
 
         if len(self.records) >= self.batchSize:
             self.bulkSaveObjects(self.records)

--- a/processes/covers.py
+++ b/processes/covers.py
@@ -85,4 +85,3 @@ class CoverProcess(CoreProcess):
         if len(self.records) >= self.batchSize:
             self.bulkSaveObjects(self.records)
             self.records = set()
-            print(self.records)

--- a/processes/covers.py
+++ b/processes/covers.py
@@ -76,4 +76,4 @@ class CoverProcess(CoreProcess):
         )
 
         edition.links.append(coverLink)
-        self.records.append(edition)
+        self.records.add(edition)

--- a/processes/hathiTrust.py
+++ b/processes/hathiTrust.py
@@ -17,7 +17,7 @@ class HathiTrustProcess(CoreProcess):
     HATHI_RIGHTS_SKIPS = ['ic', 'icus', 'ic-world', 'und']
 
     def __init__(self, *args):
-        super(HathiTrustProcess, self).__init__(*args[:4])
+        super(HathiTrustProcess, self).__init__(*args[:4], batchSize=1000)
         self.generateEngine()
         self.createSession()
 

--- a/processes/oclcCatalog.py
+++ b/processes/oclcCatalog.py
@@ -11,7 +11,7 @@ from model import Record
 
 class CatalogProcess(CoreProcess):
     def __init__(self, *args):
-        super(CatalogProcess, self).__init__(*args[:4])
+        super(CatalogProcess, self).__init__(*args[:4], batchSize=50)
 
         # PostgreSQL Connection
         self.generateEngine()

--- a/processes/oclcClassify.py
+++ b/processes/oclcClassify.py
@@ -50,7 +50,8 @@ class ClassifyProcess(CoreProcess):
         for rec in self.windowedQuery(baseQuery, windowSize=windowSize):
             self.frbrizeRecord(rec)
             rec.frbr_status = 'complete'
-            self.records.append(rec)
+            rec.cluster_status = False
+            self.records.add(rec)
 
     def windowedQuery(self, query, windowSize=100):
         singleEntity = query.is_single_entity

--- a/tests/unit/test_core_process.py
+++ b/tests/unit/test_core_process.py
@@ -56,7 +56,7 @@ class TestCoreProcess:
 
         mockSession.assert_called_once
         mockRecord.updateExisting.assert_called_with('existing_record')
-        assert coreInstance.records[0] == 'existing_record'
+        assert list(coreInstance.records)[0] == 'existing_record'
 
     def test_addDCDWToUpdateList_new(self, coreInstance, mocker):
         mockSession = mocker.MagicMock()
@@ -69,10 +69,10 @@ class TestCoreProcess:
         coreInstance.addDCDWToUpdateList(mockRecord)
 
         mockSession.assert_called_once
-        assert coreInstance.records[0] == mockDocument
+        assert list(coreInstance.records)[0] == mockDocument
 
     def test_addDCDWToUpdateList_new_save_records(self, coreInstance, mocker):
-        coreInstance.records = ['record{}'.format(i) for i in range(999)]
+        coreInstance.records = set(['record{}'.format(i) for i in range(999)])
 
         mockSession = mocker.MagicMock()
         mockSession.query().filter().first.return_value = None

--- a/tests/unit/test_core_process.py
+++ b/tests/unit/test_core_process.py
@@ -96,3 +96,21 @@ class TestCoreProcess:
         coreInstance.saveRecords()
 
         mockBulkSave.assert_called_with(['record0', 'record1', 'record2'])
+    
+    def test_windowedQuery_single(self, coreInstance, mocker):
+        mockQuery = mocker.MagicMock(is_single_entity=True)
+        mockQuery.add_column().order_by.return_value = mockQuery
+        mockQuery.filter.return_value = mockQuery
+        mockQuery.limit().all.side_effect = [[('rec1', 1), ('rec2', 2), ('rec3', 3)], None]
+
+        coreInstance.ingestLimit = None
+        assert list(coreInstance.windowedQuery(mocker.MagicMock(id=1), mockQuery)) == ['rec1', 'rec2', 'rec3']
+
+    def test_windowedQuery_tuple(self, coreInstance, mocker):
+        mockQuery = mocker.MagicMock(is_single_entity=False)
+        mockQuery.add_column().order_by.return_value = mockQuery
+        mockQuery.filter.return_value = mockQuery
+        mockQuery.limit().all.side_effect = [[('rec1', 1), ('rec2', 2), ('rec3', 3)], None]
+
+        coreInstance.ingestLimit = None
+        assert list(coreInstance.windowedQuery(mocker.MagicMock(id=1), mockQuery)) == [('rec1',), ('rec2',), ('rec3',)]

--- a/tests/unit/test_cover_process.py
+++ b/tests/unit/test_cover_process.py
@@ -150,10 +150,10 @@ class TestCoverProcess:
         mockManager = mocker.MagicMock(fetcher=mockFetcher, coverFormat='tst', coverContent='testBytes')
         mockEdition = mocker.MagicMock(links=[])
 
-        testProcess.records = []
+        testProcess.records = set()
         testProcess.storeFoundCover(mockManager, mockEdition)
 
-        assert testProcess.records[0] == mockEdition
+        assert list(testProcess.records)[0] == mockEdition
         assert mockEdition.links[0].url == 'test_aws_bucket.s3.amazonaws.com/covers/test/1.tst'
         assert mockEdition.links[0].media_type == 'image/tst'
         assert mockEdition.links[0].flags == {'cover': True}

--- a/tests/unit/test_cover_process.py
+++ b/tests/unit/test_cover_process.py
@@ -11,6 +11,7 @@ class TestCoverProcess:
         class TestCoverProcess(CoverProcess):
             def __init__(self, *args):
                 self.fileBucket = 'test_aws_bucket'
+                self.batchSize = 3
 
         return TestCoverProcess()
 
@@ -35,7 +36,7 @@ class TestCoverProcess:
         mockQuery.filter.return_value = 'testQuery'
 
         mockSubQuery = mocker.MagicMock()
-        mockSubQuery.select_from().join().filter.return_value = 'subQuery'
+        mockSubQuery.select_from().join().distinct().filter.return_value = 'subQuery'
 
         testProcess.session = mocker.MagicMock()
         testProcess.session.query.side_effect = [mockQuery, mockSubQuery]
@@ -48,14 +49,14 @@ class TestCoverProcess:
         testProcess.session.query.assert_has_calls([
             mocker.call(Edition), mocker.call('edition_id')
         ])
-        mockSubQuery.select_from().join().filter.call_args[0][0].compare(Link.flags['cover'] == 'true')
+        mockSubQuery.select_from().join().distinct().filter.call_args[0][0].compare(Link.flags['cover'] == 'true')
 
     def test_generateQuery_custom_date(self, testProcess, mocker):
         mockQuery = mocker.MagicMock()
         mockQuery.filter.return_value = 'testQuery'
 
         mockSubQuery = mocker.MagicMock()
-        mockSubQuery.select_from().join().filter.return_value = 'subQuery'
+        mockSubQuery.select_from().join().distinct().filter.return_value = 'subQuery'
 
         testProcess.session = mocker.MagicMock()
         testProcess.session.query.side_effect = [mockQuery, mockSubQuery]
@@ -74,7 +75,7 @@ class TestCoverProcess:
         mockQuery.filter.return_value = 'testQuery'
 
         mockSubQuery = mocker.MagicMock()
-        mockSubQuery.select_from().join().filter.return_value = 'subQuery'
+        mockSubQuery.select_from().join().distinct().filter.return_value = 'subQuery'
 
         testProcess.session = mocker.MagicMock()
         testProcess.session.query.side_effect = [mockQuery, mockSubQuery]
@@ -93,16 +94,15 @@ class TestCoverProcess:
         assert mockQuery.filter.call_args[0][1].compare(Edition.date_modified >= testQueryDate)
 
     def test_fetchEditionCovers(self, testProcess, mocker):
-        mockQuery = mocker.MagicMock()
-        mockQuery.all.return_value = ['ed1', 'ed2', 'ed3']
-
         processMocks = mocker.patch.multiple(CoverProcess,
             searchForCover=mocker.DEFAULT,
-            storeFoundCover=mocker.DEFAULT
+            storeFoundCover=mocker.DEFAULT,
+            windowedQuery=mocker.DEFAULT
         )
         processMocks['searchForCover'].side_effect = ['manager1', None, 'manager2']
+        processMocks['windowedQuery'].return_value = ['ed1', 'ed2', 'ed3']
 
-        testProcess.fetchEditionCovers(mockQuery)
+        testProcess.fetchEditionCovers('mockQuery')
 
         processMocks['searchForCover'].assert_has_calls([
             mocker.call('ed1'), mocker.call('ed2'), mocker.call('ed3')
@@ -145,16 +145,18 @@ class TestCoverProcess:
 
     def test_storeFoundCover(self, testProcess, mocker):
         mockPut = mocker.patch.object(CoverProcess, 'putObjectInBucket')
+        mockSave = mocker.patch.object(CoverProcess, 'bulkSaveObjects')
 
         mockFetcher = mocker.MagicMock(SOURCE='test', coverID=1)
         mockManager = mocker.MagicMock(fetcher=mockFetcher, coverFormat='tst', coverContent='testBytes')
         mockEdition = mocker.MagicMock(links=[])
 
-        testProcess.records = set()
+        testProcess.records = set(['ed1', 'ed2'])
         testProcess.storeFoundCover(mockManager, mockEdition)
 
-        assert list(testProcess.records)[0] == mockEdition
+        assert list(testProcess.records) == []
         assert mockEdition.links[0].url == 'test_aws_bucket.s3.amazonaws.com/covers/test/1.tst'
         assert mockEdition.links[0].media_type == 'image/tst'
         assert mockEdition.links[0].flags == {'cover': True}
+        assert mockSave.call_args[0][0] == set(['ed1', 'ed2', mockEdition])
         mockPut.assert_called_once_with('testBytes', 'covers/test/1.tst', 'test_aws_bucket')

--- a/tests/unit/test_fetcher_hathitrust.py
+++ b/tests/unit/test_fetcher_hathitrust.py
@@ -60,6 +60,16 @@ class TestHathiFetcher:
         mockSetCover.assert_called_once_with(1, 24)
         mockRequest.assert_called_once_with('testAPIRoot/structure/1?format=json&v=2')
 
+    def test_fetchVolumeCover_mets_error(self, testFetcher, mockMETSObject, mocker):
+        mockResponse = mocker.MagicMock()
+        mockMETSObject['METS:structMap']['METS:div']['METS:div'] = {i: 'data' for i in range(25)}
+        mockResponse.json.return_value = mockMETSObject
+        mockRequest = mocker.patch.object(HathiFetcher, 'makeHathiReq')
+        mockRequest.return_value = mockResponse
+
+        with pytest.raises(HathiCoverError):
+            testFetcher.fetchVolumeCover(1)
+
     def test_fetchVolumeCover_error(self, testFetcher, mocker):
         mockRequest = mocker.patch.object(HathiFetcher, 'makeHathiReq')
         mockRequest.return_value = None

--- a/tests/unit/test_oclcClassify_process.py
+++ b/tests/unit/test_oclcClassify_process.py
@@ -151,22 +151,6 @@ class TestOCLCClassifyProcess:
         mockDatetime.timedelta.assert_not_called
         mockQuery.filter.assert_not_called
 
-    def test_windowedQuery_single(self, testInstance, mocker):
-        mockQuery = mocker.MagicMock(is_single_entity=True)
-        mockQuery.add_column().order_by.return_value = mockQuery
-        mockQuery.filter.return_value = mockQuery
-        mockQuery.limit().all.side_effect = [[('rec1',), ('rec2',), ('rec3',)], None]
-
-        assert list(testInstance.windowedQuery(mockQuery)) == ['rec1', 'rec2', 'rec3']
-
-    def test_windowedQuery_tuple(self, testInstance, mocker):
-        mockQuery = mocker.MagicMock(is_single_entity=False)
-        mockQuery.add_column().order_by.return_value = mockQuery
-        mockQuery.filter.return_value = mockQuery
-        mockQuery.limit().all.side_effect = [[('rec1', 1), ('rec2', 2), ('rec3', 3)], None]
-
-        assert list(testInstance.windowedQuery(mockQuery)) == [('rec1',), ('rec2',), ('rec3',)]
-
     def test_frbrizeRecord_success_valid_author(self, testInstance, testRecord, mocker):
         mockIdentifiers = mocker.patch.object(ClassifyManager, 'getQueryableIdentifiers')
         mockIdentifiers.return_value = ['1|test']

--- a/tests/unit/test_oclcClassify_process.py
+++ b/tests/unit/test_oclcClassify_process.py
@@ -140,16 +140,15 @@ class TestOCLCClassifyProcess:
 
         mockSession.query().filter.return_value = mockQuery
         mockRecords = [mocker.MagicMock(name=i) for i in range(100)]
-        mockQuery.yield_per.return_value = mockRecords
+        mockWindowed = mocker.patch.object(ClassifyProcess, 'windowedQuery')
+        mockWindowed.return_value = mockRecords
 
         testInstance.ingestLimit = 100
         testInstance.classifyRecords(full=True)
 
-        mockSession.query.filter.assert_called_once
-        mockSession.query.limit.assert_called_once
-        mockDatetime.utcnow.assert_not_called
-        mockDatetime.timedelta.assert_not_called
-        mockQuery.filter.assert_not_called
+        mockDatetime.utcnow.assert_not_called()
+        mockDatetime.timedelta.assert_not_called()
+        mockFrbrize.assert_has_calls([mocker.call(rec) for rec in mockRecords])
 
     def test_frbrizeRecord_success_valid_author(self, testInstance, testRecord, mocker):
         mockIdentifiers = mocker.patch.object(ClassifyManager, 'getQueryableIdentifiers')

--- a/tests/unit/test_oclcClassify_process.py
+++ b/tests/unit/test_oclcClassify_process.py
@@ -22,7 +22,7 @@ class TestOCLCClassifyProcess:
     def testInstance(self, mocker):
         class TestClassifyProcess(ClassifyProcess):
             def __init__(self, *args):
-                self.records = []
+                self.records = set()
                 self.ingestLimit = None
                 self.rabbitQueue = os.environ['OCLC_QUEUE']
                 self.rabbitRoute = os.environ['OCLC_ROUTING_KEY']


### PR DESCRIPTION
Real-world testing has revealed several issues with the interactions between the DRB application and its PostgreSQL database. This aims to resolve those issues by:

- Adding additional `CASCADE` constraints to foreign keys to allow records to be properly deleted by the `ClusterProcess`
- Update the bulk save operations code to prevent race conditions, particularly in the `OCLCClassifyProcess`
- Add additional indexes on several important columns