### PR TITLE
HOTFIX Handle identifiers with commas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unreleased -- v0.4.2
+## Fixed
+- Handle identifiers with commas in record queries and import processes
+
 ## 2021-03-19 -- v0.4.1
 ### Added
 - OCLC API Rate Limit Check in Classify Process

--- a/mappings/hathitrust.py
+++ b/mappings/hathitrust.py
@@ -40,6 +40,17 @@ class HathiMapping(CSVMapping):
         self.record.source = 'hathitrust'
         self.record.source_id = self.record.identifiers[0]
 
+        # Split any identifier that contains a comma into multiple values
+        cleanIdentifiers = []
+        for iden in self.record.identifiers:
+            if ',' in iden:
+                sourceIdens, idenType = iden.split('|')
+                idenList = sourceIdens.split(',')
+                cleanIdentifiers.extend(['{}|{}'.format(i, idenType) for i in idenList])
+            else:
+                cleanIdentifiers.append(iden)
+        self.record.identifiers = cleanIdentifiers
+
         # Parse publisher from publication date
         self.record.dates = self.record.dates or ['']
         pubDate = self.record.dates[0]
@@ -52,7 +63,6 @@ class HathiMapping(CSVMapping):
         publisher = pubDate.replace(pubDateExtract, '').split('|')[0].strip('[], .;')
         self.record.publisher = '{}||'.format(publisher)
 
-        
         # Parse contributers into full names
         self.record.contributors = self.record.contributors or []
         for i, contributor in enumerate(self.record.contributors):

--- a/processes/sfrCluster.py
+++ b/processes/sfrCluster.py
@@ -152,7 +152,9 @@ class ClusterProcess(CoreProcess):
 
         while i < len(identifiers):
             logger.debug('Querying Batch {} of {}'.format(ceil(i/100)+1, ceil(len(identifiers)/100)))
-            idArray = '{{{}}}'.format(','.join(identifiers[i:i+step]))
+
+            idArray = self.formatIdenArray(identifiers[i:i+step])
+
             matches = self.session.query(Record.title, Record.id, Record.identifiers)\
                 .filter(~Record.id.in_(list(matchedIDs)))\
                 .filter(Record.identifiers.overlap(idArray))\
@@ -190,3 +192,13 @@ class ClusterProcess(CoreProcess):
         titleTokenSet = set(titleTokens) - set(['a', 'an', 'the', 'of'])
 
         return titleTokenSet
+
+    @staticmethod
+    def formatIdenArray(identifiers):
+        idenStrings = []
+        
+        for iden in identifiers:
+            idenStr = '"{}"'.format(iden) if ',' in iden else iden
+            idenStrings.append(idenStr)
+        
+        return '{{{}}}'.format(','.join(idenStrings))

--- a/tests/unit/test_hathitrust_mapping.py
+++ b/tests/unit/test_hathitrust_mapping.py
@@ -20,7 +20,7 @@ class TestHathingMapping:
     @pytest.fixture
     def testRecord_standard(self, mocker):
         return mocker.MagicMock(
-            identifiers=['1|hathi', '2|test'],
+            identifiers=['1|hathi', '2|test', '3,4|test'],
             dates=['Test Publisher [1900]|publication_date', '2000 [other]|copyright_date'],
             contributors=['contr|test'],
             rights='hathitrust|testLic|testReas||summary',
@@ -58,6 +58,7 @@ class TestHathingMapping:
 
         assert testMapping.record.source == 'hathitrust'
         assert testMapping.record.source_id == '1|hathi'
+        assert testMapping.record.identifiers == ['1|hathi', '2|test', '3|test', '4|test']
         assert testMapping.record.dates == ['1900|publication_date', '2000 [other]|copyright_date']
         assert testMapping.record.publisher == 'Test Publisher||'
         assert testMapping.record.contributors == ['Contributor|test']


### PR DESCRIPTION
In rare instances an identifier may contain a comma (either intentionally or unintentionally), this can cause issues in the clustering process as the constructed query will interpret an identifier that contains a comma as two seperate values to query. This is resolved by wrapping any such identifiers in quotation marks.

This also removes a source of potential commas in identifiers by splitting hathitrust identifiers on commas on ingest. Due to the format of hathitrust records in rare cases catalogers merged multiple identifiers into a single column. This ensures that we have more accurate data with which to cluster records