### PR TITLE
NOREF API Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 # CHANGELOG
 
+## unreleased -- v0.4.3
+### Fixed
+- Extended API handling of multiple query parameters
+- Resolved bug in search API response that omitted `formats` facet
+
 ## 2021-03-25 -- v0.4.2
-## Added
+### Added
 - Swagger documentation
-## Fixed
+### Fixed
 - Handle identifiers with commas in record queries and import processes
 - Minor bug in handling keyword queries
 

--- a/api/elastic.py
+++ b/api/elastic.py
@@ -220,6 +220,9 @@ class ElasticClient():
             currentAgg = 'edition_filter_{}'.format(i)
             lastAgg = lastAgg.bucket(currentAgg, agg)
         
-        lastAgg.bucket('lang_parent', 'nested', path='editions.languages')\
+        lastAgg = lastAgg.bucket('lang_parent', 'nested', path='editions.languages')\
             .bucket('languages', 'terms', **{'field': 'editions.languages.language', 'size': 200})\
-            .bucket('editions_per_language', 'reverse_nested')
+            .bucket('editions_per', 'reverse_nested')
+
+        lastAgg.bucket('formats', 'terms', **{'field': 'editions.formats', 'size': 10})\
+            .bucket('editions_per', 'reverse_nested')

--- a/swagger.v4.json
+++ b/swagger.v4.json
@@ -447,9 +447,9 @@
             "type": "object",
             "properties": {
                 "facets": {
-                    "type": "array",
+                    "type": "object",
                     "items": {
-                        "$ref": "#/definitions/FacetOption"
+                        "$ref": "#/definitions/FacetObject"
                     }
                 },
                 "paging": {
@@ -634,6 +634,23 @@
                 },
                 "volume": {
                     "type": "string"
+                }
+            }
+        },
+        "FacetObject": {
+            "type": "object",
+            "properties": {
+                "languages": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/FacetOption"
+                    }
+                },
+                "formats": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/FacetOption"
+                    }
                 }
             }
         },

--- a/tests/unit/test_api_es.py
+++ b/tests/unit/test_api_es.py
@@ -597,5 +597,9 @@ class TestElasticClient:
         mockQuery.aggs.bucket.assert_called_once_with('editions', 'baseAgg')
         mockRoot.bucket.assert_has_calls([
             mocker.call('edition_filter_0', 'testAgg'),
-            mocker.call('lang_parent', 'nested', path='editions.languages')
+            mocker.call('lang_parent', 'nested', path='editions.languages'),
+            mocker.call('languages', 'terms', field='editions.languages.language', size=200),
+            mocker.call('editions_per', 'reverse_nested'),
+            mocker.call('formats', 'terms', field='editions.formats', size=10),
+            mocker.call('editions_per', 'reverse_nested')
         ])

--- a/tests/unit/test_api_utils.py
+++ b/tests/unit/test_api_utils.py
@@ -8,11 +8,17 @@ class TestAPIUtils:
         return {
             'editions': {
                 'edition_filter_0': {
-                    'key': 'lang_parent',
-                    'buckets': [
-                        {'key': 'Test1', 'editions_per_language': {'doc_count': 1}},
-                        {'key': 'Test2', 'editions_per_language': {'doc_count': 3}}
-                    ]
+                    'languages': {
+                        'buckets': [
+                            {'key': 'Lang1', 'editions_per': {'doc_count': 1}},
+                            {'key': 'Lang2', 'editions_per': {'doc_count': 3}}
+                        ]
+                    },
+                    'formats': {
+                        'buckets': [
+                            {'key': 'Format1', 'editions_per': {'doc_count': 5}}
+                        ]
+                    }
                 }
             }
         }
@@ -70,11 +76,18 @@ class TestAPIUtils:
         assert testPairs[0] == ('test', 'value')
         assert testPairs[1] == ('test', 'bareValue')
 
-    def test_formatAggregationResult(self, testAggregationResp):
-        languageAggregations = APIUtils.formatAggregationResult(testAggregationResp)
+    def test_extractParamPairs_comma_delimited(self):
+        testPairs = APIUtils.extractParamPairs('test', {'test': ['test:value,bareValue']})
 
-        assert languageAggregations[0] == {'value': 'Test1', 'count': 1}
-        assert languageAggregations[1] == {'value': 'Test2', 'count': 3}
+        assert testPairs[0] == ('test', 'value')
+        assert testPairs[1] == ('test', 'bareValue')
+
+    def test_formatAggregationResult(self, testAggregationResp):
+        testAggregations = APIUtils.formatAggregationResult(testAggregationResp)
+
+        assert testAggregations['languages'][0] == {'value': 'Lang1', 'count': 1}
+        assert testAggregations['languages'][1] == {'value': 'Lang2', 'count': 3}
+        assert testAggregations['formats'][0] == {'value': 'Format1', 'count': 5}
 
     def test_formatPagingOptions(self, testHitObject):
         testPagingOptions = APIUtils.formatPagingOptions(testHitObject)


### PR DESCRIPTION
This makes two improvements to the API following early testing

1) The search query now handles multiple parameters of the same type in two ways: `query=title:Test&query=author:Test` and `query=title:Test,author:Test`
2) The search response block now includes both `language` and `format` facet blocks. The `format` block had been erroneously omitted previously