### PR TITLE
HOTFIX Ensure Cover links are present in edition records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unreleased -- v0.5.1
+### Fixed
+- Ensure that covers are present in API responses
+
 ## 2021-04-05 -- v0.5.0
 ### Added
 - OPDS2 endpoints and structure

--- a/api/utils.py
+++ b/api/utils.py
@@ -76,7 +76,7 @@ class APIUtils():
         for edition in work.editions:
             if editionIds and edition.id not in editionIds:
                 continue
-
+            
             editionDict = cls.formatEdition(edition)
 
             if showAll is True or (showAll is False and len(editionDict['items']) > 0):
@@ -92,29 +92,27 @@ class APIUtils():
     def formatEdition(cls, edition):
         editionDict = dict(edition)
         editionDict['edition_id'] = edition.id
-        editionDict['items'] = []
         editionDict['publication_date'] = edition.publication_date.year if edition.publication_date else None
+        editionDict['links'] = [
+            {'link_id': l.id, 'mediaType': l.media_type, 'url': l.url}
+            for l in edition.links
+        ]
 
+        editionDict['items'] = []
         for item in edition.items:
             itemDict = dict(item)
             itemDict['item_id'] = item.id
             itemDict['location'] = item.physical_location['name'] if item.physical_location else None
 
-            itemDict['links'] = []
-            for link in item.links:
-                itemDict['links'].append({
-                    'link_id': link.id,
-                    'mediaType': link.media_type,
-                    'url': link.url
-                })
+            itemDict['links'] = [
+                {'link_id': l.id, 'mediaType': l.media_type, 'url': l.url}
+                for l in item.links
+            ]
 
-            itemDict['rights'] = []
-            for rights in item.rights:
-                itemDict['rights'].append({
-                    'source': rights.source,
-                    'license': rights.license,
-                    'rightsStatement': rights.rights_statement
-                })
+            itemDict['rights'] = [
+                {'source': r.source, 'license': r.license, 'rightsStatement': r.rights_statement}
+                for r in item.rights
+            ]
 
             editionDict['items'].append(itemDict)
 

--- a/tests/unit/test_api_utils.py
+++ b/tests/unit/test_api_utils.py
@@ -63,7 +63,10 @@ class TestAPIUtils:
     @pytest.fixture
     def testEdition(self, MockDBObject, testItem, mocker):
         return MockDBObject(
-            id='ed1', publication_date=mocker.MagicMock(year=2000), items=[testItem]
+            id='ed1',
+            publication_date=mocker.MagicMock(year=2000),
+            items=[testItem],
+            links=[mocker.MagicMock(id='co1', media_type='image/png', url='testCover')]
         )
 
     @pytest.fixture
@@ -183,6 +186,9 @@ class TestAPIUtils:
 
         assert formattedEdition['edition_id'] == 'ed1'
         assert formattedEdition['publication_date'] == 2000
+        assert formattedEdition['links'][0]['link_id'] == 'co1'
+        assert formattedEdition['links'][0]['mediaType'] == 'image/png'
+        assert formattedEdition['links'][0]['url'] == 'testCover'
         assert formattedEdition['items'][0]['item_id'] == 'it1'
         assert formattedEdition['items'][0]['location'] == 'test'
         assert formattedEdition['items'][0]['links'][0]['link_id'] == 'li1'


### PR DESCRIPTION
The `links` block on editions was dropped in a regression and needs to be re-added so that cover links are present in API responses.