### PR TITLE
Remove Changelog Requirement for Regression Tests

### DIFF
--- a/.github/workflows/tests-regression.yaml
+++ b/.github/workflows/tests-regression.yaml
@@ -7,15 +7,6 @@ on:
     - cron:  '0 0 * * 1'
 
 jobs:
-  changelog:
-    name: Updates Changelog
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: dangoslen/changelog-enforcer@v1.4.0
-        with:
-          changeLogPath: "CHANGELOG.md"
-          skipLabel: "no-changelog"
   test:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add deadlock handling in `ClusterProcess`
 - Scheduled tests-regression.yaml to run every Monday 12 AM EST
 - Renamed tests.yaml as "tests-unit.yaml"
+- Remove changelog job from tests-regression.yaml
 
 
 ## 2021-04-15 -- v0.5.6


### PR DESCRIPTION
Since tests run by allure-pytest will not have changes associated with each scheduled run, there is no need for Changelog requirement in Github workflow tests-regression.yaml.