### PR TITLE
NOREF Fix Single Record Clustering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Race conditions in OCLC Classify fetching process
 - Missing CASCADE constraints on several database tables
 - Missing indexes on several database tables
+- Fix processing of single record works at the clustering stage
 
 ## 2021-02-23 -- v0.2.3
 ### Fixed

--- a/processes/sfrCluster.py
+++ b/processes/sfrCluster.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timedelta
-import os
 import re
 
 from .core import CoreProcess
@@ -51,19 +50,21 @@ class ClusterProcess(CoreProcess):
         self.closeConnection()
 
     def clusterRecord(self, rec):
+        print(rec.title, rec.source_id)
         matchedIDs = self.findAllMatchingRecords(rec.identifiers)
 
         filterParams = None
         if len(matchedIDs) < 1:
             filterParams = Record.uuid == rec.uuid
+            matchedIDs = [rec.id]
         else:
             filterParams = Record.id.in_(matchedIDs)
 
-            clusteredEditions, instances = self.clusterMatchedRecords(matchedIDs)
-            dbWork = self.createWorkFromEditions(clusteredEditions, instances)
-            self.session.flush()
+        clusteredEditions, instances = self.clusterMatchedRecords(matchedIDs)
+        dbWork = self.createWorkFromEditions(clusteredEditions, instances)
+        self.session.flush()
 
-            self.indexWorkInElasticSearch(dbWork)
+        self.indexWorkInElasticSearch(dbWork)
 
         self.session.query(Record)\
             .filter(filterParams)\

--- a/tests/unit/test_sfrCluster_process.py
+++ b/tests/unit/test_sfrCluster_process.py
@@ -25,11 +25,7 @@ class TestSFRClusterProcess:
 
     @pytest.fixture
     def testRecord(self, mocker):
-        mockRecord = mocker.MagicMock()
-        mockRecord.identifiers = ['1|test']
-        mockRecord.uuid = 'testUUID'
-
-        return mockRecord
+        return mocker.MagicMock(id=1, identifiers=['1|test'], uuid='testUUID')
 
     def test_runProcess_daily(self, testInstance, mocker):
         mockCluster = mocker.patch.object(ClusterProcess, 'clusterRecords')
@@ -161,7 +157,9 @@ class TestSFRClusterProcess:
         mockFindMatching = mocker.patch.object(ClusterProcess, 'findAllMatchingRecords')
         mockFindMatching.return_value = []
         mockClusterMatched = mocker.patch.object(ClusterProcess, 'clusterMatchedRecords')
+        mockClusterMatched.return_value = (['ed1'], ['inst1'])
         mockCreateFromEds = mocker.patch.object(ClusterProcess, 'createWorkFromEditions')
+        mockCreateFromEds.return_value = 'testDBWork'
         mockIndexInES = mocker.patch.object(ClusterProcess, 'indexWorkInElasticSearch')
         mockCommit = mocker.patch.object(ClusterProcess, 'commitChanges')
 
@@ -170,10 +168,10 @@ class TestSFRClusterProcess:
         testInstance.clusterRecord(testRecord)
 
         mockFindMatching.assert_called_once_with(['1|test'])
-        mockClusterMatched.assert_not_called
-        mockCreateFromEds.assert_not_called
-        mockIndexInES.assert_not_called
-        mockSession.flush.assert_not_called()
+        mockClusterMatched.assert_called_once_with([1])
+        mockCreateFromEds.assert_called_once_with(['ed1'], ['inst1'])
+        mockIndexInES.assert_called_once_with('testDBWork')
+        mockSession.flush.assert_called_once()
         mockSession.query.assert_called_once()
         mockCommit.assert_called_once()
 


### PR DESCRIPTION
Due to a information flow misjudgement the clustering stage was skipping clustering single record works. These are valid records that have no FRBRized data because they lack adequate identifiers or simply because they are rare. This should not disqualify them from being indexed and this update ensures that they are.