### PR TITLE
SFR-1019 Analytics Reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Added
 - Link Details endpoint
 - Redis cache check for cover process
+- Added Ingest Analytics process for output to Smartsheet
 ### Fixed
 - HathiTrust cover process error handling
 - Clustering process on very large groups of records

--- a/managers/__init__.py
+++ b/managers/__init__.py
@@ -13,3 +13,4 @@ from .sfrRecord import SFRRecordManager
 from .elasticsearch import ElasticsearchManager
 from .sfrElasticRecord import SFRElasticRecordManager
 from .s3 import S3Manager
+from .smartsheet import SmartSheetManager

--- a/managers/smartsheet.py
+++ b/managers/smartsheet.py
@@ -32,8 +32,7 @@ class SmartSheetManager:
             colID = columns[name]
 
             cellValue = {'column_id': colID, 'value': value['value']}
-
-            if value.get('anomaly', False): cellValue['format'] = ',,,,,,,,,28,,,,,,,'
+            cellValue['format'] = ',,,,,,,,,28,,,,,,,' if value.get('anomaly', False) else ',,,,,,,,,3,,,,,,,'
 
             newRow.cells.append(cellValue)
 

--- a/managers/smartsheet.py
+++ b/managers/smartsheet.py
@@ -1,0 +1,55 @@
+import os
+import smartsheet
+
+class SmartSheetManager:
+    def __init__(self, apiToken=None, sheetID=None):
+        super(SmartSheetManager, self).__init__()
+        self.apiToken = apiToken or os.environ['SMARTSHEET_API_TOKEN']
+        self.sheetID = sheetID or int(os.environ['SMARTSHEET_SHEET_ID'])
+        self.client = None
+
+    def createClient(self):
+        self.client = smartsheet.Smartsheet(self.apiToken)
+        self.client.errors_as_exceptions(True)
+
+    def getColumns(self):
+        colResponse = self.client.Sheets.get_columns(
+            self.sheetID, include_all=True
+        )
+
+        return {c.title: c.id for c in colResponse.data}
+
+    def insertRow(self, rowData):
+        newRow = self.createNewRow()
+
+        columns = self.getColumns()
+
+        rows = self.getRows(columnIDs=[columns['Col ID']], modifiedSince=rowData['Date']['value'])
+        lastPCNum = int(rows[-1].cells[0].value) if len(rows) > 0 else 0
+        rowData['Col ID'] = {'value': lastPCNum + 1}
+
+        for name, value in rowData.items():
+            colID = columns[name]
+
+            cellValue = {'column_id': colID, 'value': value['value']}
+
+            if value.get('anomaly', False): cellValue['format'] = ',,,,,,,,,28,,,,,,,'
+
+            newRow.cells.append(cellValue)
+
+        self.client.Sheets.add_rows(self.sheetID, [newRow])
+
+    def getRows(self, columnIDs=None, modifiedSince=None):
+        getSheetArgs = {}
+        
+        if columnIDs: getSheetArgs['column_ids'] = columnIDs
+
+        if modifiedSince: getSheetArgs['rows_modified_since'] = modifiedSince
+
+        sheetResp = self.client.Sheets.get_sheet(self.sheetID, **getSheetArgs)
+
+        return sheetResp.rows
+
+    @staticmethod
+    def createNewRow():
+        return smartsheet.models.Row()

--- a/processes/__init__.py
+++ b/processes/__init__.py
@@ -10,3 +10,4 @@ from .developmentSetup import DevelopmentSetupProcess
 from .s3Files import S3Process
 from .api import APIProcess
 from .muse import MUSEProcess
+from .ingestReport import IngestReportProcess

--- a/processes/ingestReport.py
+++ b/processes/ingestReport.py
@@ -19,14 +19,17 @@ class IngestReportProcess(CoreProcess):
         # Smartsheet SDK
         self.smartsheet = SmartSheetManager()
         self.smartsheet.createClient()
+        print(self.smartsheet.client.Server.server_info())
+        # raise Exception
 
     def runProcess(self):
         self.generateReport()
 
     def generateReport(self):
-        periodStart = datetime.utcnow() - timedelta(days=1)
+        now = datetime.utcnow()
+        periodStart = now - timedelta(days=1)
 
-        dailyRow = {'Date': {'value': periodStart.strftime('%Y-%m-%d')}}
+        dailyRow = {'Date': {'value': now.strftime('%Y-%m-%d')}}
         for table in [Work, Edition, Item, Record]:
             totals = self.getTableCounts(table, periodStart)
             dailyRow = {**dailyRow, **totals}

--- a/processes/ingestReport.py
+++ b/processes/ingestReport.py
@@ -1,0 +1,65 @@
+from datetime import datetime, timedelta
+
+from .core import CoreProcess
+from model import Work, Edition, Item, Record
+from managers import SmartSheetManager
+from logger import createLog
+
+logger = createLog(__name__)
+
+
+class IngestReportProcess(CoreProcess):
+    def __init__(self, *args):
+        super(IngestReportProcess, self).__init__(*args[:4])
+
+        # PostgreSQL Connection
+        self.generateEngine()
+        self.createSession()
+
+        # Smartsheet SDK
+        self.smartsheet = SmartSheetManager()
+        self.smartsheet.createClient()
+
+    def runProcess(self):
+        self.generateReport()
+
+    def generateReport(self):
+        periodStart = datetime.utcnow() - timedelta(days=1)
+
+        dailyRow = {'Date': {'value': periodStart.strftime('%Y-%m-%d')}}
+        for table in [Work, Edition, Item, Record]:
+            totals = self.getTableCounts(table, periodStart)
+            dailyRow = {**dailyRow, **totals}
+
+        self.smartsheet.insertRow(dailyRow)
+
+    def getTableCounts(self, table, periodStart):
+        logger.info('Getting Totals for {}'.format(table.__name__))
+
+        totalCount = self.session.query(table.id).count()
+
+        modifiedCount = self.session.query(table.id)\
+            .filter(table.date_modified > periodStart)\
+            .filter(table.date_created < periodStart)\
+            .count()
+
+        createdCount = self.session.query(table.id)\
+            .filter(table.date_created > periodStart).count()
+
+        totals = self.setAnomalyStatus(totalCount, modifiedCount, createdCount)
+
+        return {
+            'Total {}s'.format(table.__name__): totals['total'],
+            '{}s Modified'.format(table.__name__): totals['modified'],
+            '{}s Created'.format(table.__name__): totals['created'] 
+        }
+
+    @staticmethod
+    def setAnomalyStatus(total, modified, created):
+        anomalyThreshold = total / 10
+
+        return {
+            'total': {'value': total, 'anomaly': False},
+            'modified': {'value': modified, 'anomaly': modified > anomalyThreshold},
+            'created': {'value': created, 'anomaly': created > anomalyThreshold}
+        }

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ pyyaml
 redis
 requests
 requests_oauthlib
+smartsheet-python-sdk
 sklearn
 sqlalchemy
 waitress

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -46,7 +46,9 @@ class TestHelpers:
         'BARDO_CCE_API': 'test_cce_url',
         'MUSE_MARC_URL': 'test_muse_url',
         'MUSE_CSV_URL': 'test_muse_csv',
-        'DOAB_OAI_URL': 'test_doab_url'
+        'DOAB_OAI_URL': 'test_doab_url',
+        'SMARTSHEET_API_TOKEN': 'test_smartsheet_token',
+        'SMARTSHEET_SHEET_ID': '1000'
     }
 
     @classmethod

--- a/tests/unit/test_cover_process.py
+++ b/tests/unit/test_cover_process.py
@@ -36,7 +36,7 @@ class TestCoverProcess:
         mockQuery.filter.return_value = 'testQuery'
 
         mockSubQuery = mocker.MagicMock()
-        mockSubQuery.select_from().join().distinct().filter.return_value = '{\'sub\'}'
+        mockSubQuery.select_from().join().distinct().filter.return_value = ['sub']
 
         testProcess.session = mocker.MagicMock()
         testProcess.session.query.side_effect = [mockQuery, mockSubQuery]
@@ -45,7 +45,7 @@ class TestCoverProcess:
         testQuery = testProcess.generateQuery()
 
         assert testQuery == 'testQuery'
-        assert mockQuery.filter.call_args[0][0].compare(~Edition.id.in_('{\'sub\'}'))
+        assert mockQuery.filter.call_args[0][0].compare(~Edition.id.in_(['sub']))
         testProcess.session.query.assert_has_calls([
             mocker.call(Edition), mocker.call('edition_id')
         ])
@@ -56,7 +56,7 @@ class TestCoverProcess:
         mockQuery.filter.return_value = 'testQuery'
 
         mockSubQuery = mocker.MagicMock()
-        mockSubQuery.select_from().join().distinct().filter.return_value = '{\'sub\'}'
+        mockSubQuery.select_from().join().distinct().filter.return_value = ['sub'] 
 
         testProcess.session = mocker.MagicMock()
         testProcess.session.query.side_effect = [mockQuery, mockSubQuery]
@@ -66,7 +66,7 @@ class TestCoverProcess:
         testQuery = testProcess.generateQuery()
 
         assert testQuery == 'testQuery'
-        assert mockQuery.filter.call_args[0][0].compare(~Edition.id.in_('{\'sub\'}'))
+        assert mockQuery.filter.call_args[0][0].compare(~Edition.id.in_(['sub']))
         testDate = datetime.datetime.strptime('2020-01-01', '%Y-%m-%d')
         assert mockQuery.filter.call_args[0][1].compare(Edition.date_modified >= testDate)
 
@@ -75,7 +75,7 @@ class TestCoverProcess:
         mockQuery.filter.return_value = 'testQuery'
 
         mockSubQuery = mocker.MagicMock()
-        mockSubQuery.select_from().join().distinct().filter.return_value = '{\'sub\'}'
+        mockSubQuery.select_from().join().distinct().filter.return_value = ['sub']
 
         testProcess.session = mocker.MagicMock()
         testProcess.session.query.side_effect = [mockQuery, mockSubQuery]
@@ -90,7 +90,7 @@ class TestCoverProcess:
         testQuery = testProcess.generateQuery()
 
         assert testQuery == 'testQuery'
-        assert mockQuery.filter.call_args[0][0].compare(~Edition.id.in_('{\'sub\'}'))
+        assert mockQuery.filter.call_args[0][0].compare(~Edition.id.in_(['sub']))
         assert mockQuery.filter.call_args[0][1].compare(Edition.date_modified >= testQueryDate)
 
     def test_fetchEditionCovers(self, testProcess, mocker):

--- a/tests/unit/test_cover_process.py
+++ b/tests/unit/test_cover_process.py
@@ -36,7 +36,7 @@ class TestCoverProcess:
         mockQuery.filter.return_value = 'testQuery'
 
         mockSubQuery = mocker.MagicMock()
-        mockSubQuery.select_from().join().distinct().filter.return_value = 'subQuery'
+        mockSubQuery.select_from().join().distinct().filter.return_value = '{\'sub\'}'
 
         testProcess.session = mocker.MagicMock()
         testProcess.session.query.side_effect = [mockQuery, mockSubQuery]
@@ -45,7 +45,7 @@ class TestCoverProcess:
         testQuery = testProcess.generateQuery()
 
         assert testQuery == 'testQuery'
-        assert mockQuery.filter.call_args[0][0].compare(~Edition.id.in_('subQuery'))
+        assert mockQuery.filter.call_args[0][0].compare(~Edition.id.in_('{\'sub\'}'))
         testProcess.session.query.assert_has_calls([
             mocker.call(Edition), mocker.call('edition_id')
         ])
@@ -56,7 +56,7 @@ class TestCoverProcess:
         mockQuery.filter.return_value = 'testQuery'
 
         mockSubQuery = mocker.MagicMock()
-        mockSubQuery.select_from().join().distinct().filter.return_value = 'subQuery'
+        mockSubQuery.select_from().join().distinct().filter.return_value = '{\'sub\'}'
 
         testProcess.session = mocker.MagicMock()
         testProcess.session.query.side_effect = [mockQuery, mockSubQuery]
@@ -66,7 +66,7 @@ class TestCoverProcess:
         testQuery = testProcess.generateQuery()
 
         assert testQuery == 'testQuery'
-        assert mockQuery.filter.call_args[0][0].compare(~Edition.id.in_('subQuery'))
+        assert mockQuery.filter.call_args[0][0].compare(~Edition.id.in_('{\'sub\'}'))
         testDate = datetime.datetime.strptime('2020-01-01', '%Y-%m-%d')
         assert mockQuery.filter.call_args[0][1].compare(Edition.date_modified >= testDate)
 
@@ -75,7 +75,7 @@ class TestCoverProcess:
         mockQuery.filter.return_value = 'testQuery'
 
         mockSubQuery = mocker.MagicMock()
-        mockSubQuery.select_from().join().distinct().filter.return_value = 'subQuery'
+        mockSubQuery.select_from().join().distinct().filter.return_value = '{\'sub\'}'
 
         testProcess.session = mocker.MagicMock()
         testProcess.session.query.side_effect = [mockQuery, mockSubQuery]
@@ -90,7 +90,7 @@ class TestCoverProcess:
         testQuery = testProcess.generateQuery()
 
         assert testQuery == 'testQuery'
-        assert mockQuery.filter.call_args[0][0].compare(~Edition.id.in_('subQuery'))
+        assert mockQuery.filter.call_args[0][0].compare(~Edition.id.in_('{\'sub\'}'))
         assert mockQuery.filter.call_args[0][1].compare(Edition.date_modified >= testQueryDate)
 
     def test_fetchEditionCovers(self, testProcess, mocker):

--- a/tests/unit/test_ingestReport_process.py
+++ b/tests/unit/test_ingestReport_process.py
@@ -23,10 +23,10 @@ class TestIngestReportProcess:
 
     def test_generateReport(self, testInstance, mocker):
         now = datetime.utcnow()
+        startTime = now - timedelta(days=1)
         mockDate = mocker.patch('processes.ingestReport.datetime')
         mockDate.utcnow.return_value = now 
-        testDate = now - timedelta(days=1)
-        testDateStr = testDate.strftime('%Y-%m-%d')
+        nowStr = now.strftime('%Y-%m-%d')
 
         mockGetTable = mocker.patch.object(IngestReportProcess, 'getTableCounts')
         mockGetTable.side_effect = [
@@ -36,11 +36,11 @@ class TestIngestReportProcess:
         testInstance.generateReport()
 
         mockGetTable.assert_has_calls([
-            mocker.call(Work, testDate), mocker.call(Edition, testDate),
-            mocker.call(Item, testDate), mocker.call(Record, testDate)
+            mocker.call(Work, startTime), mocker.call(Edition, startTime),
+            mocker.call(Item, startTime), mocker.call(Record, startTime)
         ])
         testInstance.smartsheet.insertRow.assert_called_once_with(
-            {'Date': {'value': testDateStr}, 'Works': 'test', 'Editions': 'test', 'Items': 'test', 'Records': 'test'}
+            {'Date': {'value': nowStr}, 'Works': 'test', 'Editions': 'test', 'Items': 'test', 'Records': 'test'}
         )
 
     def test_getTableCounts(self, testInstance, mocker):

--- a/tests/unit/test_ingestReport_process.py
+++ b/tests/unit/test_ingestReport_process.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import date, timedelta
 import pytest
 
 from processes import IngestReportProcess
@@ -22,11 +22,11 @@ class TestIngestReportProcess:
         mockGenerate.assert_called_once()
 
     def test_generateReport(self, testInstance, mocker):
-        now = datetime.utcnow()
+        now = date.today()
         startTime = now - timedelta(days=1)
-        mockDate = mocker.patch('processes.ingestReport.datetime')
-        mockDate.utcnow.return_value = now 
-        nowStr = now.strftime('%Y-%m-%d')
+        mockDate = mocker.patch('processes.ingestReport.date')
+        mockDate.today.return_value = now 
+        startStr = startTime.strftime('%Y-%m-%d')
 
         mockGetTable = mocker.patch.object(IngestReportProcess, 'getTableCounts')
         mockGetTable.side_effect = [
@@ -40,7 +40,7 @@ class TestIngestReportProcess:
             mocker.call(Item, startTime), mocker.call(Record, startTime)
         ])
         testInstance.smartsheet.insertRow.assert_called_once_with(
-            {'Date': {'value': nowStr}, 'Works': 'test', 'Editions': 'test', 'Items': 'test', 'Records': 'test'}
+            {'Date': {'value': startStr}, 'Works': 'test', 'Editions': 'test', 'Items': 'test', 'Records': 'test'}
         )
 
     def test_getTableCounts(self, testInstance, mocker):

--- a/tests/unit/test_ingestReport_process.py
+++ b/tests/unit/test_ingestReport_process.py
@@ -1,0 +1,67 @@
+from datetime import datetime, timedelta
+import pytest
+
+from processes import IngestReportProcess
+from model import Work, Edition, Item, Record
+
+class TestIngestReportProcess:
+    @pytest.fixture
+    def testInstance(self, mocker):
+        class TestIngestReportProcess(IngestReportProcess):
+            def __init__(self, *args):
+                self.smartsheet = mocker.MagicMock()
+                self.session = mocker.MagicMock()
+        
+        return TestIngestReportProcess('TestProcess', 'testFile', 'testDate')
+    
+    def test_runProcess(self, testInstance, mocker):
+        mockGenerate = mocker.patch.object(IngestReportProcess, 'generateReport')
+
+        testInstance.runProcess()
+
+        mockGenerate.assert_called_once()
+
+    def test_generateReport(self, testInstance, mocker):
+        now = datetime.utcnow()
+        mockDate = mocker.patch('processes.ingestReport.datetime')
+        mockDate.utcnow.return_value = now 
+        testDate = now - timedelta(days=1)
+        testDateStr = testDate.strftime('%Y-%m-%d')
+
+        mockGetTable = mocker.patch.object(IngestReportProcess, 'getTableCounts')
+        mockGetTable.side_effect = [
+            {'Works': 'test'}, {'Editions': 'test'}, {'Items': 'test'}, {'Records': 'test'}
+        ]
+
+        testInstance.generateReport()
+
+        mockGetTable.assert_has_calls([
+            mocker.call(Work, testDate), mocker.call(Edition, testDate),
+            mocker.call(Item, testDate), mocker.call(Record, testDate)
+        ])
+        testInstance.smartsheet.insertRow.assert_called_once_with(
+            {'Date': {'value': testDateStr}, 'Works': 'test', 'Editions': 'test', 'Items': 'test', 'Records': 'test'}
+        )
+
+    def test_getTableCounts(self, testInstance, mocker):
+        testInstance.session.query().count.return_value = 10 # total
+        testInstance.session.query().filter().filter().count.return_value = 3 # modified
+        testInstance.session.query().filter().count.return_value = 2 # created
+
+        mockAnomaly = mocker.patch.object(IngestReportProcess, 'setAnomalyStatus')
+        mockAnomaly.return_value = {'total': 10, 'modified': 3, 'created': 2}
+
+        mockTable = mocker.MagicMock(__name__='Test', id=1, date_modified=1, date_created=1)
+        testCounts = testInstance.getTableCounts(mockTable, 0)
+
+        assert testCounts['Total Tests'] == 10
+        assert testCounts['Tests Modified'] == 3
+        assert testCounts['Tests Created'] == 2
+        mockAnomaly.assert_called_once_with(10, 3, 2)
+
+    def test_setAnomalyStatus(self):
+        testAnomalyObject = IngestReportProcess.setAnomalyStatus(100, 25, 5)
+
+        assert testAnomalyObject['total'] == {'value': 100, 'anomaly': False}
+        assert testAnomalyObject['modified'] == {'value': 25, 'anomaly': True}
+        assert testAnomalyObject['created'] == {'value': 5, 'anomaly': False}

--- a/tests/unit/test_smartsheet_manager.py
+++ b/tests/unit/test_smartsheet_manager.py
@@ -67,10 +67,10 @@ class TestNYPLApiManager:
         sheetMocks['getColumns'].assert_called_once()
         sheetMocks['getRows'].assert_called_once_with(columnIDs=[2], modifiedSince='testDate')
         mockRow.cells.append.assert_has_calls([
-            mocker.call({'column_id': 1, 'value': 'testDate'}),
-            mocker.call({'column_id': 3, 'value': 10}),
+            mocker.call({'column_id': 1, 'value': 'testDate', 'format': ',,,,,,,,,3,,,,,,,'}),
+            mocker.call({'column_id': 3, 'value': 10, 'format': ',,,,,,,,,3,,,,,,,'}),
             mocker.call({'column_id': 4, 'value': 25, 'format': ',,,,,,,,,28,,,,,,,'}),
-            mocker.call({'column_id': 2, 'value': 1})
+            mocker.call({'column_id': 2, 'value': 1, 'format': ',,,,,,,,,3,,,,,,,'})
         ])
         testInstance.client.Sheets.add_rows.assert_called_once_with(1000, [mockRow])
          

--- a/tests/unit/test_smartsheet_manager.py
+++ b/tests/unit/test_smartsheet_manager.py
@@ -1,0 +1,93 @@
+import pytest
+
+from managers import SmartSheetManager
+from tests.helper import TestHelpers
+
+
+class TestNYPLApiManager:
+    @classmethod
+    def setup_class(cls):
+        TestHelpers.setEnvVars()
+
+    @classmethod
+    def teardown_class(cls):
+        TestHelpers.clearEnvVars()
+
+    @pytest.fixture
+    def testInstance(self):
+        return SmartSheetManager()
+
+    def test_initializer(self, testInstance):
+        assert testInstance.apiToken == 'test_smartsheet_token'
+        assert testInstance.sheetID == 1000
+        assert testInstance.client == None
+
+    def test_createClient(self, testInstance, mocker):
+        mockClient = mocker.MagicMock()
+        mockSheet = mocker.patch('managers.smartsheet.smartsheet')
+        mockSheet.Smartsheet.return_value = mockClient
+
+        testInstance.createClient()
+
+        assert testInstance.client == mockClient
+        mockSheet.Smartsheet.assert_called_once_with('test_smartsheet_token')
+        testInstance.client.errors_as_exceptions.assert_called_once_with(True)
+
+    def test_getColumns(self, testInstance, mocker):
+        mockColumn = mocker.MagicMock(title='Test Column', id=1)
+        mockResp = mocker.MagicMock(data=[mockColumn])
+        testInstance.client = mocker.MagicMock()
+        testInstance.client.Sheets.get_columns.return_value = mockResp
+
+        testColumns = testInstance.getColumns()
+
+        assert testColumns == {'Test Column': 1}
+        testInstance.client.Sheets.get_columns.assert_called_once_with(
+            1000, include_all=True
+        )
+
+    def test_insertRow(self, testInstance, mocker):
+        testInstance.client = mocker.MagicMock()
+        sheetMocks = mocker.patch.multiple(
+            SmartSheetManager,
+            createNewRow=mocker.DEFAULT,
+            getColumns=mocker.DEFAULT,
+            getRows=mocker.DEFAULT
+        )
+        mockRow = mocker.MagicMock()
+        sheetMocks['createNewRow'].return_value = mockRow
+        sheetMocks['getColumns'].return_value = {'Date': 1, 'Col ID': 2, 'Test': 3, 'Test2': 4}
+        sheetMocks['getRows'].return_value = []
+
+        testInstance.insertRow(
+            {'Date': {'value': 'testDate'}, 'Test': {'value': 10}, 'Test2': {'value': 25, 'anomaly': True}}
+        )
+
+        sheetMocks['createNewRow'].assert_called_once()
+        sheetMocks['getColumns'].assert_called_once()
+        sheetMocks['getRows'].assert_called_once_with(columnIDs=[2], modifiedSince='testDate')
+        mockRow.cells.append.assert_has_calls([
+            mocker.call({'column_id': 1, 'value': 'testDate'}),
+            mocker.call({'column_id': 3, 'value': 10}),
+            mocker.call({'column_id': 4, 'value': 25, 'format': ',,,,,,,,,28,,,,,,,'}),
+            mocker.call({'column_id': 2, 'value': 1})
+        ])
+        testInstance.client.Sheets.add_rows.assert_called_once_with(1000, [mockRow])
+         
+    def test_getRows(self, testInstance, mocker):
+        mockClient = mocker.MagicMock()
+        testInstance.client = mockClient
+        mockClient.Sheets.get_sheet.return_value = mocker.MagicMock(rows=[1, 2])
+
+        testRows = testInstance.getRows(columnIDs=[1], modifiedSince='testDate')
+
+        assert testRows == [1, 2]
+        mockClient.Sheets.get_sheet.assert_called_once_with(
+            1000, column_ids=[1], rows_modified_since='testDate'
+        )
+
+    def test_createNewRow(self, mocker):
+        mockSheet = mocker.patch('managers.smartsheet.smartsheet')
+        mockSheet.models.Row.return_value = 'testRow'
+
+        assert SmartSheetManager.createNewRow() == 'testRow'


### PR DESCRIPTION
At the request of several people responsible for providing status updates on this project, it has been requested that we produce regular updates on the number of records available in DRB, as well as how many records we update/modify daily/weekly.

This adds this functionality by producing a simple report that is output to Smartsheet and which provides a daily snapshot of the database. This includes:

- Totals for `Work`, `Edition`, `Item` and `Record` records
- Counts for the number of created and modified records for each of the record types detailed above
- Highlighting of cells where data may be "anomalous" (exceeding 10% changed in a single day)