### PR TITLE
HOTFIX Lower OCLC Limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Fixed
 - Extended API handling of multiple query parameters
 - Resolved bug in search API response that omitted `formats` facet
+- Lowered OCLC Query Limit to match actual 24-limit (400,000)
 
 ## 2021-03-25 -- v0.4.2
 ### Added

--- a/api/elastic.py
+++ b/api/elastic.py
@@ -220,7 +220,7 @@ class ElasticClient():
             currentAgg = 'edition_filter_{}'.format(i)
             lastAgg = lastAgg.bucket(currentAgg, agg)
         
-        lastAgg = lastAgg.bucket('lang_parent', 'nested', path='editions.languages')\
+        lastAgg.bucket('lang_parent', 'nested', path='editions.languages')\
             .bucket('languages', 'terms', **{'field': 'editions.languages.language', 'size': 200})\
             .bucket('editions_per', 'reverse_nested')
 

--- a/config/qa.yaml
+++ b/config/qa.yaml
@@ -34,6 +34,7 @@ HATHI_API_ROOT: https://babel.hathitrust.org/cgi/htd
 
 # OCLC CONFIGURATION
 # OCLC_API_KEY must be configured in secrets file
+OCLC_QUERY_LIMIT: 390000
 
 # AWS CONFIGURATION
 # AWS_ACCESS and AWS_SECRET must be configured in secrets file

--- a/managers/redis.py
+++ b/managers/redis.py
@@ -17,7 +17,7 @@ class RedisManager:
         self.presentTime = datetime.utcnow()
         self.oneDayAgo = self.presentTime - timedelta(days=1)
 
-        self.oclcLimit = os.environ.get('OCLC_QUERY_LIMIT', 500000)
+        self.oclcLimit = os.environ.get('OCLC_QUERY_LIMIT', 400000)
     
     def createRedisClient(self):
         self.redisClient = Redis(
@@ -48,7 +48,7 @@ class RedisManager:
         incrementValue = self.redisClient.get('{}/{}/{}'.format(
             service, self.presentTime.strftime('%Y-%m-%d'), identifier
         ))
-        print('REDIS TAG ', incrementValue)
+
         return bool(incrementValue) and (int(incrementValue) >= self.oclcLimit)
 
     def setIncrementerRedis(self, service, identifier):


### PR DESCRIPTION
The previous rate limit was set to 500,000. Which was too high and exceed the 24-hour limit for API queries. This lowers the number to 390,000, which should keep the API requests below the overall limit.