### PR TITLE
HOTFIX Remove edition eager loading

### DIFF
--- a/api/db.py
+++ b/api/db.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from sqlalchemy.orm import joinedload, contains_eager, sessionmaker
+from sqlalchemy.orm import joinedload, sessionmaker
 from sqlalchemy.sql import text
 
 from model import Work, Edition, Link, Item, Record
@@ -18,7 +18,6 @@ class DBClient():
         return session.query(Work)\
             .join(Edition)\
             .options(
-                contains_eager(Work.editions),
                 joinedload(Work.editions, Edition.links),
                 joinedload(Work.editions, Edition.items),
                 joinedload(Work.editions, Edition.items, Item.links, innerjoin=True),


### PR DESCRIPTION
A setting in an effort to improve load times was causing the `edition_count` value to be incorrect. Removing an `options` call in the database query resolves the issue. This line was intended to improve performance, however removing seems to have a negligible, if any, impact on loading times.