### PR TITLE
NOREF 20210410 bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## unreleased -- v0.5.5
 ### Fixed
 - Added deadlock handling to batch commit method
+- Skip record from classify that have already been processed
+- Handle closed channel in rabbitMQ manager
+
 
 ## 2021-04-09 -- v0.5.4
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unreleased -- v0.5.5
+### Fixed
+- Added deadlock handling to batch commit method
+
 ## 2021-04-09 -- v0.5.4
 ### Fixed
 - Typo in edition detail parsing method

--- a/managers/rabbitmq.py
+++ b/managers/rabbitmq.py
@@ -1,7 +1,7 @@
 import json
 from pika import BlockingConnection, ConnectionParameters
 from pika.credentials import PlainCredentials
-from pika.exceptions import ConnectionWrongStateError, StreamLostError
+from pika.exceptions import ConnectionWrongStateError, StreamLostError, ChannelClosedByBroker
 import os
 
 class RabbitMQManager:
@@ -75,6 +75,11 @@ class RabbitMQManager:
             self.createRabbitConnection()
             self.createChannel()
             return self.getMessageFromQueue(queueName)
+        except ChannelClosedByBroker:
+            self.createRabbitConnection()
+            self.createChannel()
+
+        return None
     
     def acknowledgeMessageProcessed(self, deliveryTag):
         try:

--- a/processes/oclcClassify.py
+++ b/processes/oclcClassify.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from lxml import etree
 import os
 
 from .core import CoreProcess
@@ -89,17 +90,25 @@ class ClassifyProcess(CoreProcess):
             iden=identifier, idenType=idType, author=author, title=title
         )
 
-        for classifyResult in classifier.getClassifyResponse():
-            self.createClassifyDCDWRecord(classifyResult, identifier, idType)
+        for classifyXML in classifier.getClassifyResponse():
+            if self.checkIfClassifyWorkFetched(classifyXML) is True:
+                logger.debug('Skipping Duplicate Classify Record')
+                continue
+
+            classifier.checkAndFetchAdditionalEditions(classifyXML)
+
+            self.createClassifyDCDWRecord(
+                classifyXML, classifier.addlIds, identifier, idType
+            )
     
-    def createClassifyDCDWRecord(self, classifyResult, identifier, idType):
-        classifyXML, additionalOCLCs = classifyResult
+    def createClassifyDCDWRecord(self, classifyXML, additionalOCLCs, identifier, idType):
         classifyRec = ClassifyMapping(
             classifyXML,
             {'oclc': 'http://classify.oclc.org'},
             {},
             (identifier, idType)
         )
+
         classifyRec.applyMapping()
 
         classifyRec.extendIdentifiers(additionalOCLCs)
@@ -121,3 +130,10 @@ class ClassifyProcess(CoreProcess):
         self.sendMessageToQueue(
             self.rabbitQueue, self.rabbitRoute, {'oclcNo': oclcNo, 'owiNo': owiNo}
         )
+
+    def checkIfClassifyWorkFetched(self, classifyXML):
+        workOWI = classifyXML.find(
+            './/work', namespaces=ClassifyManager.NAMESPACE
+        ).attrib['owi']
+
+        return self.checkSetRedis('classifyWork', workOWI, 'owi')

--- a/processes/oclcClassify.py
+++ b/processes/oclcClassify.py
@@ -63,9 +63,6 @@ class ClassifyProcess(CoreProcess):
                 logger.warning('Exceeding max requests to OCLC catalog, breaking')
                 break
 
-            if len(self.records) >= 100:
-                self.saveRecords()
-
     def frbrizeRecord(self, record):
         for iden in ClassifyManager.getQueryableIdentifiers(record.identifiers):
             identifier, idenType = tuple(iden.split('|'))

--- a/tests/unit/test_oclcClassify_process.py
+++ b/tests/unit/test_oclcClassify_process.py
@@ -1,4 +1,5 @@
 import datetime
+from lxml import etree
 import os
 import pytest
 
@@ -27,6 +28,18 @@ class TestOCLCClassifyProcess:
                 self.rabbitRoute = os.environ['OCLC_ROUTING_KEY']
         
         return TestClassifyProcess('TestProcess', 'testFile', 'testDate')
+    
+    @pytest.fixture
+    def testXMLResponse(self):
+        def constructResponse(code, responseBlock):
+            return etree.fromstring('''<?xml version="1.0"?>
+                <classify xmlns="http://classify.oclc.org" xmlns:oclc="http://classify.oclc.org">
+                    <response code="{}"/>
+                    {}
+                </classify>
+            '''.format(code, responseBlock))
+        
+        return constructResponse
 
     @pytest.fixture
     def testRecord(self, mocker):
@@ -210,12 +223,14 @@ class TestOCLCClassifyProcess:
         
     def test_classifyRecordByMetadata_success(self, testInstance, mocker):
         mockClassifier = mocker.patch('processes.oclcClassify.ClassifyManager')
-        mockClassifierInstance = mocker.MagicMock()
+        mockClassifierInstance = mocker.MagicMock(addlIds=[])
         mockClassifier.return_value = mockClassifierInstance
         mockClassifierInstance.getClassifyResponse.return_value = [
             'xml1', 'xml2', 'xml3'
         ]
 
+        mockCheckFetched = mocker.patch.object(ClassifyProcess, 'checkIfClassifyWorkFetched')
+        mockCheckFetched.side_effect = [False, True, False]
         mockCreateDCDW = mocker.patch.object(ClassifyProcess, 'createClassifyDCDWRecord')
 
         testInstance.classifyRecordByMetadata('1', 'test', 'testAuthor', 'testTitle')
@@ -223,12 +238,19 @@ class TestOCLCClassifyProcess:
         mockClassifier.assert_called_once_with(
             iden='1', idenType='test', author='testAuthor', title='testTitle'
         )
-        mockClassifier.getClassifyResponse.assert_called_once
+
+        mockClassifierInstance.getClassifyResponse.assert_called_once()
+
+        mockCheckFetched.assert_has_calls([
+            mocker.call('xml1'), mocker.call('xml2'), mocker.call('xml3')
+        ])
+
+        mockClassifierInstance.checkAndFetchAdditionalEditions.assert_has_calls([
+            mocker.call('xml1'), mocker.call('xml3')
+        ])
 
         mockCreateDCDW.assert_has_calls([
-            mocker.call('xml1', '1', 'test'),
-            mocker.call('xml2', '1', 'test'),
-            mocker.call('xml3', '1', 'test')
+            mocker.call('xml1', [], '1', 'test'), mocker.call('xml3', [], '1', 'test')
         ])
 
     def test_classifyRecordByMetadata_error(self, testInstance, mocker):
@@ -237,7 +259,7 @@ class TestOCLCClassifyProcess:
         mockClassifier.return_value = mockClassifierInstance
         mockClassifierInstance.getClassifyResponse.side_effect = ClassifyError
 
-        mockCreateDCDW = mocker.patch.object(ClassifyProcess, 'createClassifyDCDWRecord')
+        mocker.patch.object(ClassifyProcess, 'createClassifyDCDWRecord')
 
         with pytest.raises(ClassifyError):
             testInstance.classifyRecordByMetadata('1', 'test', 'testAuthor', 'testTitle')
@@ -293,3 +315,13 @@ class TestOCLCClassifyProcess:
         mockSendMessage.assert_called_once_with(
             'test_oclc_queue', 'test_oclc_key', {'oclcNo': '1', 'owiNo': '1'}
         )
+
+    def test_checkIfClassifyWorkFetched(self, testInstance, testXMLResponse, mocker):
+        testXML = testXMLResponse(2, '<work owi="1"/>')
+
+        mockCheckRedis = mocker.patch.object(ClassifyProcess, 'checkSetRedis')
+        mockCheckRedis.return_value = False
+
+        assert testInstance.checkIfClassifyWorkFetched(testXML) == False
+
+        mockCheckRedis.assert_called_once_with('classifyWork', '1', 'owi')

--- a/tests/unit/test_oclcClassify_process.py
+++ b/tests/unit/test_oclcClassify_process.py
@@ -76,7 +76,6 @@ class TestOCLCClassifyProcess:
 
     def test_classifyRecords_not_full(self, testInstance, mocker):
         mockFrbrize = mocker.patch.object(ClassifyProcess, 'frbrizeRecord')
-        mockFrbrize.side_effect = lambda x: testInstance.records.add(len(testInstance.records))
         mockSession = mocker.MagicMock()
         mockQuery = mocker.MagicMock()
         testInstance.session = mockSession
@@ -90,17 +89,13 @@ class TestOCLCClassifyProcess:
         mockOCLCCheck = mocker.patch.object(ClassifyProcess, 'checkIncrementerRedis')
         mockOCLCCheck.side_effect = [False] * 100
 
-        mockSave = mocker.patch.object(ClassifyProcess, 'saveRecords')
-
         testInstance.classifyRecords()
 
         mockWindowed.assert_called_once()
         mockFrbrize.assert_has_calls([mocker.call(rec) for rec in mockRecords])
-        mockSave.assert_called_once()
 
     def test_classifyRecords_custom_range(self, testInstance, mocker):
         mockFrbrize = mocker.patch.object(ClassifyProcess, 'frbrizeRecord')
-        mockFrbrize.side_effect = lambda x: testInstance.records.add(len(testInstance.records))
         mockSession = mocker.MagicMock()
         mockQuery = mocker.MagicMock()
         testInstance.session = mockSession
@@ -115,19 +110,15 @@ class TestOCLCClassifyProcess:
         mockOCLCCheck = mocker.patch.object(ClassifyProcess, 'checkIncrementerRedis')
         mockOCLCCheck.side_effect = [False] * 100
 
-        mockSave = mocker.patch.object(ClassifyProcess, 'saveRecords')
-
         testInstance.classifyRecords(startDateTime='testDate')
 
         mockDatetime.utcnow.assert_not_called()
         mockDatetime.timedelta.assert_not_called()
         mockWindowed.assert_called_once()
         mockFrbrize.assert_has_calls([mocker.call(rec) for rec in mockRecords])
-        mockSave.assert_called_once()
 
     def test_classifyRecords_full(self, testInstance, mocker):
         mockFrbrize = mocker.patch.object(ClassifyProcess, 'frbrizeRecord')
-        mockFrbrize.side_effect = lambda x: testInstance.records.add(len(testInstance.records))
         mockSession = mocker.MagicMock()
         mockQuery = mocker.MagicMock()
         testInstance.session = mockSession
@@ -141,19 +132,15 @@ class TestOCLCClassifyProcess:
         mockOCLCCheck = mocker.patch.object(ClassifyProcess, 'checkIncrementerRedis')
         mockOCLCCheck.side_effect = [False] * 50 + [True]
 
-        mockSave = mocker.patch.object(ClassifyProcess, 'saveRecords')
-
         testInstance.classifyRecords(full=True)
 
         mockDatetime.utcnow.assert_not_called()
         mockDatetime.timedelta.assert_not_called()
         mockWindowed.assert_called_once()
         mockFrbrize.assert_has_calls([mocker.call(rec) for rec in mockRecords[:50]])
-        mockSave.assert_not_called()
 
     def test_classifyRecords_full_batch(self, testInstance, mocker):
         mockFrbrize = mocker.patch.object(ClassifyProcess, 'frbrizeRecord')
-        mockFrbrize.side_effect = lambda x: testInstance.records.add(len(testInstance.records))
         mockSession = mocker.MagicMock()
         mockQuery = mocker.MagicMock()
         testInstance.session = mockSession
@@ -167,15 +154,12 @@ class TestOCLCClassifyProcess:
         mockOCLCCheck = mocker.patch.object(ClassifyProcess, 'checkIncrementerRedis')
         mockOCLCCheck.side_effect = [False] * 100
 
-        mockSave = mocker.patch.object(ClassifyProcess, 'saveRecords')
-
         testInstance.ingestLimit = 100
         testInstance.classifyRecords(full=True)
 
         mockDatetime.utcnow.assert_not_called()
         mockDatetime.timedelta.assert_not_called()
         mockFrbrize.assert_has_calls([mocker.call(rec) for rec in mockRecords])
-        mockSave.assert_called_once()
 
     def test_frbrizeRecord_success_valid_author(self, testInstance, testRecord, mocker):
         mockIdentifiers = mocker.patch.object(ClassifyManager, 'getQueryableIdentifiers')

--- a/tests/unit/test_oclcClassify_process.py
+++ b/tests/unit/test_oclcClassify_process.py
@@ -273,7 +273,7 @@ class TestOCLCClassifyProcess:
         mockAddDCDW = mocker.patch.object(ClassifyProcess, 'addDCDWToUpdateList')
         mockfetchOCLC = mocker.patch.object(ClassifyProcess, 'fetchOCLCCatalogRecords')
 
-        testInstance.createClassifyDCDWRecord(('testXML', []), '1', 'test')
+        testInstance.createClassifyDCDWRecord('testXML', [], '1', 'test')
 
         mockMapping.assert_called_once_with(
             'testXML', {'oclc': 'http://classify.oclc.org'}, {}, ('1', 'test')


### PR DESCRIPTION
This includes a number of stability and performance bugfixes pertaining mainly to OCLC services. These are:

- Handle closed channel errors when processing OCLC Catalog records
- Skip Classify records that have already been processed for faster operation of the Classify process
- Handle database deadlocks in the classify process (which should be less common with the above improvements)