### PR TITLE
NORFE Add GHA deployment action

### DIFF
--- a/.github/workflows/build-qa.yaml
+++ b/.github/workflows/build-qa.yaml
@@ -1,0 +1,42 @@
+# On merge to development,
+# build a container and deploy to ECR
+name: Publish qa
+on:
+  pull_request:
+    branches: [main]
+    types: [closed]
+
+jobs:
+  publish_qa:
+    name: Publish image to ECR
+    if: github.event.pull_request.merged
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: Configure AWS credentials from QA account
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Build, tag, and push image to Amazon ECR
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: sfr_ingest_pipeline
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:latest
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
+
+      - name: Force ECS Update
+        run: |
+          aws ecs update-service --cluster sfr-pipeline-qa --service sfr-pipeline-qa --force-new-deployment

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,7 +8,16 @@ on:
     actions: [ opened ]
 
 jobs:
-  build:
+  changelog:
+    name: Updates Changelog
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dangoslen/changelog-enforcer@v1.4.0
+        with:
+          changeLogPath: "CHANGELOG.md"
+          skipLabel: "no-changelog"
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,9 +1,6 @@
 name: ETL_Pipeline_Tests
 
 on: 
-  push: 
-    braches:
-      - '*'
   pull_request:
     actions: [ opened ]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Link Details endpoint
 - Redis cache check for cover process
 - Added Ingest Analytics process for output to Smartsheet
+- Added GHA deployment step to ECS
 ### Fixed
 - HathiTrust cover process error handling
 - Clustering process on very large groups of records


### PR DESCRIPTION
This adds new functionality to the Github Actions integration for this repo. Primarily this adds a deployment action that builds the docker image for this repository and deploys it to ECS. It also adds a step in the test action to ensure that the `CHANGELOG` has been updated.