### PR TITLE
NOREF Hathi Cover Bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## unreleased -- v0.3.1
+### Added
+- Redis cache check for cover process
+### Fixed
+- HathiTrust cover process error handling
+
 ## 2021-03-05 -- v0.3.0
 ### Added
 - Language and Total Record count API endpoints

--- a/managers/coverFetchers/hathiFetcher.py
+++ b/managers/coverFetchers/hathiFetcher.py
@@ -25,7 +25,7 @@ class HathiFetcher(AbstractFetcher):
 
     def hasCover(self):
         for value, source in self.identifiers:
-            if source != 'hathi': continue
+            if source != 'hathi' or '.' not in value: continue
 
             try:
                 self.fetchVolumeCover(value)
@@ -36,7 +36,6 @@ class HathiFetcher(AbstractFetcher):
             except HathiCoverError as e:
                 logger.error('Unable to parse HathiTrust volume for cover')
                 logger.debug(e.message)
-                pass
 
         return False
 
@@ -54,8 +53,8 @@ class HathiFetcher(AbstractFetcher):
 
         try:
             pageList = metsJSON['METS:structMap']['METS:div']['METS:div'][:25]
-        except TypeError:
-            logger.debug(metsJSON['METS:structMap']['METS:div']['METS:div'])
+        except (TypeError, KeyError):
+            logger.debug(metsJSON)
             raise HathiCoverError('Unexpected METS format in hathi rec {}'.format(htid))
 
         rankedMETSPages = sorted(

--- a/managers/coverManager.py
+++ b/managers/coverManager.py
@@ -6,8 +6,8 @@ import managers.coverFetchers as fetchers
 
 
 class CoverManager:
-    def __init__(self, edition, dbSession):
-        self.edition = edition
+    def __init__(self, identifiers, dbSession):
+        self.identifiers = identifiers
         self.dbSession = dbSession
 
         self.loadFetchers()
@@ -26,13 +26,8 @@ class CoverManager:
             self.fetchers[fetcherClass.ORDER - 1] = fetcherClass
 
     def fetchCover(self):
-        edIdentifiers = [
-            (i.identifier, i.authority)
-            for i in self.edition.identifiers
-        ]
-
         for fetcherClass in self.fetchers:
-            fetcher = fetcherClass(edIdentifiers, self.dbSession)
+            fetcher = fetcherClass(self.identifiers, self.dbSession)
             
             if fetcher.hasCover() is True:
                 self.fetcher = fetcher

--- a/managers/redis.py
+++ b/managers/redis.py
@@ -24,14 +24,14 @@ class RedisManager:
             socket_timeout=5
         )
     
-    def checkSetRedis(self, service, identifier, idenType):
+    def checkSetRedis(self, service, identifier, idenType, expirationTime=60*60*24*7):
         queryTime = self.redisClient.get('{}/{}/{}/{}'.format(self.environment, service, identifier, idenType))
 
         if queryTime is not None and datetime.strptime(queryTime.decode('utf-8'), '%Y-%m-%dT%H:%M:%S') >= self.oneDayAgo:
             logger.debug('Identifier {} recently queried'.format(identifier))    
             return True
         
-        self.setRedis(service, identifier, idenType)
+        self.setRedis(service, identifier, idenType, expirationTime=expirationTime)
         return False
         
     

--- a/tests/unit/test_cover_manager.py
+++ b/tests/unit/test_cover_manager.py
@@ -8,11 +8,11 @@ class TestCoverManager:
     @pytest.fixture
     def testManager(self, mocker):
         class MockCoverManager(CoverManager):
-            def __init__(self, edition, dbSession):
-                self.edition = edition
+            def __init__(self, identifiers, dbSession):
+                self.identifiers = identifiers
                 self.dbSession = dbSession
 
-        return MockCoverManager(mocker.MagicMock(), mocker.MagicMock())
+        return MockCoverManager([(1, 'test')], mocker.MagicMock())
 
     @pytest.fixture
     def mockImageCreator(self, mocker):
@@ -34,8 +34,6 @@ class TestCoverManager:
         assert testManager.fetchers[3].__name__ == 'ContentCafeFetcher'
 
     def test_fetchCover_success(self, testManager, mocker):
-        testManager.edition.identifiers = [mocker.MagicMock(identifier=1, authority='test')]
-
         mockFetcher = mocker.MagicMock()
         mockFetcher.hasCover.return_value = True
         testManager.fetchers = [mocker.MagicMock(return_value=mockFetcher)]
@@ -46,8 +44,6 @@ class TestCoverManager:
         mockFetcher.hasCover.assert_called_once()
 
     def test_fetchCover_none(self, testManager, mocker):
-        testManager.edition.identifiers = [mocker.MagicMock(identifier=1, authority='test')]
-
         mockFetcher = mocker.MagicMock()
         mockFetcher.hasCover.return_value = False
         testManager.fetchers = [mocker.MagicMock(return_value=mockFetcher)]

--- a/tests/unit/test_fetcher_hathitrust.py
+++ b/tests/unit/test_fetcher_hathitrust.py
@@ -34,15 +34,22 @@ class TestHathiFetcher:
     def test_hasCover_true(self, testFetcher, mocker):
         mocker.patch.object(HathiFetcher, 'fetchVolumeCover')
 
-        testFetcher.identifiers = [(1, 'test'), (2, 'hathi')]
+        testFetcher.identifiers = [('1', 'test'), ('tst.2', 'hathi')]
         assert testFetcher.hasCover() == True
 
     def test_hasCover_false(self, testFetcher, mocker):
+        mocker.patch.object(HathiFetcher, 'fetchVolumeCover')
+
+        testFetcher.identifiers = [('1', 'test'), ('2', 'hathi')]
+        assert testFetcher.hasCover() == False
+
+    def test_hasCover_fetch_error(self, testFetcher, mocker):
         mockFetch = mocker.patch.object(HathiFetcher, 'fetchVolumeCover')
         mockFetch.side_effect = HathiCoverError('test error')
 
-        testFetcher.identifiers = [(1, 'test'), (2, 'hathi')]
+        testFetcher.identifiers = [('1', 'test'), ('tst.2', 'hathi')]
         assert testFetcher.hasCover() == False
+
 
     def test_fetchVolumeCover_success(self, testFetcher, mockMETSObject, mockPages, mocker):
         mockResponse = mocker.MagicMock()


### PR DESCRIPTION
The HathiTrust cover fetcher manager was throwing unexpected errors on malformed METS JSON records. This catches these errors and skips these malformed records.

This also adds a redis check for cover identifiers to prevent duplicate fetching of cover files when an identifier has already been queried