### PR TITLE
NOREF Update Cover query for SQLAlchemy 1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixed
 - Update QA Config file
 - Removed unecessary SQL queries from record building process
+- Updated Queries to be compatible with SQLAlchemy 1.4
 
 ## 2021-03-16 -- v0.4.0
 ### Added

--- a/processes/covers.py
+++ b/processes/covers.py
@@ -1,6 +1,5 @@
 from datetime import datetime, timedelta
 import os
-from sqlalchemy import column
 
 from .core import CoreProcess
 from managers import CoverManager
@@ -37,8 +36,7 @@ class CoverProcess(CoreProcess):
     def generateQuery(self):
         baseQuery = self.session.query(Edition)
 
-        subQuery = self.session.query(column('edition_id'))\
-            .select_from(EDITION_LINKS)\
+        subQuery = self.session.query(EDITION_LINKS.c.edition_id)\
             .join(Link)\
             .distinct('edition_id')\
             .filter(Link.flags['cover'] == 'true')

--- a/tests/unit/test_cover_process.py
+++ b/tests/unit/test_cover_process.py
@@ -37,7 +37,7 @@ class TestCoverProcess:
         mockQuery.filter.return_value = 'testQuery'
 
         mockSubQuery = mocker.MagicMock()
-        mockSubQuery.select_from().join().distinct().filter.return_value = ['sub']
+        mockSubQuery.join().distinct().filter.return_value = ['sub']
 
         testProcess.session = mocker.MagicMock()
         testProcess.session.query.side_effect = [mockQuery, mockSubQuery]
@@ -48,14 +48,14 @@ class TestCoverProcess:
         assert testQuery == 'testQuery'
         assert mockQuery.filter.call_args[0][0].compare(~Edition.id.in_(['sub']))
         assert testProcess.session.query.call_count == 2
-        mockSubQuery.select_from().join().distinct().filter.call_args[0][0].compare(Link.flags['cover'] == 'true')
+        mockSubQuery.join().distinct().filter.call_args[0][0].compare(Link.flags['cover'] == 'true')
 
     def test_generateQuery_custom_date(self, testProcess, mocker):
         mockQuery = mocker.MagicMock()
         mockQuery.filter.return_value = 'testQuery'
 
         mockSubQuery = mocker.MagicMock()
-        mockSubQuery.select_from().join().distinct().filter.return_value = ['sub'] 
+        mockSubQuery.join().distinct().filter.return_value = ['sub'] 
 
         testProcess.session = mocker.MagicMock()
         testProcess.session.query.side_effect = [mockQuery, mockSubQuery]
@@ -74,7 +74,7 @@ class TestCoverProcess:
         mockQuery.filter.return_value = 'testQuery'
 
         mockSubQuery = mocker.MagicMock()
-        mockSubQuery.select_from().join().distinct().filter.return_value = ['sub']
+        mockSubQuery.join().distinct().filter.return_value = ['sub']
 
         testProcess.session = mocker.MagicMock()
         testProcess.session.query.side_effect = [mockQuery, mockSubQuery]


### PR DESCRIPTION
The new release of SQLAlchemy is somewhat more strict in how it interprets SQL queries. This makes a minor modification to the main cover query to comply with this. A side effect is that the query is now somewhat simpler and should be clearer for future maintainers.