### PR TITLE
NOREF 20210412 bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Added deadlock handling to batch commit method
 - Skip record from classify that have already been processed
 - Handle closed channel in rabbitMQ manager
+- Move Record status update to standard batch query
+- Handle `None` values in array of author names
 
 
 ## 2021-04-09 -- v0.5.4

--- a/processes/oclcClassify.py
+++ b/processes/oclcClassify.py
@@ -56,7 +56,6 @@ class ClassifyProcess(CoreProcess):
         for rec in self.windowedQuery(Record, baseQuery, windowSize=windowSize):
             self.frbrizeRecord(rec)
 
-
             # Update Record with status
             rec.cluster_status = False
             rec.frbr_status = 'complete'


### PR DESCRIPTION
These are two minor bugfixes to handle stability issues in the OCLC Classify Process.

- Deadlocks can be received when updating the status of queried records while classifying them. At present these updates are made individually, but due to improvements in the query process this is no longer necessary. Instead these records are added to the session and committed in a method that handles/retries when deadlocks are encontered. This obviates the need for additional deadlock handling.
- Adding an additional error class to an author parsing method. Previously this expected either a null value or an array of strings. This new condition also handles an array which contains null values.