### PR TITLE
HOTFIX Resolve breaking error with sqlalchemy query construction

### DIFF
--- a/api/db.py
+++ b/api/db.py
@@ -17,9 +17,9 @@ class DBClient():
 
         return session.query(Work)\
             .join(Edition)\
-            .option(joinedload(Edition.links))\
+            .options(joinedload(Work.editions, Edition.links))\
             .join(Item)\
-            .option(joinedload(Item.links))\
+            .options(joinedload(Work.editions, Edition.items, Item.links))\
             .filter(Work.uuid.in_(uuids), Edition.id.in_(editionIds))\
             .all()
 

--- a/tests/unit/test_api_db.py
+++ b/tests/unit/test_api_db.py
@@ -29,7 +29,7 @@ class TestDBClient:
         mockMaker.return_value = mockCreator
         mockSession = mocker.MagicMock()
         mockCreator.return_value = mockSession
-        mockSession.query().join().option().join().option().filter()\
+        mockSession.query().join().options().join().options().filter()\
             .all.return_value = ['work1', 'work3']
 
         mockFlatten = mocker.patch.object(APIUtils, 'flatten')
@@ -42,7 +42,7 @@ class TestDBClient:
         assert workResult == ['work1', 'work3']
         mockMaker.assert_called_once_with(bind=testInstance.engine)
         mockCreator.assert_called_once()
-        mockSession.query().join().option().join().option().filter()\
+        mockSession.query().join().options().join().options().filter()\
             .all.assert_called_once()
 
     def test_fetchSingleWork(self, testInstance, mocker):


### PR DESCRIPTION
Fixes an erroneous update to improve query performance. Substitutes `options` for `option` and ensures that a full path for the join clause is present.