### PR TITLE
SFR-1007 Update NYPL records

### DIFF
--- a/api/utils.py
+++ b/api/utils.py
@@ -60,13 +60,18 @@ class APIUtils():
                 continue
 
             editionDict = dict(edition)
+            editionDict['edition_id'] = edition.id
             editionDict['items'] = []
 
             for item in edition.items:
                 itemDict = dict(item)
+                itemDict['item_id'] = item.id
+                itemDict['location'] = item.physical_location['name'] if item.physical_location else None
                 itemDict['links'] = []
                 for link in item.links:
-                    itemDict['links'].append(dict(link))
+                    linkDict = dict(link)
+                    linkDict['item_id'] = link.id
+                    itemDict['links'].append(linkDict)
 
                 editionDict['items'].append(itemDict)
 

--- a/mappings/nypl.py
+++ b/mappings/nypl.py
@@ -68,7 +68,7 @@ class NYPLMapping(SQLMapping):
                 ('656', '{a}|{2}|'),
                 ('690', '{a} -- {b} -- {v} -- {x} -- {z}|lcsh|{0}'),
             ],
-            'has_part': [('856', '1|{u}|nypl|catalog|{z}')],
+            'has_part': [('856', '1|{u}|nypl|text/html|{z}')],
         }
 
     def applyMapping(self):
@@ -126,7 +126,7 @@ class NYPLMapping(SQLMapping):
 
         # Add catalog link derived from nypl identifier if 856 field is not present
         if len(self.record.has_part) < 1:
-            self.record.has_part.append('1|{}|nypl|catalog|text/html'.format(
+            self.record.has_part.append('1|{}|nypl|text/html|{{}}'.format(
                 'https://www.nypl.org/research/collections/shared-collection-catalog/bib/b{}'.format(self.source['id'])
             ))
 
@@ -144,7 +144,7 @@ class NYPLMapping(SQLMapping):
                     item['location']['code'], item['location']['name'], pos
                 ))
 
-                self.record.has_part.append('{}|{}|nypl|edd|text/html'.format(
+                self.record.has_part.append('{}|{}|nypl|application/x.html+edd|{{}}'.format(
                     pos,
-                    'http://www.nypl.com/research/collections/shared-collection-catalog/hold/request/b{}-i{}'.format(self.source['id'], item['id'])
+                    'http://www.nypl.org/research/collections/shared-collection-catalog/hold/request/b{}-i{}'.format(self.source['id'], item['id'])
                 ))

--- a/tests/unit/test_api_utils.py
+++ b/tests/unit/test_api_utils.py
@@ -46,7 +46,7 @@ class TestAPIUtils:
 
     @pytest.fixture
     def testItem(self, MockDBObject, testLink):
-        return MockDBObject(id='it1', links=[testLink])
+        return MockDBObject(id='it1', links=[testLink], physical_location={'name': 'test'})
 
     @pytest.fixture
     def testEdition(self, MockDBObject, testItem):
@@ -116,6 +116,7 @@ class TestAPIUtils:
         assert testWorkDict['title'] == 'Test Title'
         assert testWorkDict['editions'][0]['id'] == 'ed1'
         assert testWorkDict['editions'][0]['items'][0]['id'] == 'it1'
+        assert testWorkDict['editions'][0]['items'][0]['location'] == 'test'
         assert testWorkDict['editions'][0]['items'][0]['links'][0]['id'] == 'li1'
 
     def test_formatWork_showAll_false(self, testWork):

--- a/tests/unit/test_nypl_mapping.py
+++ b/tests/unit/test_nypl_mapping.py
@@ -103,6 +103,6 @@ class TestNYPLMapping:
         assert testMapping.record.contributors == ['Contributor|1234|n9876|Tester']
         assert testMapping.record.coverage == ['tst|Test|2']
         assert testMapping.record.has_part == [
-            '1|https://www.nypl.org/research/collections/shared-collection-catalog/bib/b1|nypl|catalog|text/html',
-            '2|http://www.nypl.com/research/collections/shared-collection-catalog/hold/request/b1-i1|nypl|edd|text/html'
+            '1|https://www.nypl.org/research/collections/shared-collection-catalog/bib/b1|nypl|text/html|{}',
+            '2|http://www.nypl.org/research/collections/shared-collection-catalog/hold/request/b1-i1|nypl|application/x.html+edd|{}'
         ]


### PR DESCRIPTION
This updates NYPL bib records both on ingest and in the API response.

On ingest it updates the `media_type` values to `text/html` for catalog pages and to `application/x.html+edd` for EDD options. The second option here is temporary pending discussion and may be udpated later. This also fixes an error assigning some URLs to `nypl.com`

In the API response it sets a `location` value for item records for context with NYPL items and adds `item_id` and `edition_id` to the response for context as well