### PR TITLE
SFR-1026 Improved Grouping Traversal

### DIFF
--- a/managers/kMeans.py
+++ b/managers/kMeans.py
@@ -235,19 +235,18 @@ class KMeansManager:
 
             try:
                 if start != prevStart: startScore = self.cluster(start, score=True) 
-                if stop != prevStop: stopScore = self.cluster(stop, score=True) 
-            except ConvergenceWarning:
+            except (ValueError, ConvergenceWarning):
                 print('Exceeded number of distinct clusters, break')
-                if start == 2:
-                    start = 1
-                    startScore = 1
-                    break
-                else:
-                    stop = middle
-                    continue
-            except ValueError:
-                self.k = 1
-                return None
+                start = 1
+                startScore = 1
+                break
+
+            try:
+                if stop != prevStop: stopScore = self.cluster(stop, score=True) 
+            except (ValueError, ConvergenceWarning):
+                print('Exceeded number of distinct clusters, break')
+                stop = middle
+                continue
 
             if stop - start <= 1:
                 break

--- a/managers/sfrRecord.py
+++ b/managers/sfrRecord.py
@@ -81,13 +81,13 @@ class SFRRecordManager:
         return list(cleanLinks)
 
     def buildEditionStructure(self, records, editions):
-        editionRecs = {}
+        editionRecs = [] 
 
         for editionTuple in editions:
             edYear, recs = editionTuple
-            editionRecs[edYear] = list(filter(None, [
+            editionRecs.append((edYear, list(filter(None, [
                 r if r.uuid in recs else None for r in records
-            ]))
+            ]))))
         
         return editionRecs
 
@@ -96,7 +96,7 @@ class SFRRecordManager:
         
         workData = SFRRecordManager.createEmptyWorkRecord()
         
-        for pubYear, instances in editionRecs.items():
+        for pubYear, instances in editionRecs:
             self.buildEdition(workData, pubYear, instances)
         
         return workData

--- a/mappings/hathitrust.py
+++ b/mappings/hathitrust.py
@@ -18,7 +18,7 @@ class HathiMapping(CSVMapping):
                 ('{}|oclc', 7),
                 ('{}|isbn', 8),
                 ('{}|issn', 9),
-                ('{}|isbn', 10)
+                ('{}|lccn', 10)
             ],
             'rights': ('hathitrust|{}|{}||{}', 2, 13, 14),
             'is_part_of': [('{}|volume', 4)],

--- a/processes/oclcClassify.py
+++ b/processes/oclcClassify.py
@@ -48,7 +48,7 @@ class ClassifyProcess(CoreProcess):
                 startDateTime = datetime.utcnow() - timedelta(hours=24)
             baseQuery = baseQuery.filter(Record.date_modified > startDateTime)
 
-        windowSize = 100 if (self.ingestLimit and self.ingestLimit > 100) else self.ingestLimit
+        windowSize = 100 if (self.ingestLimit is None or self.ingestLimit > 100) else self.ingestLimit
         for rec in self.windowedQuery(Record, baseQuery, windowSize=windowSize):
             self.frbrizeRecord(rec)
 

--- a/processes/sfrCluster.py
+++ b/processes/sfrCluster.py
@@ -90,7 +90,7 @@ class ClusterProcess(CoreProcess):
         return editions, records
 
     def findAllMatchingRecords(self, identifiers):
-        idens = list(filter(lambda x: re.search(r'\|(?:lcc|ddc)$', x) == None, identifiers))
+        idens = list(filter(lambda x: re.search(r'\|(?:isbn|issn|oclc|lccn|owi)$', x) != None, identifiers))
 
         return self.queryIdens(idens)
 
@@ -113,7 +113,7 @@ class ClusterProcess(CoreProcess):
 
         iterations = 0
 
-        while iterations < 6:
+        while iterations < 3:
             logger.debug('Checking IDS: {}'.format(len(checkIdens)))
             matches = self.getRecordBatches(list(checkIdens), matchedIDs.copy())
             logger.debug('Got Matches: {}'.format(len(matches)))
@@ -127,7 +127,7 @@ class ClusterProcess(CoreProcess):
             for match in matches:
                 recID, recIdentifiers = match
                 checkIdens.update(list(filter(
-                    lambda x: re.search(r'\|(?:lcc|ddc)$', x) == None and x not in checkedIdens,
+                    lambda x: re.search(r'\|(?:isbn|issn|oclc|lccn|owi)$', x) != None and x not in checkedIdens,
                     recIdentifiers)
                 ))
                 matchedIDs.add(recID)

--- a/tests/unit/test_sfrCluster_process.py
+++ b/tests/unit/test_sfrCluster_process.py
@@ -238,19 +238,19 @@ class TestSFRClusterProcess:
         mockRedisCheck.side_effect = [False, True, False]
 
         mockGetBatch = mocker.patch.object(ClusterProcess, 'getRecordBatches')
-        mockGetBatch.side_effect = [[(1, ['4|lcc', '5|test'])], [(2, ['6|ddc'])], []]
+        mockGetBatch.side_effect = [[(1, ['4|lcc', '5|oclc'])], [(2, ['6|ddc'])], []]
 
-        testIDs = testInstance.queryIdens(['1|test', '2|test', '3|test'])
+        testIDs = testInstance.queryIdens(['1|oclc', '2|oclc', '3|oclc'])
 
         assert testIDs == [1, 2]
         mockRedisCheck.assert_has_calls([
-            mocker.call('cluster', '1|test', 'all'),
-            mocker.call('cluster', '2|test', 'all'),
-            mocker.call('cluster', '3|test', 'all')
+            mocker.call('cluster', '1|oclc', 'all'),
+            mocker.call('cluster', '2|oclc', 'all'),
+            mocker.call('cluster', '3|oclc', 'all')
         ])
-        assert set(mockGetBatch.call_args_list[0][0][0]) == set(['1|test', '3|test'])
+        assert set(mockGetBatch.call_args_list[0][0][0]) == set(['1|oclc', '3|oclc'])
         assert mockGetBatch.call_args_list[0][0][1] == set([])
-        assert set(mockGetBatch.call_args_list[1][0][0]) == set(['5|test'])
+        assert set(mockGetBatch.call_args_list[1][0][0]) == set(['5|oclc'])
         assert mockGetBatch.call_args_list[1][0][1] == set([1])
         assert set(mockGetBatch.call_args_list[2][0][0]) == set([])
         assert mockGetBatch.call_args_list[2][0][1] == set([1, 2])

--- a/tests/unit/test_sfrRecord_manager.py
+++ b/tests/unit/test_sfrRecord_manager.py
@@ -145,8 +145,10 @@ class TestSFRRecordManager:
             mockRecords, [(1900, ['uuid1', 'uuid2', 'uuid4']), (2000, ['uuid3', 'uuid5'])]
         )
 
-        assert testEditions[1900] == mockRecords[:2]
-        assert testEditions[2000] == mockRecords[2:]
+        assert testEditions[0][0] == 1900
+        assert testEditions[0][1] == mockRecords[:2]
+        assert testEditions[1][0] == 2000
+        assert testEditions[1][1] == mockRecords[2:]
 
     def test_buildWork(self, testInstance, mocker):
         managerMocks = mocker.patch.multiple(
@@ -156,10 +158,10 @@ class TestSFRRecordManager:
             buildEdition=mocker.DEFAULT
         )
 
-        managerMocks['buildEditionStructure'].return_value = {
-            1900: ['instance1', 'instance2'],
-            2000: ['instance3', 'instance4', 'instance5']
-        }
+        managerMocks['buildEditionStructure'].return_value = [
+            (1900, ['instance1', 'instance2']),
+            (2000, ['instance3', 'instance4', 'instance5'])
+        ]
         managerMocks['createEmptyWorkRecord'].return_value = 'testWorkData'
         
         testWorkData = testInstance.buildWork('testRecords', 'testEditions')


### PR DESCRIPTION
This implements several improvements to the clustering process that should both increase its accuracy and speed. This is achieved through several major changes:

- The "elbow" method of calculating the ideal value for K (the number of clusters to use) has been replaced with the `silhouette_score` method. Not only is this recommended by the developers of the `sklearn` module but it means replacing a large amount of custom code with a standard method call. Removing the opaque custom code (which performed fairly complex mathematical transformations) should make the process much more maintainable
- The means of traversing a set of `Record`s was previously linear, proceeding by regular intervals (which were dependent on the size of the collection). This has been replaced by a bisection method that allows the ideal K value to be found in fewer iterations. In testing this has proven to be just as accurate

Additionally, several minor bugs and improvements have been made:

- The HathiTrust process had a bug resolved that was mislabeling LCCNs as ISBNs
- A small bug was fixed that was potentially merging editions by year too zealously
- The number of iterations run for each clustering process was reduced for performance reasons