### PR TITLE
SFR-1041 Cluster Level Bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## unreleased -- v0.4.3
+## 2021-03-29 -- v0.4.3
 ### Fixed
 - Extended API handling of multiple query parameters
 - Resolved bug in search API response that omitted `formats` facet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## unreleased -- v0.4.4
+### Fixed
+- Handling of ISO-639-2/b language codes
+- Insertion of blank values into `rights_date` column
+
 ## 2021-03-29 -- v0.4.3
 ### Fixed
 - Extended API handling of multiple query parameters

--- a/processes/sfrCluster.py
+++ b/processes/sfrCluster.py
@@ -98,7 +98,7 @@ class ClusterProcess(CoreProcess):
         return self.queryIdens(idens)
 
     def createWorkFromEditions(self, editions, instances):
-        recordManager = SFRRecordManager(self.session)
+        recordManager = SFRRecordManager(self.session, self.statics['iso639'])
         workData = recordManager.buildWork(instances, editions)
         recordManager.saveWork(workData)
         recordManager.mergeRecords()

--- a/static/iso639.json
+++ b/static/iso639.json
@@ -1,0 +1,24 @@
+{
+    "2b": {
+        "alb": "sqi",
+        "arm": "hye",
+        "baq": "eus",
+        "bur": "mya",
+        "chi": "zho",
+        "cze": "ces",
+        "dut": "nld",
+        "fre": "fra",
+        "geo": "kat",
+        "ger": "deu",
+        "gre": "ell",
+        "ice": "isl",
+        "mac": "mkd",
+        "mao": "mri",
+        "may": "msa",
+        "per": "fas",
+        "rum": "ron",
+        "slo": "slk",
+        "tib": "bod",
+        "wel": "cym"
+    }
+}

--- a/static/manager.py
+++ b/static/manager.py
@@ -14,7 +14,7 @@ class StaticManager:
             self.parseStaticPath(staticPath)
     
     def parseStaticPath(self, staticPath):
-        staticName = re.search(r'\/([a-z]+)\.json', staticPath).group(1)
+        staticName = re.search(r'\/([a-z0-9]+)\.json', staticPath).group(1)
 
         with open(staticPath, 'r') as staticFile:
             staticJSON = json.load(staticFile)

--- a/tests/unit/test_sfrCluster_process.py
+++ b/tests/unit/test_sfrCluster_process.py
@@ -20,6 +20,7 @@ class TestSFRClusterProcess:
         class TestClusterProcess(ClusterProcess):
             def __init__(self, process, customFile, ingestPeriod):
                 self.records = []
+                self.statics = {'iso639': {}}
         
         return TestClusterProcess('TestProcess', 'testFile', 'testDate')
 
@@ -227,7 +228,7 @@ class TestSFRClusterProcess:
         testWork = testInstance.createWorkFromEditions('testEditions', 'testInstances')
 
         assert testWork == 'testWork'
-        mockManagerInst.assert_called_once_with('testSession')
+        mockManagerInst.assert_called_once_with('testSession', {})
         mockRecManager.buildWork.assert_called_once_with('testInstances', 'testEditions')
         mockRecManager.saveWork.assert_called_once_with('testWorkData')
         mockRecManager.mergeRecords.assert_called_once()

--- a/tests/unit/test_sfrRecord_manager.py
+++ b/tests/unit/test_sfrRecord_manager.py
@@ -7,7 +7,7 @@ class TestSFRRecordManager:
     @pytest.fixture
     def testInstance(self, mocker):
         mocker.patch('managers.sfrRecord.Work')
-        return SFRRecordManager(mocker.MagicMock())
+        return SFRRecordManager(mocker.MagicMock(), {'2b': {'ger': 'deu'}})
 
     @pytest.fixture
     def testDCDWRecord(self, mocker):
@@ -272,26 +272,33 @@ class TestSFRRecordManager:
 
         assert parsedData.tests == [1, 2, 3]
 
-    def test_getLanguage_all_values_match_full_name(self):
-        testLanguage = SFRRecordManager.getLanguage({'language': 'English'})
+    def test_getLanguage_all_values_match_full_name(self, testInstance):
+        testLanguage = testInstance.getLanguage({'language': 'English'})
 
         assert testLanguage['iso_2'] == 'en'
         assert testLanguage['iso_3'] == 'eng'
         assert testLanguage['language'] == 'English'
 
-    def test_getLanguage_all_values_match_iso_2(self):
-        testLanguage = SFRRecordManager.getLanguage({'iso_2': 'de'})
+    def test_getLanguage_all_values_match_iso_2(self, testInstance):
+        testLanguage = testInstance.getLanguage({'iso_2': 'de'})
 
         assert testLanguage['iso_2'] == 'de'
         assert testLanguage['iso_3'] == 'deu'
         assert testLanguage['language'] == 'German'
 
-    def test_getLanguage_all_values_match_iso_3(self):
-        testLanguage = SFRRecordManager.getLanguage({'iso_2': 'zho'})
+    def test_getLanguage_all_values_match_iso_3(self, testInstance):
+        testLanguage = testInstance.getLanguage({'iso_3': 'zho'})
 
         assert testLanguage['iso_2'] == 'zh'
         assert testLanguage['iso_3'] == 'zho'
         assert testLanguage['language'] == 'Chinese'
+
+    def test_getLanguage_all_values_match_iso_639_2_b(self, testInstance):
+        testLanguage = testInstance.getLanguage({'iso_3': 'ger'})
+
+        assert testLanguage['iso_2'] == 'de'
+        assert testLanguage['iso_3'] == 'deu'
+        assert testLanguage['language'] == 'German'
 
     def test_parseLinkFlags(self):
         assert (
@@ -300,8 +307,8 @@ class TestSFRRecordManager:
             {'flags': {'testing': True}, 'key': 'value'}
         )
 
-    def test_getLanguage_all_values_match_missing_iso_2(self):
-        testLanguage = SFRRecordManager.getLanguage({'language': 'Klingon'})
+    def test_getLanguage_all_values_match_missing_iso_2(self, testInstance):
+        testLanguage = testInstance.getLanguage({'language': 'Klingon'})
 
         assert testLanguage['iso_2'] is None
         assert testLanguage['iso_3'] == 'tlh'


### PR DESCRIPTION
In order to serve accurate data in the API two minor bugs were uncovered in the process of testing the API. These are:

- Removing empty strings from `rights` records to prevent issues with the `rights_date` column
- Handling ISO-639-2/b language codes. These have been depricated in ISO-639-3 but are still common in catalogs. A static mapping to more current terms has been added to handle these cases.