### PR TITLE
NOREF Edition Detail and RabbitMQ fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## unreleased -- v0.5.4
+### Fixed
+- Typo in edition detail parsing method
+- Handle errors in connection to RabbitMQ server on message get and acknowledge
+
 ## 2021-04-08 --v0.5.3
 ### Fixed
 - Included instance records in edition detail response

--- a/api/db.py
+++ b/api/db.py
@@ -52,9 +52,7 @@ class DBClient():
     def fetchSingleLink(self, linkID):
         session = sessionmaker(bind=self.engine)()
 
-        return session.query(Link)\
-            .options(joinedload(Link.items, Item.edition, Edition.work))\
-            .filter(Link.id == linkID).first()
+        return session.query(Link).filter(Link.id == linkID).first()
 
     def fetchRecordsByUUID(self, uuids):
         session = sessionmaker(bind=self.engine)()

--- a/api/utils.py
+++ b/api/utils.py
@@ -142,7 +142,7 @@ class APIUtils():
         
         outRecord['authors'] = cls.formatPipeDelimitedData(record.authors, ['name', 'viaf', 'lcnaf', 'primary'])
         outRecord['contributors'] = cls.formatPipeDelimitedData(record.contributors, ['name', 'viaf', 'lcnaf', 'rolse'])
-        outRecord['publishers'] = cls.formatPipeDelimitedData(record.publishers, ['name', 'viaf', 'lcnaf'])
+        outRecord['publishers'] = cls.formatPipeDelimitedData(record.publisher, ['name', 'viaf', 'lcnaf'])
         outRecord['dates'] = cls.formatPipeDelimitedData(record.dates, ['date', 'type'])
         outRecord['languages'] = cls.formatPipeDelimitedData(record.languages, ['language', 'iso_2', 'iso_3'])
         outRecord['identifiers'] = cls.formatPipeDelimitedData(record.identifiers, ['identifier', 'authority'])

--- a/managers/rabbitmq.py
+++ b/managers/rabbitmq.py
@@ -69,7 +69,17 @@ class RabbitMQManager:
 
     
     def getMessageFromQueue(self, queueName):
-        return self.channel.basic_get(queueName)
+        try:
+            return self.channel.basic_get(queueName)
+        except (ConnectionWrongStateError, StreamLostError):
+            self.createRabbitConnection()
+            self.createChannel()
+            return self.getMessageFromQueue(queueName)
     
     def acknowledgeMessageProcessed(self, deliveryTag):
-        self.channel.basic_ack(deliveryTag)
+        try:
+            self.channel.basic_ack(deliveryTag)
+        except (ConnectionWrongStateError, StreamLostError):
+            self.createRabbitConnection()
+            self.createChannel()
+            self.acknowledgeMessageProcessed(deliveryTag)

--- a/tests/unit/test_api_db.py
+++ b/tests/unit/test_api_db.py
@@ -29,8 +29,7 @@ class TestDBClient:
         mockMaker.return_value = mockCreator
         mockSession = mocker.MagicMock()
         mockCreator.return_value = mockSession
-        mockSession.query().join().options().join().options().filter()\
-            .all.return_value = ['work1', 'work3']
+        mockSession.query().join().options().filter().all.return_value = ['work1', 'work3']
 
         mockFlatten = mocker.patch.object(APIUtils, 'flatten')
         mockFlatten.return_value = [1, 2, 3]
@@ -42,8 +41,7 @@ class TestDBClient:
         assert workResult == ['work1', 'work3']
         mockMaker.assert_called_once_with(bind=testInstance.engine)
         mockCreator.assert_called_once()
-        mockSession.query().join().options().join().options().filter()\
-            .all.assert_called_once()
+        mockSession.query().join().options().filter().all.assert_called_once()
 
     def test_fetchSingleWork(self, testInstance, mocker):
         mockCreator = mocker.MagicMock()
@@ -51,14 +49,14 @@ class TestDBClient:
         mockMaker.return_value = mockCreator
         mockSession = mocker.MagicMock()
         mockCreator.return_value = mockSession
-        mockSession.query().filter().first.return_value = 'testWork'
+        mockSession.query().options().filter().first.return_value = 'testWork'
 
         workResult = testInstance.fetchSingleWork('uuid')
 
         assert workResult == 'testWork'
         mockMaker.assert_called_once_with(bind=testInstance.engine)
         mockCreator.assert_called_once()
-        mockSession.query().filter().first.assert_called_once()
+        mockSession.query().options().filter().first.assert_called_once()
 
     def test_fetchSingleEdition(self, testInstance, mocker):
         mockCreator = mocker.MagicMock()
@@ -66,14 +64,14 @@ class TestDBClient:
         mockMaker.return_value = mockCreator
         mockSession = mocker.MagicMock()
         mockCreator.return_value = mockSession
-        mockSession.query().filter().first.return_value = 'testEdition'
+        mockSession.query().options().filter().first.return_value = 'testEdition'
 
         editionResult = testInstance.fetchSingleEdition('editionID')
 
         assert editionResult == 'testEdition'
         mockMaker.assert_called_once_with(bind=testInstance.engine)
         mockCreator.assert_called_once()
-        mockSession.query().filter().first.assert_called_once()
+        mockSession.query().options().filter().first.assert_called_once()
 
     def test_fetchSingleLink(self, testInstance, mocker):
         mockCreator = mocker.MagicMock()
@@ -81,14 +79,14 @@ class TestDBClient:
         mockMaker.return_value = mockCreator
         mockSession = mocker.MagicMock()
         mockCreator.return_value = mockSession
-        mockSession.query().filter().first.return_value = 'testLink'
+        mockSession.query().options().filter().first.return_value = 'testLink'
 
         editionResult = testInstance.fetchSingleLink('linkID')
 
         assert editionResult == 'testLink'
         mockMaker.assert_called_once_with(bind=testInstance.engine)
         mockCreator.assert_called_once()
-        mockSession.query().filter().first.assert_called_once()
+        mockSession.query().options().filter().first.assert_called_once()
 
     def test_fetchRecordsByUUID(self, testInstance, mocker):
         mockCreator = mocker.MagicMock()

--- a/tests/unit/test_api_db.py
+++ b/tests/unit/test_api_db.py
@@ -79,14 +79,14 @@ class TestDBClient:
         mockMaker.return_value = mockCreator
         mockSession = mocker.MagicMock()
         mockCreator.return_value = mockSession
-        mockSession.query().options().filter().first.return_value = 'testLink'
+        mockSession.query().filter().first.return_value = 'testLink'
 
         editionResult = testInstance.fetchSingleLink('linkID')
 
         assert editionResult == 'testLink'
         mockMaker.assert_called_once_with(bind=testInstance.engine)
         mockCreator.assert_called_once()
-        mockSession.query().options().filter().first.assert_called_once()
+        mockSession.query().filter().first.assert_called_once()
 
     def test_fetchRecordsByUUID(self, testInstance, mocker):
         mockCreator = mocker.MagicMock()

--- a/tests/unit/test_api_utils.py
+++ b/tests/unit/test_api_utils.py
@@ -64,7 +64,7 @@ class TestAPIUtils:
             table_of_contents='Test TOC',
             authors=['auth1', 'auth2', 'auth3'],
             contributors=['contrib1', 'contrib2'],
-            publishers=['pub1'],
+            publisher=['pub1'],
             dates=['date1', 'date2'],
             languages=['lang1'],
             identifiers=['id1', 'id2', 'id3'],


### PR DESCRIPTION
This bugfix commit includes two minor fixes to different aspects of the application.

- In the edition detail parser an erronous `publishers` reference is changed to `publisher`
- In the RabbitMQ client errors in connections are now handled for message receipt and acknowledgement, as well as generation.