### PR TITLE
NOREF Further Clustering Improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # CHANGELOG
 
 ## unreleased -- v0.4.1
+### Added
+- OCLC API Rate Limit Check in Classify Process
+- Improved clustering process with more accurate date and title checking
 ### Fixed
 - Update QA Config file
+- Removed unecessary SQL queries from record building process
 
 ## 2021-03-16 -- v0.4.0
 ### Added

--- a/api/db.py
+++ b/api/db.py
@@ -1,8 +1,7 @@
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.sql import text
 
-from model import Work, Edition, Item, Link
-from model.postgres.item import ITEM_LINKS
+from model import Work, Edition, Link
 from .utils import APIUtils
 
 class DBClient():
@@ -17,34 +16,23 @@ class DBClient():
 
         return session.query(Work)\
             .join(Edition)\
-            .join(Item, ITEM_LINKS, Link)\
             .filter(Work.uuid.in_(uuids), Edition.id.in_(editionIds))\
             .all()
 
     def fetchSingleWork(self, uuid):
         session = sessionmaker(bind=self.engine)()
 
-        return session.query(Work)\
-            .join(Edition)\
-            .join(Item, ITEM_LINKS, Link)\
-            .filter(Work.uuid == uuid).first()
+        return session.query(Work).filter(Work.uuid == uuid).first()
 
     def fetchSingleEdition(self, editionID, showAll=False):
         session = sessionmaker(bind=self.engine)()
 
-        return session.query(Edition)\
-            .outerjoin(Item, ITEM_LINKS, Link)\
-            .filter(Edition.id == editionID).first()
+        return session.query(Edition).filter(Edition.id == editionID).first()
 
     def fetchSingleLink(self, linkID):
         session = sessionmaker(bind=self.engine)()
 
-        return session.query(Link)\
-            .join(ITEM_LINKS, Item)\
-            .join(Edition)\
-            .join(Work)\
-            .filter(Link.id == linkID)\
-            .first()
+        return session.query(Link).filter(Link.id == linkID).first()
 
     def fetchRowCounts(self):
         session = sessionmaker(bind=self.engine)()

--- a/managers/kMeans.py
+++ b/managers/kMeans.py
@@ -5,10 +5,10 @@ import warnings
 
 import pandas as pd
 from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.feature_extraction import DictVectorizer
 from sklearn.cluster import KMeans
 from sklearn.metrics import silhouette_score
 from sklearn.pipeline import Pipeline, FeatureUnion
-from sklearn.preprocessing import MinMaxScaler
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.exceptions import ConvergenceWarning
 
@@ -17,7 +17,7 @@ from logger import createLog
 logger = createLog(__name__)
 
 
-class TextSelector(BaseEstimator, TransformerMixin):
+class FeatureSelector(BaseEstimator, TransformerMixin):
     def __init__(self, key):
         self.key = key
 
@@ -26,17 +26,6 @@ class TextSelector(BaseEstimator, TransformerMixin):
 
     def transform(self, X):
         return X[self.key]
-
-
-class NumberSelector(BaseEstimator, TransformerMixin):
-    def __init__(self, key):
-        self.key = key
-
-    def fit(self, X, y=None):
-        return self
-
-    def transform(self, X):
-        return X[[self.key]]
 
 
 class KMeansManager:
@@ -48,7 +37,7 @@ class KMeansManager:
     def createPipeline(self, transformers):
         pipelineComponents = {
             'place': ('place', Pipeline([
-                ('selector', TextSelector(key='place')),
+                ('selector', FeatureSelector(key='place')),
                 ('tfidf', TfidfVectorizer(
                     preprocessor=KMeansManager.pubProcessor,
                     stop_words='english',
@@ -58,7 +47,7 @@ class KMeansManager:
                 )
             ])),
             'publisher': ('publisher', Pipeline([
-                ('selector', TextSelector(key='publisher')),
+                ('selector', FeatureSelector(key='publisher')),
                 ('tfidf', TfidfVectorizer(
                     preprocessor=KMeansManager.pubProcessor,
                     stop_words='english',
@@ -68,7 +57,7 @@ class KMeansManager:
                 )
             ])),
             'edition': ('edition', Pipeline([
-                ('selector', TextSelector(key='edition')),
+                ('selector', FeatureSelector(key='edition')),
                 ('tfidf', TfidfVectorizer(
                     preprocessor=KMeansManager.pubProcessor,
                     stop_words='english',
@@ -78,16 +67,16 @@ class KMeansManager:
                 )
             ])),
             'pubDate': ('pubDate', Pipeline([
-                ('selector', NumberSelector(key='pubDate')),
-                ('scaler', MinMaxScaler())
+                ('selector', FeatureSelector(key='pubDate')),
+                ('vect', DictVectorizer())
             ]))
         }
 
         pipelineWeights = {
-            'place': 0.5,
+            'place': 1.0,
             'publisher': 1.0,
-            'edition': 0.75,
-            'pubDate': 2.0 
+            'edition': 1.0,
+            'pubDate': 1.25
         }
 
         return Pipeline([
@@ -95,7 +84,7 @@ class KMeansManager:
                 transformer_list=[pipelineComponents[t] for t in transformers],
                 transformer_weights={t: pipelineWeights[t] for t in transformers}
             )),
-            ('kmeans', KMeans(n_clusters=self.currentK, max_iter=150, n_init=5))
+            ('kmeans', KMeans(n_clusters=self.currentK, max_iter=100, n_init=3))
         ])
     
     @classmethod
@@ -118,18 +107,23 @@ class KMeansManager:
 
     def createDF(self):
         logger.info('Generating DataFrame from instance data')
-        self.df = pd.DataFrame([
-            {
-                'place': i.spatial if i.spatial else '',
-                'publisher': KMeansManager.getPublisher(i.publisher),
-                'pubDate': KMeansManager.getPubDateFloat(i.dates),
-                'edition': KMeansManager.getEditionStatement(i.has_version),
-                'uuid': i.uuid
-            }
-            for i in self.instances
-            if KMeansManager.emptyInstance(i) != False
-        ])
+
+        self.df = pd.DataFrame(columns=['place', 'publisher', 'pubDate', 'edition', 'uuid'])
+
+        for i in self.instances:
+            spatialData, dateData, publisherData = self.getInstanceData(i)
+
+            if bool(spatialData) or dateData != {} or publisherData:
+                self.df = self.df.append({
+                    'place': spatialData or '',
+                    'publisher': publisherData,
+                    'pubDate': dateData,
+                    'edition': self.getEditionStatement(i.has_version),
+                    'uuid': i.uuid
+                }, ignore_index=True)
+
         self.maxK = len(self.df.index) if len(self.df.index) > 1 else 2
+
         if self.maxK > 5000:
             self.maxK = int(self.maxK * (1/9))
         elif self.maxK > 1000:
@@ -138,49 +132,58 @@ class KMeansManager:
             self.maxK = int(self.maxK * (3/9))
         elif self.maxK > 250:
             self.maxK = int(self.maxK * (4/9))
+
+        if self.maxK > 1000: self.maxK = 1000
     
-    @staticmethod
-    def emptyInstance(instance):
-        return bool(instance.spatial or\
-            KMeansManager.getPubDateFloat(instance.dates) or\
-            KMeansManager.getPublisher(instance.publisher))
+    @classmethod
+    def getInstanceData(cls, instance):
+        spatial = instance.spatial
+        date = cls.getPubDateObject(instance.dates)
+        publisher = cls.getPublisher(instance.publisher)
+
+        return (spatial, date, publisher)
 
     @classmethod
-    def getPubDateFloat(cls, dates):
+    def getPubDateObject(cls, dates):
+        if dates is None or len(dates) < 1: return {}
+
         pubYears = {}
-        if not dates:
-            return 0
+
         for d in dates:
             try:
                 date, dateType = tuple(d.split('|'))
-            except ValueError:
-                return 0
-            dateStr = str(date).strip('];:.,- ')
-            if re.match(r'[0-9]{4}-[0-9]{4}', dateStr):
-                rangeMatches = re.match(r'([0-9]{4})-([0-9]{4})', dateStr)
-                startYear = rangeMatches.group(1)
-                endYear = rangeMatches.group(2)
-                pubYears[dateType] = (int(startYear) + int(endYear)) / 2
-            elif re.match(r'[0-9]{4}-[0-9]{2}-[0-9]{2}', dateStr):
-                try:
+
+                dateGroups = re.search(r'([\d\-\?]+)', date)
+
+                dateStr = dateGroups.group(1)
+
+                startYear, endYear = ('', '')
+
+                if re.match(r'[0-9]{4}-[0-9]{4}', dateStr):
+                    rangeMatches = re.match(r'([0-9]{4})-([0-9]{4})', dateStr)
+                    startYear = rangeMatches.group(1)
+                    endYear = rangeMatches.group(2)
+                elif re.match(r'[0-9]{4}-[0-9]{2}-[0-9]{2}', dateStr):
                     year, _, _ = tuple(dateStr.split('-'))
-                    pubYears[dateType] = int(year)
-                except ValueError:
-                    logger.warning('Unable to parse date {}'.format(dateStr))
-            else:
-                try:
-                    dateInt = int(dateStr)
-                    pubYears[dateType] = dateInt
-                except ValueError:
-                    logger.warning('Unable to parse date {}'.format(dateStr))
-                    pass
+                    startYear, endYear = (year, year)
+                elif re.match(r'[0-9]{4}-[0-9]{2}', dateStr):
+                    year, _ = tuple(dateStr.split('-'))
+                    startYear, endYear = (year, year)
+                else:
+                    startYear, endYear = (dateStr, dateStr)
+
+                yearParser = YearObject(startYear, endYear)
+                yearParser.setYearComponents()
+                pubYears[dateType] = dict(yearParser)
+            except (ValueError, AttributeError, IndexError) as e:
+                logger.warning('Unable to parse date {}'.format(d))
 
         for datePref in ['copyright_date', 'publication_date']:
             if datePref in pubYears.keys():
                 return pubYears[datePref]
         
         logger.debug('Unable to locate publication date')
-        return 0
+        return {}
     
     @classmethod
     def getPublisher(cls, pubStr):
@@ -203,7 +206,7 @@ class KMeansManager:
         return ''
     
     def generateClusters(self):
-        print('Generating Clusters from instances')
+        logger.info('Generating Clusters from instances')
         try:
             logger.info('Calculating number of clusters, max {}'.format(
                 self.maxK
@@ -224,7 +227,7 @@ class KMeansManager:
                 self.clusters[item].append(self.df.loc[[n]])
             except KeyError:
                 continue
-    
+
     def getK(self, start, stop):
         warnings.filterwarnings('error', category=ConvergenceWarning)
 
@@ -300,11 +303,62 @@ class KMeansManager:
             yearEds = defaultdict(list)
             logger.debug('Parsing cluster {}'.format(clust))
             for ed in self.clusters[clust]:
-                logger.debug('Adding instance to {} edition'.format(
-                    ed.iloc[0]['pubDate']
-                ))
-                yearEds[ed.iloc[0]['pubDate']].append(ed.iloc[0]['uuid'])
+                editionYear = YearObject.convertYearDictToStr(ed.iloc[0]['pubDate'])
+                logger.debug('Adding instance to {} edition'.format(editionYear))
+                yearEds[editionYear].append(ed.iloc[0]['uuid'])
             eds.extend([(year, data) for year, data in yearEds.items()])
             eds.sort(key=lambda x: x[0])
 
         return eds
+
+
+class YearObject:
+    def __init__(self, start, end):
+        self.start = str(start)
+        self.end = str(end)
+        self.century = [None, None]
+        self.decade = [None, None]
+        self.year = [None, None]
+
+    def setYearComponents(self):
+        self.setCentury()
+        self.setDecade()
+        self.setYear()
+    
+    def setCentury(self):
+        self.century[0] = int(self.start[:2])
+
+        if len(self.end) > 2: self.century[1] = int(self.end[:2])
+
+    def setDecade(self):
+        if self.start[2] not in ['-', '?']: self.decade[0] = int(self.start[2])
+
+        if len(self.end) > 2 and self.end[2] not in ['-', '?']: self.decade[1] = int(self.end[2])
+
+    def setYear(self):
+        if self.start[3] not in ['-', '?']: self.year[0] = int(self.start[3])
+
+        if len(self.end) > 2 and self.end[3] not in ['-', '?']: self.year[1] = int(self.end[3])
+
+    def __iter__(self):
+        for key in ['century', 'decade', 'year']:
+            yearComp = getattr(self, key)
+
+            if yearComp[0] is not None: yield '{}Start'.format(key), yearComp[0]
+
+            if yearComp[1] is not None: yield '{}End'.format(key), yearComp[1]
+
+    @staticmethod
+    def convertYearDictToStr(yearDict):
+        startYear = YearObject.getYearStr(yearDict, 'Start')
+        endYear = YearObject.getYearStr(yearDict, 'End')
+
+        return '{}-{}'.format(startYear, endYear) if endYear and endYear != startYear else str(startYear)
+
+    @staticmethod
+    def getYearStr(yearDict, yearType):
+        century = yearDict.get('century{}'.format(yearType), None)
+        decade = yearDict.get('decade{}'.format(yearType), None)
+        year = yearDict.get('year{}'.format(yearType), None)
+
+        return ''.join(map(lambda x: str(x) if x is not None else 'x', [century, decade, year]))

--- a/managers/oclcClassify.py
+++ b/managers/oclcClassify.py
@@ -252,7 +252,7 @@ class ClassifyManager:
     @staticmethod
     def getQueryableIdentifiers(identifiers):
         return list(filter(
-            lambda x: re.search(r'\|(?:isbn|issn|oclc|lccn)$', x) != None,
+            lambda x: re.search(r'\|(?:isbn|issn|oclc)$', x) != None,
             identifiers
         ))
 

--- a/processes/covers.py
+++ b/processes/covers.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta
 import os
-
+from sqlalchemy import column
 
 from .core import CoreProcess
 from managers import CoverManager
@@ -37,7 +37,7 @@ class CoverProcess(CoreProcess):
     def generateQuery(self):
         baseQuery = self.session.query(Edition)
 
-        subQuery = self.session.query('edition_id')\
+        subQuery = self.session.query(column('edition_id'))\
             .select_from(EDITION_LINKS)\
             .join(Link)\
             .distinct('edition_id')\

--- a/tests/unit/test_api_db.py
+++ b/tests/unit/test_api_db.py
@@ -29,7 +29,7 @@ class TestDBClient:
         mockMaker.return_value = mockCreator
         mockSession = mocker.MagicMock()
         mockCreator.return_value = mockSession
-        mockSession.query().join().join().filter().all.return_value = ['work1', 'work3']
+        mockSession.query().join().filter().all.return_value = ['work1', 'work3']
 
         mockFlatten = mocker.patch.object(APIUtils, 'flatten')
         mockFlatten.return_value = [1, 2, 3]
@@ -41,7 +41,7 @@ class TestDBClient:
         assert workResult == ['work1', 'work3']
         mockMaker.assert_called_once_with(bind=testInstance.engine)
         mockCreator.assert_called_once()
-        mockSession.query().join().join().filter().all.assert_called_once()
+        mockSession.query().join().filter().all.assert_called_once()
 
     def test_fetchSingleWork(self, testInstance, mocker):
         mockCreator = mocker.MagicMock()
@@ -49,14 +49,14 @@ class TestDBClient:
         mockMaker.return_value = mockCreator
         mockSession = mocker.MagicMock()
         mockCreator.return_value = mockSession
-        mockSession.query().join().join().filter().first.return_value = 'testWork'
+        mockSession.query().filter().first.return_value = 'testWork'
 
         workResult = testInstance.fetchSingleWork('uuid')
 
         assert workResult == 'testWork'
         mockMaker.assert_called_once_with(bind=testInstance.engine)
         mockCreator.assert_called_once()
-        mockSession.query().join().join().filter().first.assert_called_once()
+        mockSession.query().filter().first.assert_called_once()
 
     def test_fetchSingleEdition(self, testInstance, mocker):
         mockCreator = mocker.MagicMock()
@@ -64,14 +64,14 @@ class TestDBClient:
         mockMaker.return_value = mockCreator
         mockSession = mocker.MagicMock()
         mockCreator.return_value = mockSession
-        mockSession.query().outerjoin().filter().first.return_value = 'testEdition'
+        mockSession.query().filter().first.return_value = 'testEdition'
 
         editionResult = testInstance.fetchSingleEdition('editionID')
 
         assert editionResult == 'testEdition'
         mockMaker.assert_called_once_with(bind=testInstance.engine)
         mockCreator.assert_called_once()
-        mockSession.query().outerjoin().filter().first.assert_called_once()
+        mockSession.query().filter().first.assert_called_once()
 
     def test_fetchSingleLink(self, testInstance, mocker):
         mockCreator = mocker.MagicMock()
@@ -79,14 +79,14 @@ class TestDBClient:
         mockMaker.return_value = mockCreator
         mockSession = mocker.MagicMock()
         mockCreator.return_value = mockSession
-        mockSession.query().join().join().join().filter().first.return_value = 'testLink'
+        mockSession.query().filter().first.return_value = 'testLink'
 
         editionResult = testInstance.fetchSingleLink('linkID')
 
         assert editionResult == 'testLink'
         mockMaker.assert_called_once_with(bind=testInstance.engine)
         mockCreator.assert_called_once()
-        mockSession.query().join().join().join().filter().first.assert_called_once()
+        mockSession.query().filter().first.assert_called_once()
 
     def test_fetchRowCounts(self, testInstance, testCountQuery, mocker):
         mockCreator = mocker.MagicMock()

--- a/tests/unit/test_api_es.py
+++ b/tests/unit/test_api_es.py
@@ -84,7 +84,7 @@ class TestElasticClient:
 
         mockSearch.query.assert_called_once_with('searchClauses')
 
-        searchMocks['addFilterClausesAndAggregations'].assert_called_once_with([mockSearch], ['filter'])
+        searchMocks['addFilterClausesAndAggregations'].assert_called_once_with([mockSearch], ['filter'], 3)
         searchMocks['addSortClause'].assert_called_once_with(mockSearch, ['sort'])
 
         mockSearch.execute.assert_called_once()
@@ -113,7 +113,7 @@ class TestElasticClient:
 
         mockSearch.query.assert_called_once_with('searchClauses')
 
-        searchMocks['addFilterClausesAndAggregations'].assert_called_once_with([mockSearch], ['filter'])
+        searchMocks['addFilterClausesAndAggregations'].assert_called_once_with([mockSearch], ['filter'], 3)
         searchMocks['addSortClause'].assert_called_once_with(mockSearch, ['sort'])
 
         mockSearch.execute.assert_called_once
@@ -142,7 +142,7 @@ class TestElasticClient:
 
         mockSearch.query.assert_called_once_with('searchClauses')
 
-        searchMocks['addFilterClausesAndAggregations'].assert_called_once_with([mockSearch], ['filter'])
+        searchMocks['addFilterClausesAndAggregations'].assert_called_once_with([mockSearch], ['filter'], 3)
         searchMocks['addSortClause'].assert_called_once_with(mockSearch, ['sort'])
 
         mockSearch.execute.assert_called_once
@@ -171,7 +171,7 @@ class TestElasticClient:
 
         mockSearch.query.assert_called_once_with('searchClauses')
 
-        searchMocks['addFilterClausesAndAggregations'].assert_called_once_with([mockSearch], ['filter'])
+        searchMocks['addFilterClausesAndAggregations'].assert_called_once_with([mockSearch], ['filter'], 3)
         searchMocks['addSortClause'].assert_called_once_with(mockSearch, ['sort'])
 
         mockSearch.execute.assert_called_once
@@ -200,7 +200,7 @@ class TestElasticClient:
 
         mockSearch.query.assert_called_once_with('searchClauses')
 
-        searchMocks['addFilterClausesAndAggregations'].assert_called_once_with([mockSearch], ['filter'])
+        searchMocks['addFilterClausesAndAggregations'].assert_called_once_with([mockSearch], ['filter'], 3)
         searchMocks['addSortClause'].assert_called_once_with(mockSearch, ['sort'])
 
         mockSearch.execute.assert_called_once
@@ -231,7 +231,7 @@ class TestElasticClient:
 
         mockSearch.query.assert_called_once_with('searchClauses')
 
-        searchMocks['addFilterClausesAndAggregations'].assert_called_once_with([mockSearch], ['filter'])
+        searchMocks['addFilterClausesAndAggregations'].assert_called_once_with([mockSearch], ['filter'], 3)
         searchMocks['addSortClause'].assert_called_once_with(mockSearch, ['sort'])
 
         mockSearch.execute.assert_called_once
@@ -264,7 +264,7 @@ class TestElasticClient:
 
         mockSearch.query.assert_called_once_with('searchClauses')
 
-        searchMocks['addFilterClausesAndAggregations'].assert_called_once_with([mockSearch], ['filter'])
+        searchMocks['addFilterClausesAndAggregations'].assert_called_once_with([mockSearch], ['filter'], 3)
         searchMocks['addSortClause'].assert_called_once_with(mockSearch, ['sort'])
 
     def test_titleQuery(self):
@@ -386,12 +386,12 @@ class TestElasticClient:
         mockApply.return_value = mockSearch
         mockApplyAggs = mocker.patch.object(ElasticClient, 'applyAggregations')
 
-        filtersAndAggs = ElasticClient.addFilterClausesAndAggregations(mockSearch, [])
+        ElasticClient.addFilterClausesAndAggregations(mockSearch, [], 1)
 
         mockQuery.assert_called_once_with('exists', field='editions.formats')
         mockAgg.assert_called_once_with('filter', exists={'field': 'editions.formats'})
 
-        mockApply.assert_called_once_with(mockSearch, [], ['formatFilter'])
+        mockApply.assert_called_once_with(mockSearch, [], ['formatFilter'], size=1)
         mockApplyAggs.assert_called_once_with(mockSearch, ['formatAggregation'])
 
     def test_addFilterClausesAndAggregations_w_date(self, mocker):
@@ -408,7 +408,7 @@ class TestElasticClient:
         mockApply.return_value = mockSearch
         mockApplyAggs = mocker.patch.object(ElasticClient, 'applyAggregations')
 
-        filtersAndAggs = ElasticClient.addFilterClausesAndAggregations(mockSearch, [('startYear', 1900)])
+        ElasticClient.addFilterClausesAndAggregations(mockSearch, [('startYear', 1900)], 1)
 
         mockQuery.assert_has_calls([
             mocker.call('exists', field='editions.formats'),
@@ -419,7 +419,7 @@ class TestElasticClient:
             mocker.call('filter', range={'editions.publication_date': 'testRange'})
         ])
 
-        mockApply.assert_called_once_with(mockSearch, [], ['formatFilter', 'dateFilter'])
+        mockApply.assert_called_once_with(mockSearch, [], ['formatFilter', 'dateFilter'], size=1)
         mockApplyAggs.assert_called_once_with(mockSearch, ['formatAggregation', 'dateAggregation'])
 
     def test_addFilterClausesAndAggregations_w_format(self, mocker):
@@ -434,7 +434,7 @@ class TestElasticClient:
         mockApply.return_value = mockSearch
         mockApplyAggs = mocker.patch.object(ElasticClient, 'applyAggregations')
 
-        filtersAndAggs = ElasticClient.addFilterClausesAndAggregations(mockSearch, [('format', 'test1'), ('format', 'test2')])
+        ElasticClient.addFilterClausesAndAggregations(mockSearch, [('format', 'test1'), ('format', 'test2')], 1)
 
         mockQuery.assert_has_calls([
             mocker.call('exists', field='editions.formats'),
@@ -445,7 +445,7 @@ class TestElasticClient:
             mocker.call('filter', terms={'editions.formats': ['test1', 'test2']})
         ])
 
-        mockApply.assert_called_once_with(mockSearch, [], ['formatFilter', 'displayFilter'])
+        mockApply.assert_called_once_with(mockSearch, [], ['formatFilter', 'displayFilter'], size=1)
         mockApplyAggs.assert_called_once_with(mockSearch, ['formatAggregation', 'displayAggregation'])
 
     def test_addFilterClausesAndAggregations_w_language(self, mocker):
@@ -460,7 +460,7 @@ class TestElasticClient:
         mockApply.return_value = mockSearch
         mockApplyAggs = mocker.patch.object(ElasticClient, 'applyAggregations')
 
-        filtersAndAggs = ElasticClient.addFilterClausesAndAggregations(mockSearch, [('language', 'Test1')])
+        ElasticClient.addFilterClausesAndAggregations(mockSearch, [('language', 'Test1')], 1)
 
         mockQuery.assert_has_calls([
             mocker.call('exists', field='editions.formats'),
@@ -469,7 +469,7 @@ class TestElasticClient:
             mocker.call('filter', exists={'field': 'editions.formats'}),
         ])
 
-        mockApply.assert_called_once_with(mockSearch, [('language', 'Test1')], ['displayFilter'])
+        mockApply.assert_called_once_with(mockSearch, [('language', 'Test1')], ['displayFilter'], size=1)
         mockApplyAggs.assert_called_once_with(mockSearch, ['displayAggregation'])
 
     def test_addFilterClausesAndAggregations_no_filters(self, mocker):
@@ -482,7 +482,7 @@ class TestElasticClient:
         mockApply.return_value = mockSearch
         mockApplyAggs = mocker.patch.object(ElasticClient, 'applyAggregations')
 
-        filtersAndAggs = ElasticClient.addFilterClausesAndAggregations(mockSearch, [('showAll', 'true')])
+        ElasticClient.addFilterClausesAndAggregations(mockSearch, [('showAll', 'true')], 1)
 
         mockQuery.assert_has_calls([
             mocker.call('exists', field='editions.formats'),
@@ -491,7 +491,7 @@ class TestElasticClient:
             mocker.call('filter', exists={'field': 'editions.formats'}),
         ])
 
-        mockApply.assert_called_once_with(mockSearch, [], [])
+        mockApply.assert_called_once_with(mockSearch, [], [], size=1)
         mockApplyAggs.assert_called_once_with(mockSearch, [])
 
     def test_geneateDateRange_start_end(self):

--- a/tests/unit/test_cover_process.py
+++ b/tests/unit/test_cover_process.py
@@ -1,5 +1,6 @@
 import datetime
 import pytest
+from sqlalchemy import column
 
 from model import Edition, Link
 from processes import CoverProcess
@@ -46,9 +47,7 @@ class TestCoverProcess:
 
         assert testQuery == 'testQuery'
         assert mockQuery.filter.call_args[0][0].compare(~Edition.id.in_(['sub']))
-        testProcess.session.query.assert_has_calls([
-            mocker.call(Edition), mocker.call('edition_id')
-        ])
+        assert testProcess.session.query.call_count == 2
         mockSubQuery.select_from().join().distinct().filter.call_args[0][0].compare(Link.flags['cover'] == 'true')
 
     def test_generateQuery_custom_date(self, testProcess, mocker):

--- a/tests/unit/test_kmeans_yearobject.py
+++ b/tests/unit/test_kmeans_yearobject.py
@@ -1,0 +1,88 @@
+import pytest
+
+from managers.kMeans import YearObject
+
+
+class TestYearObject:
+    @pytest.fixture
+    def testObject(self):
+        return YearObject(1900, 2000)
+
+    def test_initializer(self, testObject):
+        assert testObject.start == '1900'
+        assert testObject.end == '2000'
+        assert testObject.century == [None, None]
+        assert testObject.decade == [None, None]
+        assert testObject.year == [None, None]
+
+    def test_setYearComponents(self, testObject, mocker):
+        objectMocks = mocker.patch.multiple(YearObject,
+            setCentury=mocker.DEFAULT, setDecade=mocker.DEFAULT, setYear=mocker.DEFAULT
+        )
+
+        testObject.setYearComponents()
+
+        objectMocks['setCentury'].assert_called_once()
+        objectMocks['setDecade'].assert_called_once()
+        objectMocks['setYear'].assert_called_once()
+
+    def test_setCentury_start_end(self, testObject):
+        testObject.setCentury()
+
+        assert testObject.century == [19, 20]
+
+    def test_setCentury_start_only(self, testObject):
+        testObject.end = ''
+        testObject.setCentury()
+
+        assert testObject.century == [19, None]
+
+    def test_setDecade_start_end(self, testObject):
+        testObject.setDecade()
+
+        assert testObject.decade == [0, 0]
+
+    def test_setDecade_start_only(self, testObject):
+        testObject.end = ''
+        testObject.setDecade()
+
+        assert testObject.decade == [0, None]
+
+    def test_setYear_start_end(self, testObject):
+        testObject.setYear()
+
+        assert testObject.year == [0, 0]
+
+    def test_setYear_start_only(self, testObject):
+        testObject.end = ''
+        testObject.setYear()
+
+        assert testObject.year == [0, None]
+
+    def test_convertYearDictToStr_start_end(self, mocker):
+        mockGetYear = mocker.patch.object(YearObject, 'getYearStr')
+        mockGetYear.side_effect = [1900, 2000]
+
+        assert YearObject.convertYearDictToStr('mockDict') == '1900-2000'
+
+    def test_convertYearDictToStr_start_only(self, mocker):
+        mockGetYear = mocker.patch.object(YearObject, 'getYearStr')
+        mockGetYear.side_effect = [1900, None]
+
+        assert YearObject.convertYearDictToStr('mockDict') == '1900'
+
+    def test_getYearStr(self):
+        testYearDict = {'centuryTest': 19, 'decadeTest': 9, 'yearTest': None}
+
+        assert YearObject.getYearStr(testYearDict, 'Test') == '199x'
+
+    def test_iter_for_dict(self, testObject):
+        testObject.century = [19, 20]
+        testObject.decade = [1, 1]
+        testObject.year = [1, None]
+
+        assert dict(testObject) == {
+            'centuryStart': 19, 'centuryEnd': 20,
+            'decadeStart': 1, 'decadeEnd': 1,
+            'yearStart': 1
+        }

--- a/tests/unit/test_redis_manager.py
+++ b/tests/unit/test_redis_manager.py
@@ -65,3 +65,43 @@ class TestRedisManager:
         testInstance.redisClient.set.assert_called_once_with(
             'testEnv/test/1/test', testInstance.presentTime.strftime('%Y-%m-%dT%H:%M:%S'), ex=604800
         )
+
+    def test_checkIncrementerRedis_false(self, testInstance, mocker):
+        testInstance.redisClient = mocker.MagicMock()
+        testInstance.redisClient.get.return_value = b'1'
+
+        assert testInstance.checkIncrementerRedis('test', 'id') == False
+
+        testInstance.redisClient.get.assert_called_once_with(
+            'test/{}/id'.format(testInstance.presentTime.strftime('%Y-%m-%d'))
+        )
+
+    def test_checkIncrementerRedis_true(self, testInstance, mocker):
+        testInstance.redisClient = mocker.MagicMock()
+        testInstance.redisClient.get.return_value = b'500001'
+
+        assert testInstance.checkIncrementerRedis('test', 'id') == True
+
+        testInstance.redisClient.get.assert_called_once_with(
+            'test/{}/id'.format(testInstance.presentTime.strftime('%Y-%m-%d'))
+        )
+
+    def test_checkIncrementerRedis_none_false(self, testInstance, mocker):
+        testInstance.redisClient = mocker.MagicMock()
+        testInstance.redisClient.get.return_value = None
+
+        assert testInstance.checkIncrementerRedis('test', 'id') == False
+
+        testInstance.redisClient.get.assert_called_once_with(
+            'test/{}/id'.format(testInstance.presentTime.strftime('%Y-%m-%d'))
+        )
+
+    def test_setIncrementerRedis(self, testInstance, mocker):
+        testInstance.redisClient = mocker.MagicMock()
+
+        testInstance.setIncrementerRedis('test', 'id')
+
+        testInstance.redisClient.incr.assert_called_once_with(
+            'test/{}/id'.format(testInstance.presentTime.strftime('%Y-%m-%d'))
+        )
+


### PR DESCRIPTION
The core improvement in this PR is an update to the clustering process that both makes it faster and more accurate:

The accuracy improvements are:

- Changed the publication date clustering attribute from an integer representation to a dictionary representation(which includes century, decade and year). This improves accuracy by providing the algorithm a better estimation of the relative distance between dates
- Implemented a title check (based on the OCLC Work-Set Algorithm). This verifies that grouped records share a title with the source record if they are two or more steps away from that record

The speed improvements are:

- Reduced number of iterations used in each clustering step
- Reduced possible distance for records from source from 5 steps to 3
- Improved edition generation and deduplication code by reducing total number of SQL queries made

Other minor improvements have been made to the following processes:

- `CoverProcess` Fixed bug with new SQLalchemy version
- `APIProcess` Removed unnecessary joins in sql queries to use SQLalchemy "lazy" loading and improved ElasticSearch internal loading of `inner_hits`
- Added redis-based increment check against OCLC API rate limits to ensure that the process can up to that point but not exceed it