### PR TITLE
NOREF Resolve bugs in Edition detail endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 ### Fixed
 - Typo in edition detail parsing method
 - Handle errors in connection to RabbitMQ server on message get and acknowledge
+- Handle None values in Record array fields
+- Handle expired session error in Edition detail request
 
 ## 2021-04-08 --v0.5.3
 ### Fixed

--- a/api/db.py
+++ b/api/db.py
@@ -20,9 +20,9 @@ class DBClient():
             .options(
                 contains_eager(Work.editions),
                 joinedload(Work.editions, Edition.links),
-                joinedload(Work.editions, Edition.rights),
                 joinedload(Work.editions, Edition.items),
-                joinedload(Work.editions, Edition.items, Item.links, innerjoin=True)
+                joinedload(Work.editions, Edition.items, Item.links, innerjoin=True),
+                joinedload(Work.editions, Edition.items, Item.rights),
             )\
             .filter(Work.uuid.in_(uuids), Edition.id.in_(editionIds))\
             .all()
@@ -45,7 +45,9 @@ class DBClient():
         return session.query(Edition)\
             .options(
                 joinedload(Edition.links),
-                joinedload(Edition.rights)
+                joinedload(Edition.items),
+                joinedload(Edition.items, Item.links),
+                joinedload(Edition.items, Item.rights)
             )\
             .filter(Edition.id == editionID).first()
 

--- a/api/utils.py
+++ b/api/utils.py
@@ -214,7 +214,10 @@ class APIUtils():
 
     @staticmethod
     def formatPipeDelimitedData(data, fields):
-        if isinstance(data, list):
-            return [dict(zip(fields, d.split('|'))) for d in data]
+        if data is None:
+            return None
+        elif isinstance(data, list):
+            dataList = list(filter(None, data))
+            return [dict(zip(fields, d.split('|'))) for d in dataList]
         else:
             return dict(zip(fields, data.split('|')))

--- a/tests/unit/test_api_utils.py
+++ b/tests/unit/test_api_utils.py
@@ -346,5 +346,8 @@ class TestAPIUtils:
             == {'one': 'test', 'two': 'object'}
 
     def test_formatPipeDelimitedData_list(self):
-        assert APIUtils.formatPipeDelimitedData(['test|object', 'another|thing'], ['one', 'two'])\
+        assert APIUtils.formatPipeDelimitedData(['test|object', None, 'another|thing'], ['one', 'two'])\
             == [{'one': 'test', 'two': 'object'}, {'one': 'another', 'two': 'thing'}]
+
+    def test_formatPipeDelimitedData_none(self):
+        assert APIUtils.formatPipeDelimitedData(None, ['one', 'two']) == None


### PR DESCRIPTION
This resolves two lingering issues in the edition detail endpoint:

- The method for parsing pipe delimited data did not anticipate `None` values and now handles those
- The eager loading for the Editions did not properly load `Item` links and rights objects. This was corrected