### PR TITLE
NOREF API Testing Bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 ### Fixed
 - Handling of ISO-639-2/b language codes
 - Insertion of blank values into `rights_date` column
+- Handling of `{}` in record identifiers
+- Parsing of publication objects to simple year representations in API response
+- Preservation of search result sort order after database query
 
 ## 2021-03-29 -- v0.4.3
 ### Fixed

--- a/api/elastic.py
+++ b/api/elastic.py
@@ -165,7 +165,7 @@ class ElasticClient():
 
         if len(formatFilters) > 0:
             formats = [f[1] for f in formatFilters]
-            formatFilter = Q('terms', instances__formats=formats)
+            formatFilter = Q('terms', editions__formats=formats)
             formatAggregation = A('filter', **{'terms': {'editions.formats': formats}})
 
         if len(displayFilters) > 0 and displayFilters[0][1] == 'true':

--- a/api/utils.py
+++ b/api/utils.py
@@ -52,15 +52,13 @@ class APIUtils():
         }
 
     @classmethod
-    def formatWorkOutput(cls, works, identifiers=None, showAll=True):
+    def formatWorkOutput(cls, works, identifiers, showAll=True):
         if isinstance(works, list):
             outWorks = []
-            editionIds = []
+            workDict = {str(work.uuid): work for work in works}
 
-            if identifiers:
-                editionIds = list(cls.flatten([i[1] for i in identifiers]))
-
-            for work in works:
+            for workUUID, editionIds in identifiers:
+                work = workDict[workUUID]
                 outWorks.append(cls.formatWork(work, editionIds, showAll))
             
             return outWorks
@@ -92,6 +90,7 @@ class APIUtils():
         editionDict = dict(edition)
         editionDict['edition_id'] = edition.id
         editionDict['items'] = []
+        editionDict['publication_date'] = edition.publication_date.year if edition.publication_date else None
 
         for item in edition.items:
             itemDict = dict(item)

--- a/managers/sfrRecord.py
+++ b/managers/sfrRecord.py
@@ -525,11 +525,13 @@ class SFRRecordManager:
     def normalizeDates(self, dates):
         outDates = set()
         for date in dates:
-            dateValue, dateType = tuple(date.split('|'))
             try:
+                dateValue, dateType = tuple(date.split('|'))
+    
                 cleanDate = re.search(r'\d+.*\d+', dateValue).group()
+
                 outDates.add('{}|{}'.format(cleanDate, dateType))
-            except AttributeError:
+            except (AttributeError, ValueError):
                 pass
 
         return list(outDates)

--- a/tests/unit/test_api_es.py
+++ b/tests/unit/test_api_es.py
@@ -438,7 +438,7 @@ class TestElasticClient:
 
         mockQuery.assert_has_calls([
             mocker.call('exists', field='editions.formats'),
-            mocker.call('terms', instances__formats=['test1', 'test2'])
+            mocker.call('terms', editions__formats=['test1', 'test2'])
         ])
         mockAgg.assert_has_calls([
             mocker.call('filter', exists={'field': 'editions.formats'}),

--- a/tests/unit/test_sfrCluster_process.py
+++ b/tests/unit/test_sfrCluster_process.py
@@ -287,5 +287,5 @@ class TestSFRClusterProcess:
         mockESManager.saveWork.assert_called_once
 
     def test_formatIdenArray(self):
-        assert ClusterProcess.formatIdenArray(['test|test', 'multi,test|test'])\
-            == '{test|test,"multi,test|test"}'
+        assert ClusterProcess.formatIdenArray(['{test}|test', 'multi,test|test'])\
+            == '{"{test}|test","multi,test|test"}'


### PR DESCRIPTION
This makes several improvements to increase the stability and usability of the API. These are:

- Fix erroneous object name in the ES DSL to allow for filtering on formats
- Fix "unsorting" regression following PostgreSQL query with search results
- Return only the year value for `publication_date` field on editions
- Gracefully handle some unexpected database errors