### PR TITLE
SFR-1010 Update API Response Links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## unreleased -- v0.2.4
+### Added
+- Language and Total Record count API endpoints
+- Stand-alone Edition detail API endpoint
+### Fixed
+- Updated API responses to include unique ids for edition, item and link objects
+- Added `mediaType` field to link response objects
+
 ## 2021-02-23 -- v0.2.3
 ### Fixed
 - Update RabbitMQ client to work with credentials, virtual hosts and non-default exchanges

--- a/api/app.py
+++ b/api/app.py
@@ -1,12 +1,10 @@
-from elasticsearch_dsl import Search, Q
-from flask import Flask, request, Response
+from flask import Flask
 from flask_cors import CORS
 import os
 from waitress import serve
 
 from logger import createLog
-from model import Work
-from .blueprints import search, work, info
+from .blueprints import search, work, info, edition, utils
 
 logger = createLog(__name__)
 
@@ -21,6 +19,8 @@ class FlaskAPI:
         self.app.register_blueprint(info)
         self.app.register_blueprint(search)
         self.app.register_blueprint(work)
+        self.app.register_blueprint(edition)
+        self.app.register_blueprint(utils)
 
     def run(self):
         if os.environ['ENVIRONMENT'] == 'local':

--- a/api/blueprints/__init__.py
+++ b/api/blueprints/__init__.py
@@ -1,3 +1,5 @@
 from .drbInfo import info
 from .drbSearch import search
 from .drbWork import work
+from .drbEdition import edition
+from .drbUtils import utils

--- a/api/blueprints/drbEdition.py
+++ b/api/blueprints/drbEdition.py
@@ -1,0 +1,36 @@
+from flask import Blueprint, request, current_app
+from ..db import DBClient
+from ..utils import APIUtils
+from logger import createLog
+
+logger = createLog(__name__)
+
+edition = Blueprint('edition', __name__, url_prefix='/edition')
+
+@edition.route('/<editionID>', methods=['GET'])
+def editionFetch(editionID):
+    logger.info('Fetching Edition #{}'.format(editionID))
+
+    dbClient = DBClient(current_app.config['DB_CLIENT'])
+
+    searchParams = APIUtils.normalizeQueryParams(request.args)
+    showAll = searchParams.get('showAll', ['true'])[0].lower() != 'false'
+
+    edition = dbClient.fetchSingleEdition(editionID)
+
+    if not edition:
+        logger.warning('Edition Fetch 404 on /edition/{}'.format(editionID))
+
+        return APIUtils.formatResponseObject(
+            404,
+            'singleEdition',
+            {'message': 'Unable to locate edition with id {}'.format(editionID)}
+        )
+
+    logger.debug('Edition Fetch 200 on /edition/{}'.format(editionID))
+
+    return APIUtils.formatResponseObject(
+        200,
+        'singleEdition',
+        APIUtils.formatEditionOutput(edition, showAll=showAll)
+    )

--- a/api/blueprints/drbSearch.py
+++ b/api/blueprints/drbSearch.py
@@ -14,18 +14,20 @@ def standardQuery():
     dbClient = DBClient(current_app.config['DB_CLIENT'])
 
     searchParams = APIUtils.normalizeQueryParams(request.args)
-    queryTerms = APIUtils.extractParamPairs(searchParams.get('query', []))
-    sortTerms = APIUtils.extractParamPairs(searchParams.get('sort', []))
 
-    filterTerms = APIUtils.extractParamPairs(searchParams.get('filter', []))
-    filterTerms.extend(APIUtils.extractParamPairs(searchParams.get('showAll', [])))
+    terms = {}
+    for param in ['query', 'sort', 'filter', 'showAll']:
+        terms[param] = APIUtils.extractParamPairs(param, searchParams)
+
+    if terms.get('showAll', None):
+        terms['filter'].append(terms['showAll'][0])
 
     searchPage = searchParams.get('page', [0])[0]
     searchSize = searchParams.get('size', [10])[0]
 
-    logger.info('Executing ES Query {} with filters {}'.format(searchParams, filterTerms))
+    logger.info('Executing ES Query {} with filters {}'.format(searchParams, terms['filter']))
 
-    searchResult = esClient.searchQuery(queryTerms, sortTerms, filterTerms, page=searchPage, perPage=searchSize)
+    searchResult = esClient.searchQuery(terms, page=searchPage, perPage=searchSize)
 
     resultIds = [
         (r.uuid, [e.edition_id for e in r.meta.inner_hits.editions.hits])

--- a/api/blueprints/drbSearch.py
+++ b/api/blueprints/drbSearch.py
@@ -21,6 +21,7 @@ def standardQuery():
 
     if terms.get('showAll', None):
         terms['filter'].append(terms['showAll'][0])
+        del terms['showAll']
 
     searchPage = searchParams.get('page', [0])[0]
     searchSize = searchParams.get('size', [10])[0]

--- a/api/blueprints/drbUtils.py
+++ b/api/blueprints/drbUtils.py
@@ -1,0 +1,36 @@
+from flask import Blueprint, jsonify, current_app, request
+
+from ..db import DBClient
+from ..elastic import ElasticClient
+from ..utils import APIUtils
+from logger import createLog
+
+logger = createLog(__name__)
+
+
+utils = Blueprint('utils', __name__, url_prefix='/utils')
+
+@utils.route('/languages', methods=['GET'])
+def languageCounts():
+    esClient = ElasticClient(current_app.config['ES_CLIENT'])
+
+    reqParams = APIUtils.normalizeQueryParams(request.args)
+    workCounts = reqParams.get('totals', ['true'])[0].lower() != 'false'
+
+    langResult = esClient.languageQuery(workCounts)
+
+    languageList = APIUtils.formatLanguages(langResult.aggregations)
+
+    logger.debug('Language list 200 OK on /utils/languages')
+
+    return APIUtils.formatResponseObject(200, 'languageCounts', languageList)
+
+@utils.route('/counts', methods=['GET'])
+def totalCounts():
+    dbClient = DBClient(current_app.config['DB_CLIENT'])
+
+    totalResult = dbClient.fetchRowCounts()
+
+    totalsSummary = APIUtils.formatTotals(totalResult)
+
+    return APIUtils.formatResponseObject(200, 'totalCounts', totalsSummary)

--- a/api/blueprints/drbUtils.py
+++ b/api/blueprints/drbUtils.py
@@ -19,7 +19,7 @@ def languageCounts():
 
     langResult = esClient.languageQuery(workCounts)
 
-    languageList = APIUtils.formatLanguages(langResult.aggregations)
+    languageList = APIUtils.formatLanguages(langResult.aggregations, workCounts)
 
     logger.debug('Language list 200 OK on /utils/languages')
 

--- a/api/blueprints/drbWork.py
+++ b/api/blueprints/drbWork.py
@@ -1,6 +1,4 @@
-from flask import (
-    Blueprint, request, session, url_for, redirect, current_app, jsonify
-)
+from flask import Blueprint, request, current_app
 from ..db import DBClient
 from ..utils import APIUtils
 from logger import createLog

--- a/api/db.py
+++ b/api/db.py
@@ -1,4 +1,5 @@
 from sqlalchemy.orm import sessionmaker
+from sqlalchemy.sql import text
 
 from model import Work, Edition, Item, Link, Rights, Identifier
 from model.postgres.item import ITEM_LINKS
@@ -36,3 +37,14 @@ class DBClient():
             .outerjoin(Item, ITEM_LINKS, Link)\
             .filter(Edition.id == editionID).first()
 
+    def fetchRowCounts(self):
+        session = sessionmaker(bind=self.engine)()
+
+        countQuery = text("""SELECT relname AS table, reltuples AS row_count
+            FROM pg_class c JOIN pg_namespace n ON (n.oid = c.relnamespace)
+            WHERE nspname NOT IN ('pg_catalog', 'information_schema')
+            AND relkind = 'r'
+            AND relname IN ('records', 'works', 'editions', 'items', 'links')
+        """)
+
+        return session.execute(countQuery)

--- a/api/db.py
+++ b/api/db.py
@@ -28,3 +28,11 @@ class DBClient():
             .join(Edition)\
             .join(Item, ITEM_LINKS, Link)\
             .filter(Work.uuid == uuid).first()
+
+    def fetchSingleEdition(self, editionID, showAll=False):
+        session = sessionmaker(bind=self.engine)()
+
+        return session.query(Edition)\
+            .outerjoin(Item, ITEM_LINKS, Link)\
+            .filter(Edition.id == editionID).first()
+

--- a/api/db.py
+++ b/api/db.py
@@ -1,7 +1,7 @@
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.sql import text
 
-from model import Work, Edition, Item, Link, Rights, Identifier
+from model import Work, Edition, Item, Link
 from model.postgres.item import ITEM_LINKS
 from .utils import APIUtils
 
@@ -15,12 +15,11 @@ class DBClient():
 
         session = sessionmaker(bind=self.engine)()
 
-        query = session.query(Work)\
+        return session.query(Work)\
             .join(Edition)\
             .join(Item, ITEM_LINKS, Link)\
-            .filter(Edition.id.in_(editionIds))
-
-        return query.all()
+            .filter(Edition.id.in_(editionIds))\
+            .all()
 
     def fetchSingleWork(self, uuid):
         session = sessionmaker(bind=self.engine)()

--- a/api/elastic.py
+++ b/api/elastic.py
@@ -55,6 +55,30 @@ class ElasticClient():
 
         return coreSearch.execute()
 
+    def languageQuery(self, workTotals):
+        search = self.createSearch()
+
+        query = search.query(Q())[:0]
+
+        languageAgg = query.aggs.bucket('languages', A('nested', path='editions.languages'))\
+            .bucket('languages', 'terms', **{'field': 'editions.languages.language', 'size': 250})
+
+        if workTotals:
+            languageAgg.bucket('work_totals', 'reverse_nested')
+
+        return query.execute()
+
+    def totalsQuery(self):
+        search = self.createSearch()
+
+        query = search.query(Q())[:0]
+
+        query.aggs.bucket('editions', A('nested', path='editions'))\
+            .bucket('items', A('nested', path='editions.items'))
+        query.aggs.bucket('links', A('nested', path='editions.items.links'))
+
+        return query.execute()
+
     @classmethod
     def titleQuery(cls, titleText):
         return Q('bool',

--- a/api/elastic.py
+++ b/api/elastic.py
@@ -68,17 +68,6 @@ class ElasticClient():
 
         return query.execute()
 
-    def totalsQuery(self):
-        search = self.createSearch()
-
-        query = search.query(Q())[:0]
-
-        query.aggs.bucket('editions', A('nested', path='editions'))\
-            .bucket('items', A('nested', path='editions.items'))
-        query.aggs.bucket('links', A('nested', path='editions.items.links'))
-
-        return query.execute()
-
     @classmethod
     def titleQuery(cls, titleText):
         return Q('bool',

--- a/api/elastic.py
+++ b/api/elastic.py
@@ -21,13 +21,13 @@ class ElasticClient():
     def createSearch(self):
         return Search(using=self.client, index=os.environ['ELASTICSEARCH_INDEX'])
 
-    def searchQuery(self, searchParams, sortParams, filterParams, page=0, perPage=10):
+    def searchQuery(self, params, page=0, perPage=10):
         startPos, endPos = ElasticClient.getFromSize(page, perPage)
         search = self.createSearch()
         search.source(['uuid', 'editions'])
 
         searchClauses = []
-        for field, query in searchParams:
+        for field, query in params['query']:
             if field is None or field == 'keyword':
                 searchClauses.append(Q('bool',
                     should=[
@@ -49,9 +49,9 @@ class ElasticClient():
 
         coreSearch = search.query(Q('bool', must=searchClauses))[startPos:endPos]
 
-        coreSearch = ElasticClient.addFilterClausesAndAggregations(coreSearch, filterParams)
+        coreSearch = ElasticClient.addFilterClausesAndAggregations(coreSearch, params['filter'])
 
-        coreSearch = ElasticClient.addSortClause(coreSearch, sortParams)
+        coreSearch = ElasticClient.addSortClause(coreSearch, params['sort'])
 
         return coreSearch.execute()
 
@@ -193,6 +193,8 @@ class ElasticClient():
             query = query.query('bool', must=filters)
         elif len(appliedFilters) > 0:
             query = query.query('nested', path='editions', inner_hits={'size': 100}, query=Q('bool', must=appliedFilters))
+        else:
+            query = query.query('nested', path='editions', inner_hits={'size': 100}, query=Q('match_all'))
 
         return query
 

--- a/api/utils.py
+++ b/api/utils.py
@@ -59,22 +59,44 @@ class APIUtils():
             if editionIds and edition.id not in editionIds:
                 continue
 
-            editionDict = dict(edition)
-            editionDict['items'] = []
-
-            for item in edition.items:
-                itemDict = dict(item)
-                itemDict['links'] = []
-                for link in item.links:
-                    itemDict['links'].append(dict(link))
-
-                editionDict['items'].append(itemDict)
+            editionDict = cls.formatEdition(edition)
 
             if showAll is True or (showAll is False and len(editionDict['items']) > 0):
                 workDict['editions'].append(editionDict)
 
         return workDict
 
+    @classmethod
+    def formatEditionOutput(cls, edition, showAll):
+        return cls.formatEdition(edition)
+
+    @classmethod
+    def formatEdition(cls, edition):
+        editionDict = dict(edition)
+        editionDict['edition_id'] = edition.id
+        editionDict['items'] = []
+
+        for item in edition.items:
+            itemDict = dict(item)
+            itemDict['item_id'] = item.id
+            itemDict['links'] = []
+            for link in item.links:
+                itemDict['links'].append({'link_id': link.id, 'mediaType': link.media_type})
+
+            editionDict['items'].append(itemDict)
+
+        return editionDict
+
+    @classmethod
+    def formatLanguages(cls, aggregations):
+        return sorted([
+            {'language': lang.key, 'work_total': lang.work_totals.doc_count}
+            for lang in aggregations.languages.languages.buckets
+        ], key=lambda x: x['work_total'], reverse=True)
+
+    @classmethod
+    def formatTotals(cls, response):
+        return {r[0]: r[1] for r in response}
 
     @classmethod
     def flatten(cls, nested):

--- a/api/utils.py
+++ b/api/utils.py
@@ -8,10 +8,10 @@ class APIUtils():
         return {k: v for k, v in paramDict.items()}
 
     @staticmethod
-    def extractParamPairs(paramPairs):
+    def extractParamPairs(param, pairs):
         return [
-            tuple(p.split(':')) if len(p.split(':')) > 1 else (None, p)
-            for p in paramPairs
+            tuple(p.split(':')) if len(p.split(':')) > 1 else (param, p)
+            for p in pairs.get(param, [])
         ]
 
     @classmethod

--- a/api/utils.py
+++ b/api/utils.py
@@ -88,11 +88,17 @@ class APIUtils():
         return editionDict
 
     @classmethod
-    def formatLanguages(cls, aggregations):
-        return sorted([
-            {'language': lang.key, 'work_total': lang.work_totals.doc_count}
-            for lang in aggregations.languages.languages.buckets
-        ], key=lambda x: x['work_total'], reverse=True)
+    def formatLanguages(cls, aggregations, counts=False):
+        if counts:
+            return sorted([
+                {'language': lang.key, 'work_total': lang.work_totals.doc_count}
+                for lang in aggregations.languages.languages.buckets
+            ], key=lambda x: x['work_total'], reverse=True)
+        else:
+            return sorted(
+                [{'language': lang.key} for lang in aggregations.languages.languages.buckets],
+                key=lambda x: x['language']
+            )
 
     @classmethod
     def formatTotals(cls, response):

--- a/tests/unit/test_api_edition_blueprint.py
+++ b/tests/unit/test_api_edition_blueprint.py
@@ -1,0 +1,71 @@
+from flask import Flask
+import pytest
+
+from api.blueprints.drbEdition import editionFetch
+from api.utils import APIUtils
+
+class TestEditionBlueprint:
+    @pytest.fixture
+    def mockUtils(self, mocker):
+        return mocker.patch.multiple(
+            APIUtils,
+            normalizeQueryParams=mocker.DEFAULT,
+            formatResponseObject=mocker.DEFAULT,
+            formatEditionOutput=mocker.DEFAULT
+        )
+    
+    @pytest.fixture
+    def testApp(self):
+        flaskApp = Flask('test')
+        flaskApp.config['DB_CLIENT'] = 'testDBClient'
+
+        return flaskApp
+
+    def test_editionFetch_success(self, mockUtils, testApp, mocker):
+        mockDB = mocker.MagicMock()
+        mockDBClient = mocker.patch('api.blueprints.drbEdition.DBClient')
+        mockDBClient.return_value = mockDB
+
+        mockUtils['normalizeQueryParams'].return_value = {'showAll': ['true']}
+        
+        mockDB.fetchSingleEdition.return_value = 'dbEditionRecord'
+
+        mockUtils['formatEditionOutput'].return_value = 'testEdition'
+        mockUtils['formatResponseObject'].return_value = 'singleEditionResponse'
+
+        with testApp.test_request_context('/'):
+            testAPIResponse = editionFetch(1)
+
+            assert testAPIResponse == 'singleEditionResponse'
+            mockDBClient.assert_called_once_with('testDBClient')
+
+            mockUtils['normalizeQueryParams'].assert_called_once()
+            mockUtils['formatEditionOutput'].assert_called_once_with(
+                'dbEditionRecord', showAll=True
+            )
+            mockUtils['formatResponseObject'].assert_called_once_with(
+                200, 'singleEdition', 'testEdition'
+            )
+
+    def test_editionFetch_missing(self, mockUtils, testApp, mocker):
+        mockDB = mocker.MagicMock()
+        mockDBClient = mocker.patch('api.blueprints.drbEdition.DBClient')
+        mockDBClient.return_value = mockDB
+
+        mockUtils['normalizeQueryParams'].return_value = {'showAll': ['true']}
+        
+        mockDB.fetchSingleEdition.return_value = None
+
+        mockUtils['formatResponseObject'].return_value = '404Response'
+
+        with testApp.test_request_context('/'):
+            testAPIResponse = editionFetch(1)
+
+            assert testAPIResponse == '404Response'
+            mockDBClient.assert_called_once_with('testDBClient')
+
+            mockUtils['normalizeQueryParams'].assert_called_once()
+            mockUtils['formatEditionOutput'].assert_not_called()
+            mockUtils['formatResponseObject'].assert_called_once_with(
+                404, 'singleEdition', {'message': 'Unable to locate edition with id 1'}
+            )

--- a/tests/unit/test_api_search_blueprint.py
+++ b/tests/unit/test_api_search_blueprint.py
@@ -63,9 +63,9 @@ class TestSearchBlueprint:
         mockDBClient = mocker.patch('api.blueprints.drbSearch.DBClient')
         mockDBClient.return_value = mockDB
 
-        mockUtils['normalizeQueryParams'].return_value = {
-            'query': ['q1', 'q2'], 'sort': ['s1'], 'size': [5]
-        }
+        queryParams = {'query': ['q1', 'q2'], 'sort': ['s1'], 'size': [5]}
+        mockUtils['normalizeQueryParams'].return_value = queryParams
+            
         mockUtils['extractParamPairs'].side_effect = [
             ['testQueryTerms'], ['testSortTerms'], ['testFilterTerms'], ['testShowAll']
         ]
@@ -94,10 +94,13 @@ class TestSearchBlueprint:
 
             mockUtils['normalizeQueryParams'].assert_called_once
             mockUtils['extractParamPairs'].assert_has_calls([
-                mocker.call(['q1', 'q2']), mocker.call(['s1']), mocker.call([])
+                mocker.call('query', queryParams),
+                mocker.call('sort', queryParams),
+                mocker.call('filter', queryParams),
+                mocker.call('showAll', queryParams)
             ])
             mockES.searchQuery.assert_called_once_with(
-                ['testQueryTerms'], ['testSortTerms'], ['testFilterTerms', 'testShowAll'],
+                {'query': ['testQueryTerms'], 'sort': ['testSortTerms'], 'filter': ['testFilterTerms', 'testShowAll']},
                 page=0, perPage=5
             )
             mockDB.fetchSearchedWorks.assert_called_once_with([

--- a/tests/unit/test_api_utils.py
+++ b/tests/unit/test_api_utils.py
@@ -42,7 +42,7 @@ class TestAPIUtils:
 
     @pytest.fixture
     def testLink(self, MockDBObject):
-        return MockDBObject(id='li1')
+        return MockDBObject(id='li1', media_type='application/test')
 
     @pytest.fixture
     def testItem(self, MockDBObject, testLink):
@@ -65,11 +65,10 @@ class TestAPIUtils:
         assert testParams == {'test1': 1, 'test2': 2}
 
     def test_extractParamPairs(self):
-        testPairs = APIUtils.extractParamPairs(['test:value', 'bareValue'])
+        testPairs = APIUtils.extractParamPairs('test', {'test': ['test:value', 'bareValue']})
 
-        print(testPairs)
         assert testPairs[0] == ('test', 'value')
-        assert testPairs[1] == (None, 'bareValue')
+        assert testPairs[1] == ('test', 'bareValue')
 
     def test_formatAggregationResult(self, testAggregationResp):
         languageAggregations = APIUtils.formatAggregationResult(testAggregationResp)
@@ -109,22 +108,26 @@ class TestAPIUtils:
             mocker.call('testWork2', [1, 2, 3], True)
         ])
 
-    def test_formatWork_showAll(self, testWork):
+    def test_formatWork_showAll(self, testWork, mocker):
+        mockFormatEdition = mocker.patch.object(APIUtils, 'formatEdition')
+        mockFormatEdition.return_value = {'edition_id': 'ed1', 'items': ['it1']}
+
         testWorkDict = APIUtils.formatWork(testWork, ['ed1'], True)
 
         assert testWorkDict['uuid'] == 'testUUID'
         assert testWorkDict['title'] == 'Test Title'
-        assert testWorkDict['editions'][0]['id'] == 'ed1'
-        assert testWorkDict['editions'][0]['items'][0]['id'] == 'it1'
-        assert testWorkDict['editions'][0]['items'][0]['links'][0]['id'] == 'li1'
+        assert testWorkDict['editions'][0]['edition_id'] == 'ed1'
+        assert testWorkDict['editions'][0]['items'][0] == 'it1'
+        mockFormatEdition.assert_called_once()
 
-    def test_formatWork_showAll_false(self, testWork):
-        testWork.editions[0].items = []
+    def test_formatWork_showAll_false(self, testWork, mocker):
+        mockFormatEdition = mocker.patch.object(APIUtils, 'formatEdition')
+        mockFormatEdition.return_value = {'edition_id': 'ed1', 'items': ['it1']}
         testWorkDict = APIUtils.formatWork(testWork, ['ed1'], False)
 
         assert testWorkDict['uuid'] == 'testUUID'
         assert testWorkDict['title'] == 'Test Title'
-        assert len(testWorkDict['editions']) == 0
+        assert len(testWorkDict['editions']) == 1
 
     def test_formatWork_blocked_edition(self, testWork):
         testWork.editions[0].items = []
@@ -133,6 +136,43 @@ class TestAPIUtils:
         assert testWorkDict['uuid'] == 'testUUID'
         assert testWorkDict['title'] == 'Test Title'
         assert len(testWorkDict['editions']) == 0
+
+    def test_formatEditionOputput(self, mocker):
+        mockFormatEdition = mocker.patch.object(APIUtils, 'formatEdition')
+        mockFormatEdition.return_value = 'testEdition'
+
+        assert APIUtils.formatEditionOutput(1, True) == 'testEdition'
+
+    def test_formatEdition(self, testEdition):
+        formattedEdition = APIUtils.formatEdition(testEdition)
+
+        assert formattedEdition['edition_id'] == 'ed1'
+        assert formattedEdition['items'][0]['item_id'] == 'it1'
+        assert formattedEdition['items'][0]['links'][0]['link_id'] == 'li1'
+        assert formattedEdition['items'][0]['links'][0]['mediaType'] == 'application/test'
+
+    def test_formatLanguages_no_counts(self, mocker):
+        mockAggs = mocker.MagicMock()
+        mockAggs.languages.languages.buckets = [mocker.MagicMock(key='bLang'), mocker.MagicMock(key='aLang')]
+
+        assert APIUtils.formatLanguages(mockAggs) == [{'language': 'aLang'}, {'language': 'bLang'}]
+
+    def test_formatLanguages_counts(self, mocker):
+        mockAggs = mocker.MagicMock()
+        mockAggs.languages.languages.buckets = [
+            mocker.MagicMock(key='bLang', work_totals=mocker.MagicMock(doc_count=10)),
+            mocker.MagicMock(key='cLang', work_totals=mocker.MagicMock(doc_count=30)),
+            mocker.MagicMock(key='aLang', work_totals=mocker.MagicMock(doc_count=20))
+        ]
+
+        assert APIUtils.formatLanguages(mockAggs, True) == [
+            {'language': 'cLang', 'work_total': 30},
+            {'language': 'aLang', 'work_total': 20},
+            {'language': 'bLang', 'work_total': 10}
+        ]
+
+    def test_formatTotals(self):
+        assert APIUtils.formatTotals([('test', 3), ('other', 6)]) == {'test': 3, 'other': 6}
 
     def test_flatten_already_flat(self):
         flatArray = [i for i in APIUtils.flatten([1, 2, 3, 4, 5])]

--- a/tests/unit/test_api_utils_blueprint.py
+++ b/tests/unit/test_api_utils_blueprint.py
@@ -1,0 +1,71 @@
+from flask import Flask
+import pytest
+
+from api.blueprints.drbUtils import languageCounts, totalCounts
+from api.utils import APIUtils
+
+class TestEditionBlueprint:
+    @pytest.fixture
+    def mockUtils(self, mocker):
+        return mocker.patch.multiple(
+            APIUtils,
+            normalizeQueryParams=mocker.DEFAULT,
+            formatResponseObject=mocker.DEFAULT,
+            formatLanguages=mocker.DEFAULT,
+            formatTotals=mocker.DEFAULT
+        )
+    
+    @pytest.fixture
+    def testApp(self):
+        flaskApp = Flask('test')
+        flaskApp.config['DB_CLIENT'] = 'testDBClient'
+        flaskApp.config['ES_CLIENT'] = 'testESClient'
+
+        return flaskApp
+
+    def test_languageCounts(self, mockUtils, testApp, mocker):
+        mockES = mocker.MagicMock()
+        mockESClient = mocker.patch('api.blueprints.drbUtils.ElasticClient')
+        mockESClient.return_value = mockES
+
+        mockUtils['normalizeQueryParams'].return_value = {'totals': ['true']}
+        
+        mockES.languageQuery.return_value = mocker.MagicMock(aggregations=['lang1', 'lang2'])
+
+        mockUtils['formatLanguages'].return_value = 'testLanguageList'
+        mockUtils['formatResponseObject'].return_value = 'languageListResponse'
+
+        with testApp.test_request_context('/?totals=true'):
+            testAPIResponse = languageCounts()
+
+            assert testAPIResponse == 'languageListResponse'
+            mockESClient.assert_called_once_with('testESClient')
+
+            mockUtils['normalizeQueryParams'].assert_called_once()
+            mockES.languageQuery.assert_called_once_with(True)
+            mockUtils['formatLanguages'].assert_called_once_with(['lang1', 'lang2'], True)
+            mockUtils['formatResponseObject'].assert_called_once_with(
+                200, 'languageCounts', 'testLanguageList'
+            )
+
+    def test_totalCounts(self, mockUtils, testApp, mocker):
+        mockDB = mocker.MagicMock()
+        mockDBClient = mocker.patch('api.blueprints.drbUtils.DBClient')
+        mockDBClient.return_value = mockDB
+
+        mockDB.fetchRowCounts.return_value = 'testTotalResult'
+
+        mockUtils['formatTotals'].return_value = 'testTotalSummary'
+        mockUtils['formatResponseObject'].return_value = 'totalsResponse'
+
+        with testApp.test_request_context('/'):
+            testAPIResponse = totalCounts()
+
+            assert testAPIResponse == 'totalsResponse'
+            mockDBClient.assert_called_once_with('testDBClient')
+
+            mockDB.fetchRowCounts.assert_called_once()
+            mockUtils['formatTotals'].assert_called_once_with('testTotalResult')
+            mockUtils['formatResponseObject'].assert_called_once_with(
+                200, 'totalCounts', 'testTotalSummary'
+            )


### PR DESCRIPTION
This makes several important updates to the API, including bug fixes as well as new functionality. These are:

- Added a stand-alone Edition detail API endpoint
- Added Language and Record count utility endpoints
- Fixed a bug in when using the `showAll` parameter
- Added unique id fields to edition, item and link response objects
- Added `mediaType` field to link response object to provide context to the webreader