### PR TITLE
SFR-1022 Update DOAB to OAI_DC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Handle closed channel in rabbitMQ manager
 - Move Record status update to standard batch query
 - Handle `None` values in array of author names
-
+- Update DOAB ingest process to consume OAI_DC records
 
 ## 2021-04-09 -- v0.5.4
 ### Fixed

--- a/managers/parsers/abstractParser.py
+++ b/managers/parsers/abstractParser.py
@@ -40,7 +40,9 @@ class AbstractParser(ABC):
 
         manifest.addChapter(sourceURI, self.record.title)
 
-        manifest.links['self'] = {'href': manifestURI, 'type': 'application/webpub+json'}
+        manifest.links.append(
+            {'rel': 'self', 'href': manifestURI, 'type': 'application/webpub+json'}
+        )
 
         return manifest.toJson()
 

--- a/managers/sfrRecord.py
+++ b/managers/sfrRecord.py
@@ -180,10 +180,8 @@ class SFRRecordManager:
         # Contributors
         itemContributors = set()
         for contrib in rec.contributors:
-            try:
-                _, _, _, role = tuple(contrib.split('|'))
-            except ValueError:
-                _, role = tuple(contrib.split('|'))
+            role = tuple(contrib.split('|'))[-1]
+
             if role in ['publisher', 'manufacturer', 'distributor', 'printer']:
                 editionData['contributors'].add(contrib)
             elif role in ['provider', 'repository', 'digitizer', 'responsible']:
@@ -399,7 +397,7 @@ class SFRRecordManager:
     def saveItem(self, item):
         links = item.pop('links', [])
         identifiers = item.pop('identifiers', [])
-        rights = item.pop('rights', None)
+        rights = item.pop('rights', [])
         newItem = Item(**item)
 
         # Set Links
@@ -414,7 +412,7 @@ class SFRRecordManager:
 
         # Set Rights
         newItem.rights = SFRRecordManager.setPipeDelimitedData(
-            [rights],
+            rights if isinstance(rights, list) else [rights],
             ['source', 'license', 'rights_reason', 'rights_statement', 'rights_date'],
             Rights,
             dParser=lambda x: dict(list(filter(lambda y: y[1] != '', x.items())))
@@ -471,9 +469,9 @@ class SFRRecordManager:
 
         for agent in agents:
             agentParts = agent.split('|')
-            if len(agentParts) < len(fields):
+
+            while len(agentParts) < len(fields):
                 agentParts.insert(1, '')
-                agentParts.insert(2, '')
 
             rec = dict(zip(fields, agentParts))
             recKey = re.sub(r'[.,:\(\)]+', '', rec['name'].lower())

--- a/mappings/doab.py
+++ b/mappings/doab.py
@@ -1,78 +1,60 @@
 import re
 
-from mappings.marc import MARCMapping
+from mappings.xml import XMLMapping
 
-class DOABMapping(MARCMapping):
-    SUBJ_IND_2 = {
-        0: 'lcsh', 1: 'lcch', 2: 'msh', 3: 'nalsaf', 4: '', 5: 'csh', 6: 'rvm'
-    }
-
-    def __init__(self, source, statics):
-        super(DOABMapping, self).__init__(source, statics)
+class DOABMapping(XMLMapping):
+    def __init__(self, source, namespace, statics):
+        super(DOABMapping, self).__init__(source, namespace, statics)
         self.mapping = self.createMapping()
     
     def createMapping(self):
         return {
             'identifiers': [
-                ('001', '{0}|doab'),
-                ('010', '{a}{z}|lccn'),
-                ('020', '{a}{z}|isbn'),
-                ('022', '{a}{z}|issn'),
-                ('024', '{a}|{s2}'),
-                ('035', '{a}{z}|oclc'),
-                ('040', '{a}{z}|doab')
+                ('./dc:identifier/text()', '{0}|doab'),
+                (
+                    [
+                        './datacite:alternateIdentifier/text()',
+                        './datacite:alternateIdentifier/@type'
+                    ],
+                    '{0}|{1}'
+                )
             ],
-            'authors': [
-                ('100', '{a} {b} {c} {d}|||true'),
-                ('110', '{a} {b} {c} {n} {d}|||true'),
-                ('111', '{a} {e}|||true')
-            ],
-            'title': ('245', '{a} {b}'),
-            'alternative': [
-                ('210', '{a}'),
-                ('222', '{a}'),
-                ('240', '{a} {k}'), # Uniform Title
-                ('242', '{a}'),
-                ('246', '{a}'),
-                ('247', '{a}')
-            ],
-            'has_version': ('250', '{a} {b}|'),
-            'publisher': ('260', '{b}||'),
-            'spatial': ('264', '{a}'),
+            'authors': [('./datacite:creator/text()', '{0}|||true')],
+            'contributors': [(
+                [
+                    './datacite:contributor/text()',
+                    './datacite:contributor/@type'
+                ],
+                '{0}||{1}'
+            )],
+            'title': ('./datacite:title/text()', '{0}'),
+            'is_part_of': [('./dc:relation/text()', '{0}||series')],
+            'publisher': ('./dc:publisher/text()', '{0}||'),
+            'spatial': ('./oapen:placepublication/text()', '{0}'),
             'dates': [
-                ('260', '{c}|publication_date'),
-                ('264', '{c}|copyright_date')
+                (
+                    [
+                        './datacite:date/text()',
+                        './datacite:date/@type'
+                    ],
+                    '{0}|{1}'
+                )
             ],
-            'languages': [('546', '{a}||')],
-            'extent': ('300', '{a}{b}{c}{e}{f}'),
-            'table_of_contents': ('505', '{a}'),
-            'abstract': [
-                ('500', '{a}'),
-                ('504', '{a}'),
-                ('520', '{a}'),
-            ],
-            'subjects': [
-                ('600', '{a} {b} {c} {d} {q} -- {v} -- {x} -- {y} -- {z}|{ind2}|{0}'),
-                ('610', '{a} {b} {c} {d} -- {v} -- {x} -- {y} -- {z}|{ind2}|{0}'),
-                ('611', '{a} {d} -- {v} -- {x} -- {y} -- {z}|{ind2}|{0}'),
-                ('630', '{a} {p} -- {v} -- {x} -- {y} -- {z}|{ind2}|{0}'),
-                ('648', '{a} -- {v} -- {x} -- {y} -- {z}|{ind2}|{0}'),
-                ('650', '{a} {b} -- {v} -- {x} -- {y} -- {z}|{ind2}|{0}'),
-                ('651', '{a} -- {v} -- {x} -- {y} -- {z}|{ind2}|{0}'),
-                ('655', '{a} {b} {c} -- {v} -- {x} -- {y} -- {z}|{ind2}|{0}'),
-                ('656', '{a} -- {v} -- {x} -- {y} -- {z}|{ind2}|{0}'),
-                ('657', '{a} -- {v} -- {x} -- {y} -- {z}|{ind2}|{0}')
-            ],
-            'contributors': [
-                ('260', '{f}|||manufacturer'),
-                ('700', '{a} {b} {c} {d}|||{s4}'),
-                ('710', '{a} {b} {c} {d}|||{s4}'),
-                ('711', '{a} {e}|||{s4}'),
-            ],
-            'is_part_of': ('490', '{a}|{v}|volume'),
-            'has_part': [
-                ('856', '1|{u}|doab|text/html|{{"reader": false, "download": false, "catalog": false}}')
-            ]
+            'languages': [('./dc:language/text()', '||{0}')],
+            'extent': ('./oapen:pages/text()', '{0} pages'),
+            'abstract': ('./dc:description/text()', '{0}'),
+            'subjects': [('./datacite:subject/text()', '{0}||')],
+            'has_part': [(
+                './dc:identifier/text()',
+                '1|{0}|doab|text/html|{{"reader": false, "download": false, "catalog": false}}'
+            )],
+            'rights': [(
+                [
+                    './oaire:licenseCondition/@uri',
+                    './oaire:licenseCondition/text()'
+                ],
+                'doab|{0}||{1}|'
+            )]
         }
 
     def applyFormatting(self):
@@ -81,61 +63,5 @@ class DOABMapping(MARCMapping):
         self.record.source = 'doab'
         self.record.source_id = list(self.record.identifiers[0].split('|'))[0]
 
-        # Clean up languages (splitting if necessary)
-        cleanLanguages = []
-        for language in self.record.languages:
-            cleanLanguages.extend(self.cleanAndSplitLanguage(language))
-        self.record.languages = cleanLanguages
-
-        # Clean up subjects to remove spots for missing subheadings
-        self.record.subjects = [
-            self.cleanUpSubjectHead(s)
-            for s in self.record.subjects
-        ]
-
-        # Lookup MARC contributor codes and transform to full strings
-        self.record.contributors = [
-            self.parseContributorCode(c) for c in self.record.contributors
-        ]
-
-        # Add Rights statement
-        self.record.rights = '{}|{}||{}|'.format(
-            'doab', 'https://creativecommons.org/licenses/by-nc-nd/4.0/',
-            'Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International'
-        )
-
-    def parseContributorCode(self, contributor):
-        *contribComponents, role = contributor.split('|')
-        lcRelation = self.staticValues['marc']['contributorCodes'].get(role, 'contributor')
-        return '{}|{}|{}|{}'.format(*contribComponents, lcRelation)
-
-    def cleanUpSubjectHead(self, subject):
-        subjectStr, authority, authNo = subject.split('|')
-        subjectParts = subjectStr.split('--')
-
-        outParts = []
-
-        for part in subjectParts:
-            cleanPart = part.strip(' .')
-            
-            if cleanPart == '': continue
-
-            outParts.append(cleanPart)
-
-        cleanSubject = ' -- '.join([p for p in outParts])
-
-        try:
-            authority = self.SUBJ_IND_2.get(int(authority), '')
-        except ValueError:
-            authority = ''
-
-        return '{}|{}|{}'.format(cleanSubject, authority, authNo)
-
-    def cleanAndSplitLanguage(self, language):
-        lang, *_ = language.split('|')
-        langs = re.split(r'/|\|', lang)
-
-        return [
-            '||{}'.format(l) if len(l) == 3 else '{}||'.format(l)
-            for l in langs
-        ]
+        # Clean up subjects
+        self.record.subjects = list(filter(lambda x: x[:3] != 'bic', self.record.subjects))

--- a/mappings/doab.py
+++ b/mappings/doab.py
@@ -27,7 +27,7 @@ class DOABMapping(XMLMapping):
                     './datacite:contributor/text()',
                     './datacite:contributor/@type'
                 ],
-                '{0}||{1}'
+                '{0}|||{1}'
             )],
             'title': ('./datacite:title/text()', '{0}'),
             'is_part_of': [('./dc:relation/text()', '{0}||series')],
@@ -85,21 +85,20 @@ class DOABMapping(XMLMapping):
         if self.record.source_id is None or len(self.record.identifiers) < 1:
             self.raiseMappingError('Malformed DOAB record')
 
-        print(self.record.title, self.record.source_id)
-
     def parseIdentifiers(self):
         outIDs = []
 
         for iden in self.record.identifiers:
-            if iden[:4] == 'http':
-                doabDOIGroup = re.search(self.DOI_REGEX, iden)
+            value, auth = iden.split('|')
+
+            if value[:4] == 'http':
+                doabDOIGroup = re.search(self.DOI_REGEX, value)
 
                 if doabDOIGroup:
-                    self.record.source_id = doabDOIGroup.group(1)
-
-                continue
-
-            value, auth = iden.split('|')
+                    value = doabDOIGroup.group(1)
+                    self.record.source_id = value
+                else:
+                    continue
 
             outIDs.append('{}|{}'.format(value, auth.lower()))
 
@@ -115,7 +114,7 @@ class DOABMapping(XMLMapping):
 
             outRights.append('|'.join(rightsData))
 
-        return [outRights]
+        return outRights
 
     def parseLinks(self):
         outLinks = []

--- a/processes/doab.py
+++ b/processes/doab.py
@@ -96,7 +96,7 @@ class DOABProcess(CoreProcess):
             oaiFile = self.downloadOAIRecords(fullOrPartial, startTimestamp, resumptionToken=resumptionToken)
 
             resumptionToken = self.getResumptionToken(oaiFile)
-            print(resumptionToken)
+
             if recordsProcessed < self.ingestOffset:
                 recordsProcessed += 100
                 continue

--- a/processes/doab.py
+++ b/processes/doab.py
@@ -57,13 +57,11 @@ class DOABProcess(CoreProcess):
         except MappingError as e:
             raise DOABError(e.message)
 
-        for field in ['identifiers', 'authors', 'contributors', 'title', 'is_part_of', 'publisher', 'spatial', 'dates', 'languages', 'extent', 'abstract', 'subjects', 'has_part', 'rights']:
-            print(field, getattr(doabRec.record, field, None))
-
-        '''
         linkManager = DOABLinkManager(doabRec.record)
         
         linkManager.parseLinks()
+
+        print(doabRec.record.has_part)
 
         for manifest in linkManager.manifests:
             manifestPath, manifestJSON = manifest
@@ -74,7 +72,6 @@ class DOABProcess(CoreProcess):
             self.sendFileToProcessingQueue(ePubURI, ePubPath)
 
         self.addDCDWToUpdateList(doabRec)
-        '''
 
     def importSingleOAIRecord(self, recordID):
         urlParams = 'verb=GetRecord&metadataPrefix=oai_dc&identifier=oai:directory.doabooks.org:{}'.format(recordID)

--- a/processes/doab.py
+++ b/processes/doab.py
@@ -11,6 +11,8 @@ from managers import DOABLinkManager
 
 
 class DOABProcess(CoreProcess):
+    ROOT_NAMESPACE = {None: 'http://www.openarchives.org/OAI/2.0/'}
+
     OAI_NAMESPACES = {
         'oai_dc': 'http://www.openarchives.org/OAI/2.0/oai_dc/',
         'dc': 'http://purl.org/dc/elements/1.1/',
@@ -61,8 +63,6 @@ class DOABProcess(CoreProcess):
         
         linkManager.parseLinks()
 
-        print(doabRec.record.has_part)
-
         for manifest in linkManager.manifests:
             manifestPath, manifestJSON = manifest
             self.createManifestInS3(manifestPath, manifestJSON)
@@ -96,7 +96,7 @@ class DOABProcess(CoreProcess):
             oaiFile = self.downloadOAIRecords(fullOrPartial, startTimestamp, resumptionToken=resumptionToken)
 
             resumptionToken = self.getResumptionToken(oaiFile)
-
+            print(resumptionToken)
             if recordsProcessed < self.ingestOffset:
                 recordsProcessed += 100
                 continue
@@ -119,7 +119,7 @@ class DOABProcess(CoreProcess):
     def getResumptionToken(self, oaiFile):
             try:
                 oaiXML = etree.parse(oaiFile)
-                return oaiXML.find('.//resumptionToken', namespaces=self.OAI_NAMESPACES).text
+                return oaiXML.find('.//resumptionToken', namespaces=self.ROOT_NAMESPACE).text
             except AttributeError:
                 return None
 

--- a/processes/doab.py
+++ b/processes/doab.py
@@ -2,7 +2,6 @@ from datetime import datetime, timedelta
 from io import BytesIO
 from lxml import etree
 import os
-from pymarc import parse_xml_to_array
 import requests
 
 from .core import CoreProcess
@@ -12,7 +11,13 @@ from managers import DOABLinkManager
 
 
 class DOABProcess(CoreProcess):
-    OAI_NS = '{http://www.openarchives.org/OAI/2.0/}'
+    OAI_NAMESPACES = {
+        'oai_dc': 'http://www.openarchives.org/OAI/2.0/oai_dc/',
+        'dc': 'http://purl.org/dc/elements/1.1/',
+        'datacite': 'https://schema.datacite.org/meta/kernel-4.1/metadata.xsd',
+        'oapen': 'http://purl.org/dc/elements/1.1/',
+        'oaire': 'https://raw.githubusercontent.com/rcic/openaire4/master/schemas/4.0/oaire.xsd'
+    }
 
     def __init__(self, *args):
         super(DOABProcess, self).__init__(*args[:4])
@@ -45,13 +50,17 @@ class DOABProcess(CoreProcess):
         self.saveRecords()
         self.commitChanges()
     
-    def parseDOABRecord(self, marcRec):
+    def parseDOABRecord(self, oaiRec):
         try:
-            doabRec = DOABMapping(marcRec, self.statics)
+            doabRec = DOABMapping(oaiRec, self.OAI_NAMESPACES, self.statics)
             doabRec.applyMapping()
         except MappingError as e:
             raise DOABError(e.message)
 
+        for field in ['identifiers', 'authors', 'contributors', 'title', 'is_part_of', 'publisher', 'spatial', 'dates', 'languages', 'extent', 'abstract', 'subjects', 'has_part', 'rights']:
+            print(field, getattr(doabRec.record, field, None))
+
+        '''
         linkManager = DOABLinkManager(doabRec.record)
         
         linkManager.parseLinks()
@@ -65,19 +74,20 @@ class DOABProcess(CoreProcess):
             self.sendFileToProcessingQueue(ePubURI, ePubPath)
 
         self.addDCDWToUpdateList(doabRec)
+        '''
 
     def importSingleOAIRecord(self, recordID):
-        urlParams = 'verb=GetRecord&metadataPrefix=marcxml&identifier=oai:doab-books:{}'.format(recordID)
+        urlParams = 'verb=GetRecord&metadataPrefix=oai_dc&identifier=oai:directory.doabooks.org:{}'.format(recordID)
         doabURL = '{}{}'.format(os.environ['DOAB_OAI_URL'], urlParams)
 
         doabResponse = requests.get(doabURL, timeout=30, verify=False)
 
         if doabResponse.status_code == 200:
             content = BytesIO(doabResponse.content)
-            marcRecord = parse_xml_to_array(content)[0]
+            oaidcRecord = etree.parse(content)
 
             try:
-                self.parseDOABRecord(marcRecord)
+                self.parseDOABRecord(oaidcRecord)
             except DOABError as e:
                 print('ERROR', e)
     
@@ -94,9 +104,9 @@ class DOABProcess(CoreProcess):
                 recordsProcessed += 100
                 continue
             
-            marcReader = parse_xml_to_array(oaiFile)
-
-            for record in marcReader:
+            oaidcRecords = etree.parse(oaiFile)
+            
+            for record in oaidcRecords.xpath('//oai_dc:dc', namespaces=self.OAI_NAMESPACES):
                 if record is None: continue
 
                 try:
@@ -112,7 +122,7 @@ class DOABProcess(CoreProcess):
     def getResumptionToken(self, oaiFile):
             try:
                 oaiXML = etree.parse(oaiFile)
-                return oaiXML.find('.//{}resumptionToken'.format(self.OAI_NS)).text
+                return oaiXML.find('.//resumptionToken', namespaces=self.OAI_NAMESPACES).text
             except AttributeError:
                 return None
 
@@ -125,9 +135,9 @@ class DOABProcess(CoreProcess):
         elif fullOrPartial is False:
             if not startTimestamp:
                 startTimestamp = (datetime.utcnow() - timedelta(hours=24)).strftime('%Y-%m-%d')
-            urlParams = '{}&metadataPrefix=marcxml&from={}'.format(urlParams, startTimestamp)
+            urlParams = '{}&metadataPrefix=oai_dc&from={}'.format(urlParams, startTimestamp)
         else:
-            urlParams = '{}&metadataPrefix=marcxml'.format(urlParams)
+            urlParams = '{}&metadataPrefix=oai_dc'.format(urlParams)
 
         doabURL = '{}{}'.format(doabURL, urlParams)
             

--- a/tests/unit/test_doab_mapping.py
+++ b/tests/unit/test_doab_mapping.py
@@ -1,18 +1,20 @@
 import pytest
 
 from mappings.doab import DOABMapping
+from mappings.core import MappingError
 
 
 class TestDOABMapping:
     @pytest.fixture
     def testRecord(self, mocker):
         mockRecord = mocker.MagicMock()
-        mockRecord.identifiers = ['1|doab', '2|test', '3|other']
+        mockRecord.identifiers = ['1|doab', '2|TEST', 'http://doabooks.org/handle/00.00.00/0000|doi', 'http://test|doab']
         mockRecord.title = 'Main Title'
-        mockRecord.subjects = ['subj1', 'subj2', 'subj3']
-        mockRecord.has_part = ['1|testURL|muse|testType|testFlags']
+        mockRecord.subjects = ['subj1', 'subj2', 'subj3', 'bic subj4']
+        mockRecord.has_part = ['1|http://testURL|muse|testType|testFlags', '2|testID|muse|test|test']
         mockRecord.languages = ['||lang1', '||lang2']
         mockRecord.contributors = ['cont1||', 'cont2||']
+        mockRecord.rights = ['doab| license ||statement|', 'doab|||otherStmt|']
 
         return mockRecord
 
@@ -22,7 +24,6 @@ class TestDOABMapping:
             def __init__(self):
                 self.mapping = None
                 self.record = testRecord
-                self.staticValues = {'marc': {'contributorCodes': {'tst': 'Test'}}}
         
         return TestMapping()
 
@@ -30,42 +31,50 @@ class TestDOABMapping:
         recordMapping = testMapping.createMapping()
 
         assert list(recordMapping.keys()) == [
-            'identifiers', 'authors', 'title', 'alternative', 'has_version',
-            'publisher', 'spatial', 'dates', 'languages', 'extent',
-            'table_of_contents', 'abstract', 'subjects', 'contributors',
-            'is_part_of', 'has_part'
+            'identifiers', 'authors', 'contributors', 'title', 'is_part_of',
+            'publisher', 'spatial', 'dates', 'languages', 'extent', 'abstract',
+            'subjects', 'has_part', 'rights'
         ]
-        assert recordMapping['is_part_of'] == ('490', '{a}|{v}|volume')
+        assert recordMapping['is_part_of'] == [('./dc:relation/text()', '{0}||series')]
 
     def test_applyFormatting(self, testMapping, mocker):
         mocker.patch.multiple(DOABMapping,
-            cleanAndSplitLanguage=mocker.MagicMock(side_effect=[['lng1'], ['lng2']]),
-            cleanUpSubjectHead=mocker.MagicMock(side_effect=['subj1', 'subj2', 'subj3']),
-            parseContributorCode=mocker.MagicMock(side_effect=['cont1', 'cont2'])
+            parseIdentifiers=mocker.MagicMock(return_value=['testID']),
+            parseRights=mocker.MagicMock(return_value='testRights'),
+            parseLinks=mocker.MagicMock(return_value='testLinks')
         )
 
+        testMapping.source_id = 'testID'
         testMapping.applyFormatting()
 
         assert testMapping.record.source == 'doab'
-        assert testMapping.record.source_id == '1'
         assert testMapping.record.title == 'Main Title'
         assert testMapping.record.subjects == ['subj1', 'subj2', 'subj3']
-        assert testMapping.record.languages == ['lng1', 'lng2']
-        assert testMapping.record.contributors == ['cont1', 'cont2']
-        assert list(testMapping.record.rights.split('|'))[0] == 'doab'
+        assert testMapping.record.identifiers == ['testID']
+        assert testMapping.record.rights == 'testRights'
+        assert testMapping.record.has_part == 'testLinks'
 
-    def test_parseContributorCode(self, testMapping):
-        assert testMapping.parseContributorCode('contrib|||tst') == 'contrib|||Test'
+    def test_applyFormatting_invalid_record_error(self, testMapping, mocker):
+        mocker.patch.multiple(DOABMapping,
+            parseIdentifiers=mocker.MagicMock(return_value=[]),
+            parseRights=mocker.MagicMock(return_value='testRights'),
+            parseLinks=mocker.MagicMock(return_value='testLinks')
+        )
 
-    def test_cleanUpSubjectHead(self, testMapping):
-        cleanSubject = testMapping.cleanUpSubjectHead('first -- second. -- -- ||')
+        with pytest.raises(MappingError):
+            testMapping.applyFormatting()
 
-        assert cleanSubject == 'first -- second||'
+    def test_parseIdentifiers(self, testMapping):
+        cleanIdentifiers = testMapping.parseIdentifiers()
 
-    def test_cleanUpSubjectHead_authority(self, testMapping):
-        cleanSubject = testMapping.cleanUpSubjectHead('first -- second. -- -- |0|')
+        assert cleanIdentifiers == ['1|doab', '2|test', '00.00.00/0000|doi']
 
-        assert cleanSubject == 'first -- second|lcsh|'
+    def test_parseRights(self, testMapping):
+        cleanRights = testMapping.parseRights()
 
-    def test_cleanAndSplitLanguage(self, testMapping):
-        assert testMapping.cleanAndSplitLanguage('English/deu||') == ['English||', '||deu']
+        assert cleanRights == ['doab|license||statement|']
+
+    def test_parseLinks(self, testMapping):
+        cleanLinks = testMapping.parseLinks()
+
+        assert cleanLinks == ['1|http://testURL|muse|testType|testFlags']

--- a/tests/unit/test_parser_abstract.py
+++ b/tests/unit/test_parser_abstract.py
@@ -47,7 +47,7 @@ class TestAbstractParser:
         assert testParser.createLinks() == [('http://testURI', None ,'testType', None, None)]
 
     def test_generateManifest(self, testParser, mocker):
-        mockManifest = mocker.MagicMock(links={})
+        mockManifest = mocker.MagicMock(links=[])
         mockManifest.toJson.return_value = 'jsonManifest'
 
         mockManifestManager = mocker.patch('managers.parsers.abstractParser.WebpubManifest')
@@ -56,7 +56,7 @@ class TestAbstractParser:
         testManifest = testParser.generateManifest('sourceURI', 'manifestURI')
 
         assert testManifest == 'jsonManifest'
-        assert mockManifest.links == {'self': {'href': 'manifestURI', 'type': 'application/webpub+json'}}
+        assert mockManifest.links == [{'rel': 'self', 'href': 'manifestURI', 'type': 'application/webpub+json'}]
         mockManifestManager.assert_called_once_with('sourceURI', 'application/pdf')
         mockManifest.addMetadata.assert_called_once_with(testParser.record)
         mockManifest.addChapter.assert_called_once_with('sourceURI', 'testRecord')


### PR DESCRIPTION
A recent migration of the DOAB website and API required an update to the SFR ingest process to properly access these records. No longer are DOAB records published as full MARCXML records (only "stub" MARC records are now available), and instead the ingest process needs to harvest OAI_DC records. Fortunately these are also XML records and the overall data structure did not change too drastically, so this does not represent a huge difference. Importantly we are still able to parse records for the source of their ebook files and follow those paths to retrieve ePub and PDF representations of the books. In addition to the main conversion from MARCXML to OAI_DC, this work included:

- An update to the primary identifier for each record, which is now a DOI
- Simplification to some other fields, including alternate titles and other less important metadata
- A merging of some fields (subjects, links, identifiers) into very similar elements that required explicit parsing to seperate
- A new XML structure that required changes to the mapping to properly parse (ensuring that only one child OAI record is being parsed at a time).