### PR TITLE
NOREF Update Cluster Process committing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Fixed
 - Escape special characters in search queries
 - Handle colons in the body of search queries
+- Add deadlock handling in `ClusterProcess`
 
 
 ## 2021-04-15 -- v0.5.6


### PR DESCRIPTION
While clustering records, the source records must be marked as processed (to avoid duplicating work). Previously this was done with a bare `update` statement. When running concurrently with other processes this can cause a deadlock in rare cases. This method was therefore refactored so that the `commit` can happen within a `try/except` block that handles the deadlock error.