### PR TITLE
NOREF Classify Process Improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Format `publication_date` in Link endpoint response
 - Remove `verify=False` from GET requests
 - Handle malformed author and identifiers in DOAB process
+- Improved Classification process performance
 
 
 ## 2021-04-12 -- v0.5.5

--- a/mappings/core.py
+++ b/mappings/core.py
@@ -35,8 +35,9 @@ class Core(AbstractMapping):
             if attr == 'uuid': continue
             setattr(existing, attr, value)
         
-        existing.frbr_status = 'to_do'
         existing.cluster_status = False
+        if existing.source not in ['oclcClassify', 'oclcCatalog']:
+            existing.frbr_status = 'to_do'
 
     def raiseMappingError(self, message):
         raise MappingError(message)

--- a/processes/core.py
+++ b/processes/core.py
@@ -38,6 +38,7 @@ class CoreProcess(DBManager, NyplApiManager, RabbitMQManager, RedisManager, Stat
     
     def windowedQuery(self, table, query, windowSize=100):
         singleEntity = query.is_single_entity
+        query = query.add_column(table.date_modified).order_by(table.date_modified)
         query = query.add_column(table.id).order_by(table.id)
 
         lastID = None

--- a/processes/oclcClassify.py
+++ b/processes/oclcClassify.py
@@ -47,7 +47,7 @@ class ClassifyProcess(CoreProcess):
     
     def classifyRecords(self, full=False, startDateTime=None):
         baseQuery = self.session.query(Record)\
-            .filter(Record.source != 'oclcClassify')\
+            .filter(Record.source != 'oclcClassify' and Record.source != 'oclcCatalog')\
             .filter(Record.frbr_status == 'to_do')
 
         if full is False:
@@ -139,6 +139,7 @@ class ClassifyProcess(CoreProcess):
                 self.setIncrementerRedis('oclcCatalog', 'API')
     
     def sendCatalogLookupMessage(self, oclcNo, owiNo):
+        logger.debug('Sending OCLC# {} to queue'.format(oclcNo))
         self.sendMessageToQueue(
             self.rabbitQueue, self.rabbitRoute, {'oclcNo': oclcNo, 'owiNo': owiNo}
         )

--- a/tests/unit/test_core_mapping.py
+++ b/tests/unit/test_core_mapping.py
@@ -57,13 +57,27 @@ class TestCoreMapping:
         ]
         testMapping.record = mockRecord
 
-        mockExisting = mocker.MagicMock()
-        mockExisting.uuid = 'uuid2'
-        mockExisting.frb_status = 'complete'
+        mockExisting = mocker.MagicMock(uuid='uuid2', source='test', frbr_status='complete')
 
         testMapping.updateExisting(mockExisting)
 
         assert mockExisting.uuid == 'uuid2'
         assert mockExisting.title == 'Test Title'
         assert mockExisting.frbr_status == 'to_do'
+        assert mockExisting.cluster_status == False
+
+    def test_updateExisting_oclc(self, testMapping, mocker):
+        mockRecord = mocker.MagicMock()
+        mockRecord.__iter__.return_value = [
+            ('uuid', 'uuid1'), ('title', 'Test Title')
+        ]
+        testMapping.record = mockRecord
+
+        mockExisting = mocker.MagicMock(uuid='uuid2', source='oclcClassify', frbr_status='complete')
+
+        testMapping.updateExisting(mockExisting)
+
+        assert mockExisting.uuid == 'uuid2'
+        assert mockExisting.title == 'Test Title'
+        assert mockExisting.frbr_status == 'complete'
         assert mockExisting.cluster_status == False


### PR DESCRIPTION
Investigations into the Classification process revealed several small tweaks that should improve performance:

- Adding an additional `ORDER BY` parameter to the windowed query method. This forces postgres to adequately plan/index these queries
- Prevent OCLC Catalog records from being classified, by definition these records are already classified