### PR TITLE
SFR-1042 Format Crosswalk + bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # CHANGELOG
 
 ## unreleased -- v0.5.1
+### Added
+- Format crosswalk for API filtering and related 400 Invalid request error
 ### Fixed
 - Ensure that covers are present in API responses
+- Add `edition_count` to API response
+- Handle additional `|` characters in subject headings
 
 ## 2021-04-05 -- v0.5.0
 ### Added

--- a/api/blueprints/drbSearch.py
+++ b/api/blueprints/drbSearch.py
@@ -1,5 +1,5 @@
 from flask import Blueprint, request, current_app
-from ..elastic import ElasticClient
+from ..elastic import ElasticClient, ElasticClientError
 from ..db import DBClient
 from ..utils import APIUtils
 from logger import createLog
@@ -28,7 +28,12 @@ def standardQuery():
 
     logger.info('Executing ES Query {} with filters {}'.format(searchParams, terms['filter']))
 
-    searchResult = esClient.searchQuery(terms, page=searchPage, perPage=searchSize)
+    try:
+        searchResult = esClient.searchQuery(terms, page=searchPage, perPage=searchSize)
+    except ElasticClientError as e:
+        return APIUtils.formatResponseObject(
+            400, 'searchResponse', {'message': str(e)}
+        )
 
     resultIds = [
         (r.uuid, [e.edition_id for e in r.meta.inner_hits.editions.hits])

--- a/api/utils.py
+++ b/api/utils.py
@@ -71,6 +71,7 @@ class APIUtils():
     @classmethod
     def formatWork(cls, work, editionIds, showAll):
         workDict = dict(work)
+        workDict['edition_count'] = len(work.editions)
         workDict['editions'] = []
 
         for edition in work.editions:

--- a/managers/sfrRecord.py
+++ b/managers/sfrRecord.py
@@ -507,7 +507,13 @@ class SFRRecordManager:
     def subjectParser(self, subjects):
         cleanSubjects = {}
         for subj in subjects:
-            heading, auth, authNo = subj.split('|')
+            try:
+                heading, auth, authNo = subj.split('|')
+            except ValueError:
+                authNoRev, authRev, *headRevArr = subj[::-1].split('|')
+                authNo = authNoRev[::-1]
+                auth = authRev[::-1]
+                heading = ','.join(headRevArr)[::-1]
 
             if heading == '': continue
 

--- a/tests/unit/test_api_utils.py
+++ b/tests/unit/test_api_utils.py
@@ -156,6 +156,7 @@ class TestAPIUtils:
         assert testWorkDict['title'] == 'Test Title'
         assert testWorkDict['editions'][0]['edition_id'] == 'ed1'
         assert testWorkDict['editions'][0]['items'][0] == 'it1'
+        assert testWorkDict['edition_count'] == 1
         mockFormatEdition.assert_called_once()
 
     def test_formatWork_showAll_false(self, testWork, mocker):
@@ -166,6 +167,7 @@ class TestAPIUtils:
         assert testWorkDict['uuid'] == 'testUUID'
         assert testWorkDict['title'] == 'Test Title'
         assert len(testWorkDict['editions']) == 1
+        assert testWorkDict['edition_count'] == 1
 
     def test_formatWork_blocked_edition(self, testWork):
         testWork.editions[0].items = []
@@ -174,6 +176,7 @@ class TestAPIUtils:
         assert testWorkDict['uuid'] == 'testUUID'
         assert testWorkDict['title'] == 'Test Title'
         assert len(testWorkDict['editions']) == 0
+        assert testWorkDict['edition_count'] == 1
 
     def test_formatEditionOputput(self, mocker):
         mockFormatEdition = mocker.patch.object(APIUtils, 'formatEdition')

--- a/tests/unit/test_sfrRecord_manager.py
+++ b/tests/unit/test_sfrRecord_manager.py
@@ -387,9 +387,19 @@ class TestSFRRecordManager:
     def test_subjectParser(self, testInstance, mocker):
         mockSetDelimited = mocker.patch.object(SFRRecordManager, 'setPipeDelimitedData')
         mockSetDelimited.return_value = ['testSubject']
-        testInstance.subjectParser(['Test||', 'test.|auth|1234'])
+        testInstance.subjectParser(['Test||', 'test.|auth|1234', '|auth|56768'])
 
         assert testInstance.work.subjects == ['testSubject']
         mockSetDelimited.assert_called_once_with(
             ['Test|auth|1234'], ['heading', 'authority', 'controlNo']
+        )
+
+    def test_subjectParser_unexpected_heading(self, testInstance, mocker):
+        mockSetDelimited = mocker.patch.object(SFRRecordManager, 'setPipeDelimitedData')
+        mockSetDelimited.return_value = ['testSubject']
+        testInstance.subjectParser(['Test|Other|auth|1234'])
+
+        assert testInstance.work.subjects == ['testSubject']
+        mockSetDelimited.assert_called_once_with(
+            ['Test,Other|auth|1234'], ['heading', 'authority', 'controlNo']
         )


### PR DESCRIPTION
This implements a number of improvements and necessary fixes for the API to be released as `v0.5.1`. These are:

- Added a crosswalk between simple values that can be passed as URL parameters and the full `media_type` values as stored in the ElasticSearch index
- Handle related `400` Invalid request error with a custom response
- Add `edition_count` to API response
- Improve handling of unexpected characters in subject heading parsing