### PR TITLE
SFR-1057 Add Temporary deployment Action

### DIFF
--- a/.github/workflows/build-branch-qa.yaml
+++ b/.github/workflows/build-branch-qa.yaml
@@ -1,6 +1,6 @@
 # On merge to development,
 # build a container and deploy to ECR
-name: Publish qa
+name: Publish Branch
 on:
   pull_request:
     branches: [main]

--- a/.github/workflows/build-branch-qa.yaml
+++ b/.github/workflows/build-branch-qa.yaml
@@ -67,13 +67,14 @@ jobs:
         if: ${{ steps.task-present-check.outputs.existingtask == 'false' }}
         env:
           BRANCH_NAME: ${{ github.head_ref }}
-        run: aws ecs create-service \
-          --cluster sfr-pipeline-qa \
-          --service-name $BRANCH_NAME-qa \
-          --task-definition sfr-pipeline-testing \
-          --desired-count 1 \
-          --launch-type FARGATE \
-          --network-configuration awsvpcConfiguration={subnets=[subnet-42f2e16f,subnet-6b1edc23],securityGroups=[sg-016cf234aebd31f7d],assignPublicIp=ENABLED}
+        run: | 
+          aws ecs create-service \
+            --cluster sfr-pipeline-qa \
+            --service-name $BRANCH_NAME-qa \
+            --task-definition sfr-pipeline-testing \
+            --desired-count 1 \
+            --launch-type FARGATE \
+            --network-configuration awsvpcConfiguration={subnets=[subnet-42f2e16f,subnet-6b1edc23],securityGroups=[sg-016cf234aebd31f7d],assignPublicIp=ENABLED}
 
       - name: Get ARN of branch QA task
         if: ${{ steps.task-present-check.outputs.existingtask == 'false' }}

--- a/.github/workflows/build-branch-qa.yaml
+++ b/.github/workflows/build-branch-qa.yaml
@@ -4,7 +4,7 @@ name: Publish Branch
 on:
   pull_request:
     branches: [main]
-    types: [opened]
+    types: [opened, reopened, synchronize]
 
 jobs:
   publish_qa:

--- a/.github/workflows/build-branch-qa.yaml
+++ b/.github/workflows/build-branch-qa.yaml
@@ -7,9 +7,8 @@ on:
     types: [opened, reopened, synchronize]
 
 jobs:
-  publish_qa:
+  build_branch:
     name: Publish image to ECR
-    if: github.event.pull_request.merged
     runs-on: ubuntu-latest
     steps:
       - name: checkout
@@ -37,7 +36,18 @@ jobs:
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
 
+      - name: Check if task and service already exists
+        id: task-present-check
+        run: echo "::set-output name=existing-task-arn::aws ecs list-tasks --cluster sfr-pipeline-qa --family sfr-pipeline-testing | jq '.taskArns[0]'"
+
+      - name: Force update of existing task with new container
+        if: ${{ steps.task-present-check.outputs.existing-task-arn != null }}
+        env:
+          BRANCH_NAME: ${{ github.head_ref }}
+        run: aws ecs update-service --cluster sfr-pipeline-qa --service $BRANCH_NAME-qa --force-new-deployment
+ 
       - name: Populate task definition for API container
+        if: ${{ steps.task-present-check.outputs.existing-task-arn == null }}
         id: render-api-container
         uses: aws-actions/amazon-ecs-render-task-definition@v1
         with:
@@ -46,9 +56,11 @@ jobs:
           image: ${{ steps.build-image.outputs.image }}
 
       - name: Deploy task definition to ECS
+        if: ${{ steps.task-present-check.outputs.existing-task-arn == null }}
         run: aws ecs register-task-definition --cli-input-json file://task-definition.json
 
       - name: Create new service in ECS cluster
+        if: ${{ steps.task-present-check.outputs.existing-task-arn == null }}
         env:
           BRANCH_NAME: ${{ github.head_ref }}
         run: aws ecs create-service \
@@ -60,18 +72,17 @@ jobs:
           --network-configuration awsvpcConfiguration={subnets=[subnet-42f2e16f,subnet-6b1edc23],securityGroups=[sg-016cf234aebd31f7d],assignPublicIp=ENABLED}
 
       - name: Get ARN of branch QA task
+        if: ${{ steps.task-present-check.outputs.existing-task-arn == null }}
         id: get-task-arn
-        env:
-          BRANCH_NAME: ${{ github.head_ref }}
-        run: echo "::set-output name=task-arn::aws ecs list-tasks --cluster sfr-pipeline-qa --family $BRANCH_NAME-qa | jq '.taskArns[0]'"
+        run: echo "::set-output name=task-arn::aws ecs list-tasks --cluster sfr-pipeline-qa --family sfr-pipeline-testing | jq '.taskArns[0]'"
 
       - name: Get deployed URL for service
+        if: ${{ steps.task-present-check.outputs.existing-task-arn == null }}
         id: get-task-ip
-        env:
-          BRANCH_NAME: ${{ github.head_ref }}
         run: echo "::set-output name=task-ip::aws ecs describe-tasks --cluster sfr-pipeline-qa --tasks ${{ steps.get-task-arn.outputs.task-arn }} | jq '.tasks[0].attachments[0].details[4].value'
 
       - name: Add Task IP as comment to PR
+        if: ${{ steps.task-present-check.outputs.existing-task-arn == null }}
         uses: peter-evans/create-or-update-comment@v1
         with:
           body: |

--- a/.github/workflows/build-branch-qa.yaml
+++ b/.github/workflows/build-branch-qa.yaml
@@ -38,16 +38,19 @@ jobs:
 
       - name: Check if task and service already exists
         id: task-present-check
-        run: echo "::set-output name=existing-task-arn::aws ecs list-tasks --cluster sfr-pipeline-qa --family sfr-pipeline-testing | jq '.taskArns[0]'"
+        run: |
+          taskarn=$(aws ecs list-tasks --cluster sfr-pipeline-qa --family sfr-pipeline-testing | jq '.taskArns[0]')
+          existingtask=$(if [[ "$taskarn" != "null" ]]; then echo true; else echo false; fi)
+          echo "::set-output name=existingtask::$existingtask"
 
       - name: Force update of existing task with new container
-        if: ${{ steps.task-present-check.outputs.existing-task-arn != null }}
+        if: ${{ steps.task-present-check.outputs.existingtask == true }}
         env:
           BRANCH_NAME: ${{ github.head_ref }}
         run: aws ecs update-service --cluster sfr-pipeline-qa --service $BRANCH_NAME-qa --force-new-deployment
  
       - name: Populate task definition for API container
-        if: ${{ steps.task-present-check.outputs.existing-task-arn == null }}
+        if: ${{ steps.task-present-check.outputs.existingtask == false }}
         id: render-api-container
         uses: aws-actions/amazon-ecs-render-task-definition@v1
         with:
@@ -60,7 +63,7 @@ jobs:
         run: aws ecs register-task-definition --cli-input-json file://task-definition.json
 
       - name: Create new service in ECS cluster
-        if: ${{ steps.task-present-check.outputs.existing-task-arn == null }}
+        if: ${{ steps.task-present-check.outputs.existingtask == false }}
         env:
           BRANCH_NAME: ${{ github.head_ref }}
         run: aws ecs create-service \
@@ -72,17 +75,17 @@ jobs:
           --network-configuration awsvpcConfiguration={subnets=[subnet-42f2e16f,subnet-6b1edc23],securityGroups=[sg-016cf234aebd31f7d],assignPublicIp=ENABLED}
 
       - name: Get ARN of branch QA task
-        if: ${{ steps.task-present-check.outputs.existing-task-arn == null }}
+        if: ${{ steps.task-present-check.outputs.existingtask == false }}
         id: get-task-arn
         run: echo "::set-output name=task-arn::aws ecs list-tasks --cluster sfr-pipeline-qa --family sfr-pipeline-testing | jq '.taskArns[0]'"
 
       - name: Get deployed URL for service
-        if: ${{ steps.task-present-check.outputs.existing-task-arn == null }}
+        if: ${{ steps.task-present-check.outputs.existingtask == false }}
         id: get-task-ip
         run: echo "::set-output name=task-ip::aws ecs describe-tasks --cluster sfr-pipeline-qa --tasks ${{ steps.get-task-arn.outputs.task-arn }} | jq '.tasks[0].attachments[0].details[4].value'
 
       - name: Add Task IP as comment to PR
-        if: ${{ steps.task-present-check.outputs.existing-task-arn == null }}
+        if: ${{ steps.task-present-check.outputs.existingtask == false }}
         uses: peter-evans/create-or-update-comment@v1
         with:
           body: |

--- a/.github/workflows/build-branch-qa.yaml
+++ b/.github/workflows/build-branch-qa.yaml
@@ -1,5 +1,4 @@
-# On merge to development,
-# build a container and deploy to ECR
+# On feature branch build container and deploy to temporary ECS service
 name: Publish Branch
 on:
   pull_request:
@@ -87,13 +86,14 @@ jobs:
         if: ${{ steps.task-present-check.outputs.existingtask == 'false' }}
         id: get-task-ip
         run: |
-          taskip=$(task-ip::aws ecs describe-tasks --cluster sfr-pipeline-qa --tasks ${{ steps.get-task-arn.outputs.taskarn }} | jq '.tasks[0].attachments[0].details[4].value')
+          taskip=$(aws ecs describe-tasks --cluster sfr-pipeline-qa --tasks ${{ steps.get-task-arn.outputs.taskarn }} | jq '.tasks[0].attachments[0].details[4].value')
           echo "::set-output name=taskip::$taskip"
 
       - name: Add Task IP as comment to PR
         if: ${{ steps.task-present-check.outputs.existingtask == 'false' }}
         uses: peter-evans/create-or-update-comment@v1
         with:
+          issue-number: ${{ github.event.number }}
           body: |
             This branch is deployed at the following locations:
 

--- a/.github/workflows/build-branch-qa.yaml
+++ b/.github/workflows/build-branch-qa.yaml
@@ -41,6 +41,7 @@ jobs:
         run: |
           taskarn=$(aws ecs list-tasks --cluster sfr-pipeline-qa --family sfr-pipeline-testing | jq '.taskArns[0]')
           existingtask=$(if [[ "$taskarn" != "null" ]]; then echo true; else echo false; fi)
+          echo $existingtask
           echo "::set-output name=existingtask::$existingtask"
 
       - name: Force update of existing task with new container
@@ -59,7 +60,7 @@ jobs:
           image: ${{ steps.build-image.outputs.image }}
 
       - name: Deploy task definition to ECS
-        if: ${{ steps.task-present-check.outputs.existing-task-arn == null }}
+        if: ${{ steps.task-present-check.outputs.existingtask == false }}
         run: aws ecs register-task-definition --cli-input-json file://task-definition.json
 
       - name: Create new service in ECS cluster

--- a/.github/workflows/build-branch-qa.yaml
+++ b/.github/workflows/build-branch-qa.yaml
@@ -75,11 +75,21 @@ jobs:
             --launch-type FARGATE \
             --network-configuration "awsvpcConfiguration={subnets=[subnet-42f2e16f,subnet-6b1edc23],securityGroups=[sg-016cf234aebd31f7d],assignPublicIp=ENABLED}"
 
+      - name: Wait for Service to become stable
+        if: ${{ steps.task-present-check.outputs.existingtask == 'false' }}
+        env:
+          BRANCH_NAME: ${{ github.head_ref }}
+        run: |
+          aws ecs wait services-stable \
+            --cluster sfr-pipeline-qa \
+            --services $BRANCH_NAME-qa
+
       - name: Get ARN of branch QA task
         if: ${{ steps.task-present-check.outputs.existingtask == 'false' }}
         id: get-task-arn
         run: |
           taskarn=$(aws ecs list-tasks --cluster sfr-pipeline-qa --family sfr-pipeline-testing | jq '.taskArns[0]')
+          echo "ARN: $taskarn"
           echo "::set-output name=taskarn::$taskarn"
 
       - name: Get deployed URL for service
@@ -87,6 +97,7 @@ jobs:
         id: get-task-ip
         run: |
           taskip=$(aws ecs describe-tasks --cluster sfr-pipeline-qa --tasks ${{ steps.get-task-arn.outputs.taskarn }} | jq '.tasks[0].attachments[0].details[4].value')
+          echo "IP: #taskip"
           echo "::set-output name=taskip::$taskip"
 
       - name: Add Task IP as comment to PR

--- a/.github/workflows/build-branch-qa.yaml
+++ b/.github/workflows/build-branch-qa.yaml
@@ -45,13 +45,13 @@ jobs:
           echo "::set-output name=existingtask::$existingtask"
 
       - name: Force update of existing task with new container
-        if: ${{ steps.task-present-check.outputs.existingtask }}
+        if: ${{ steps.task-present-check.outputs.existingtask == "true" }}
         env:
           BRANCH_NAME: ${{ github.head_ref }}
         run: aws ecs update-service --cluster sfr-pipeline-qa --service $BRANCH_NAME-qa --force-new-deployment
  
       - name: Populate task definition for API container
-        if: ${{ ! steps.task-present-check.outputs.existingtask }}
+        if: ${{ steps.task-present-check.outputs.existingtask == "false" }}
         id: render-api-container
         uses: aws-actions/amazon-ecs-render-task-definition@v1
         with:
@@ -60,11 +60,11 @@ jobs:
           image: ${{ steps.build-image.outputs.image }}
 
       - name: Deploy task definition to ECS
-        if: ${{ ! steps.task-present-check.outputs.existingtask }}
+        if: ${{ steps.task-present-check.outputs.existingtask == "false" }}
         run: aws ecs register-task-definition --cli-input-json file://task-definition.json
 
       - name: Create new service in ECS cluster
-        if: ${{ ! steps.task-present-check.outputs.existingtask }}
+        if: ${{ steps.task-present-check.outputs.existingtask == "false"}}
         env:
           BRANCH_NAME: ${{ github.head_ref }}
         run: aws ecs create-service \
@@ -76,17 +76,17 @@ jobs:
           --network-configuration awsvpcConfiguration={subnets=[subnet-42f2e16f,subnet-6b1edc23],securityGroups=[sg-016cf234aebd31f7d],assignPublicIp=ENABLED}
 
       - name: Get ARN of branch QA task
-        if: ${{ ! steps.task-present-check.outputs.existingtask }}
+        if: ${{ steps.task-present-check.outputs.existingtask == "false" }}
         id: get-task-arn
         run: echo "::set-output name=task-arn::aws ecs list-tasks --cluster sfr-pipeline-qa --family sfr-pipeline-testing | jq '.taskArns[0]'"
 
       - name: Get deployed URL for service
-        if: ${{ ! steps.task-present-check.outputs.existingtask }}
+        if: ${{ steps.task-present-check.outputs.existingtask == "false" }}
         id: get-task-ip
         run: echo "::set-output name=task-ip::aws ecs describe-tasks --cluster sfr-pipeline-qa --tasks ${{ steps.get-task-arn.outputs.task-arn }} | jq '.tasks[0].attachments[0].details[4].value'
 
       - name: Add Task IP as comment to PR
-        if: ${{ ! steps.task-present-check.outputs.existingtask }}
+        if: ${{ steps.task-present-check.outputs.existingtask == "false" }}
         uses: peter-evans/create-or-update-comment@v1
         with:
           body: |

--- a/.github/workflows/build-branch-qa.yaml
+++ b/.github/workflows/build-branch-qa.yaml
@@ -79,12 +79,16 @@ jobs:
       - name: Get ARN of branch QA task
         if: ${{ steps.task-present-check.outputs.existingtask == 'false' }}
         id: get-task-arn
-        run: echo "::set-output name=task-arn::aws ecs list-tasks --cluster sfr-pipeline-qa --family sfr-pipeline-testing | jq '.taskArns[0]'"
+        run: |
+          taskarn=$(aws ecs list-tasks --cluster sfr-pipeline-qa --family sfr-pipeline-testing | jq '.taskArns[0]')
+          echo "::set-output name=taskarn::$taskarn"
 
       - name: Get deployed URL for service
         if: ${{ steps.task-present-check.outputs.existingtask == 'false' }}
         id: get-task-ip
-        run: echo "::set-output name=task-ip::aws ecs describe-tasks --cluster sfr-pipeline-qa --tasks ${{ steps.get-task-arn.outputs.task-arn }} | jq '.tasks[0].attachments[0].details[4].value'
+        run: |
+          taskip=$(task-ip::aws ecs describe-tasks --cluster sfr-pipeline-qa --tasks ${{ steps.get-task-arn.outputs.taskarn }} | jq '.tasks[0].attachments[0].details[4].value')
+          echo "::set-output name=taskip::$taskip"
 
       - name: Add Task IP as comment to PR
         if: ${{ steps.task-present-check.outputs.existingtask == 'false' }}
@@ -93,5 +97,5 @@ jobs:
           body: |
             This branch is deployed at the following locations:
 
-            [DRB Front End](${{ steps.get-task-ip.output.task-ip}}:3000)
-            [DRB API](${{ steps.get-task-ip.output.task-ip}})
+            [DRB Front End](${{ steps.get-task-ip.output.taskip}}:3000)
+            [DRB API](${{ steps.get-task-ip.output.taskip}})

--- a/.github/workflows/build-branch-qa.yaml
+++ b/.github/workflows/build-branch-qa.yaml
@@ -89,7 +89,6 @@ jobs:
         id: get-task-arn
         run: |
           taskarn=$(aws ecs list-tasks --cluster sfr-pipeline-qa --family sfr-pipeline-testing | jq '.taskArns[0]')
-          echo "ARN: $taskarn"
           echo "::set-output name=taskarn::$taskarn"
 
       - name: Get deployed URL for service
@@ -97,7 +96,7 @@ jobs:
         id: get-task-ip
         run: |
           taskip=$(aws ecs describe-tasks --cluster sfr-pipeline-qa --tasks ${{ steps.get-task-arn.outputs.taskarn }} | jq '.tasks[0].attachments[0].details[4].value')
-          echo "IP: #taskip"
+          echo "IP: $taskip"
           echo "::set-output name=taskip::$taskip"
 
       - name: Add Task IP as comment to PR
@@ -108,5 +107,5 @@ jobs:
           body: |
             This branch is deployed at the following locations:
 
-            [DRB Front End](${{ steps.get-task-ip.output.taskip}}:3000)
-            [DRB API](${{ steps.get-task-ip.output.taskip}})
+            [DRB Front End](${{ steps.get-task-ip.outputs.taskip}}:3000)
+            [DRB API](${{ steps.get-task-ip.outputs.taskip}})

--- a/.github/workflows/build-branch-qa.yaml
+++ b/.github/workflows/build-branch-qa.yaml
@@ -95,7 +95,8 @@ jobs:
         if: ${{ steps.task-present-check.outputs.existingtask == 'false' }}
         id: get-task-ip
         run: |
-          taskip=$(aws ecs describe-tasks --cluster sfr-pipeline-qa --tasks ${{ steps.get-task-arn.outputs.taskarn }} | jq '.tasks[0].attachments[0].details[4].value')
+          tempip=$(aws ecs describe-tasks --cluster sfr-pipeline-qa --tasks ${{ steps.get-task-arn.outputs.taskarn }} | jq '.tasks[0].attachments[0].details[4].value')
+          taskip=$(echo $tempip | tr -d '"')
           echo "IP: $taskip"
           echo "::set-output name=taskip::$taskip"
 
@@ -107,5 +108,5 @@ jobs:
           body: |
             This branch is deployed at the following locations:
 
-            [DRB Front End](${{ steps.get-task-ip.outputs.taskip}}:3000)
-            [DRB API](${{ steps.get-task-ip.outputs.taskip}})
+            [DRB Front End](http://${{ steps.get-task-ip.outputs.taskip }}:3000)
+            [DRB API](http://${{ steps.get-task-ip.outputs.taskip }})

--- a/.github/workflows/build-branch-qa.yaml
+++ b/.github/workflows/build-branch-qa.yaml
@@ -97,7 +97,6 @@ jobs:
         run: |
           tempip=$(aws ecs describe-tasks --cluster sfr-pipeline-qa --tasks ${{ steps.get-task-arn.outputs.taskarn }} | jq '.tasks[0].attachments[0].details[4].value')
           taskip=$(echo $tempip | tr -d '"')
-          echo "IP: $taskip"
           echo "::set-output name=taskip::$taskip"
 
       - name: Add Task IP as comment to PR

--- a/.github/workflows/build-branch-qa.yaml
+++ b/.github/workflows/build-branch-qa.yaml
@@ -74,7 +74,7 @@ jobs:
             --task-definition sfr-pipeline-testing \
             --desired-count 1 \
             --launch-type FARGATE \
-            --network-configuration awsvpcConfiguration={subnets=[subnet-42f2e16f,subnet-6b1edc23],securityGroups=[sg-016cf234aebd31f7d],assignPublicIp=ENABLED}
+            --network-configuration "awsvpcConfiguration={subnets=[subnet-42f2e16f,subnet-6b1edc23],securityGroups=[sg-016cf234aebd31f7d],assignPublicIp=ENABLED}"
 
       - name: Get ARN of branch QA task
         if: ${{ steps.task-present-check.outputs.existingtask == 'false' }}

--- a/.github/workflows/build-branch-qa.yaml
+++ b/.github/workflows/build-branch-qa.yaml
@@ -45,13 +45,13 @@ jobs:
           echo "::set-output name=existingtask::$existingtask"
 
       - name: Force update of existing task with new container
-        if: ${{ steps.task-present-check.outputs.existingtask == true }}
+        if: ${{ steps.task-present-check.outputs.existingtask }}
         env:
           BRANCH_NAME: ${{ github.head_ref }}
         run: aws ecs update-service --cluster sfr-pipeline-qa --service $BRANCH_NAME-qa --force-new-deployment
  
       - name: Populate task definition for API container
-        if: ${{ steps.task-present-check.outputs.existingtask == false }}
+        if: ${{ ! steps.task-present-check.outputs.existingtask }}
         id: render-api-container
         uses: aws-actions/amazon-ecs-render-task-definition@v1
         with:
@@ -60,11 +60,11 @@ jobs:
           image: ${{ steps.build-image.outputs.image }}
 
       - name: Deploy task definition to ECS
-        if: ${{ steps.task-present-check.outputs.existingtask == false }}
+        if: ${{ ! steps.task-present-check.outputs.existingtask }}
         run: aws ecs register-task-definition --cli-input-json file://task-definition.json
 
       - name: Create new service in ECS cluster
-        if: ${{ steps.task-present-check.outputs.existingtask == false }}
+        if: ${{ ! steps.task-present-check.outputs.existingtask }}
         env:
           BRANCH_NAME: ${{ github.head_ref }}
         run: aws ecs create-service \
@@ -76,17 +76,17 @@ jobs:
           --network-configuration awsvpcConfiguration={subnets=[subnet-42f2e16f,subnet-6b1edc23],securityGroups=[sg-016cf234aebd31f7d],assignPublicIp=ENABLED}
 
       - name: Get ARN of branch QA task
-        if: ${{ steps.task-present-check.outputs.existingtask == false }}
+        if: ${{ ! steps.task-present-check.outputs.existingtask }}
         id: get-task-arn
         run: echo "::set-output name=task-arn::aws ecs list-tasks --cluster sfr-pipeline-qa --family sfr-pipeline-testing | jq '.taskArns[0]'"
 
       - name: Get deployed URL for service
-        if: ${{ steps.task-present-check.outputs.existingtask == false }}
+        if: ${{ ! steps.task-present-check.outputs.existingtask }}
         id: get-task-ip
         run: echo "::set-output name=task-ip::aws ecs describe-tasks --cluster sfr-pipeline-qa --tasks ${{ steps.get-task-arn.outputs.task-arn }} | jq '.tasks[0].attachments[0].details[4].value'
 
       - name: Add Task IP as comment to PR
-        if: ${{ steps.task-present-check.outputs.existingtask == false }}
+        if: ${{ ! steps.task-present-check.outputs.existingtask }}
         uses: peter-evans/create-or-update-comment@v1
         with:
           body: |

--- a/.github/workflows/build-branch-qa.yaml
+++ b/.github/workflows/build-branch-qa.yaml
@@ -45,13 +45,13 @@ jobs:
           echo "::set-output name=existingtask::$existingtask"
 
       - name: Force update of existing task with new container
-        if: ${{ steps.task-present-check.outputs.existingtask == "true" }}
+        if: ${{ steps.task-present-check.outputs.existingtask == 'true' }}
         env:
           BRANCH_NAME: ${{ github.head_ref }}
         run: aws ecs update-service --cluster sfr-pipeline-qa --service $BRANCH_NAME-qa --force-new-deployment
  
       - name: Populate task definition for API container
-        if: ${{ steps.task-present-check.outputs.existingtask == "false" }}
+        if: ${{ steps.task-present-check.outputs.existingtask == 'false' }}
         id: render-api-container
         uses: aws-actions/amazon-ecs-render-task-definition@v1
         with:
@@ -60,11 +60,11 @@ jobs:
           image: ${{ steps.build-image.outputs.image }}
 
       - name: Deploy task definition to ECS
-        if: ${{ steps.task-present-check.outputs.existingtask == "false" }}
+        if: ${{ steps.task-present-check.outputs.existingtask == 'false' }}
         run: aws ecs register-task-definition --cli-input-json file://task-definition.json
 
       - name: Create new service in ECS cluster
-        if: ${{ steps.task-present-check.outputs.existingtask == "false"}}
+        if: ${{ steps.task-present-check.outputs.existingtask == 'false' }}
         env:
           BRANCH_NAME: ${{ github.head_ref }}
         run: aws ecs create-service \
@@ -76,17 +76,17 @@ jobs:
           --network-configuration awsvpcConfiguration={subnets=[subnet-42f2e16f,subnet-6b1edc23],securityGroups=[sg-016cf234aebd31f7d],assignPublicIp=ENABLED}
 
       - name: Get ARN of branch QA task
-        if: ${{ steps.task-present-check.outputs.existingtask == "false" }}
+        if: ${{ steps.task-present-check.outputs.existingtask == 'false' }}
         id: get-task-arn
         run: echo "::set-output name=task-arn::aws ecs list-tasks --cluster sfr-pipeline-qa --family sfr-pipeline-testing | jq '.taskArns[0]'"
 
       - name: Get deployed URL for service
-        if: ${{ steps.task-present-check.outputs.existingtask == "false" }}
+        if: ${{ steps.task-present-check.outputs.existingtask == 'false' }}
         id: get-task-ip
         run: echo "::set-output name=task-ip::aws ecs describe-tasks --cluster sfr-pipeline-qa --tasks ${{ steps.get-task-arn.outputs.task-arn }} | jq '.tasks[0].attachments[0].details[4].value'
 
       - name: Add Task IP as comment to PR
-        if: ${{ steps.task-present-check.outputs.existingtask == "false" }}
+        if: ${{ steps.task-present-check.outputs.existingtask == 'false' }}
         uses: peter-evans/create-or-update-comment@v1
         with:
           body: |

--- a/.github/workflows/build-branch-qa.yaml
+++ b/.github/workflows/build-branch-qa.yaml
@@ -1,0 +1,81 @@
+# On merge to development,
+# build a container and deploy to ECR
+name: Publish qa
+on:
+  pull_request:
+    branches: [main]
+    types: [opened]
+
+jobs:
+  publish_qa:
+    name: Publish image to ECR
+    if: github.event.pull_request.merged
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: Configure AWS credentials from QA account
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Build, tag, and push image to Amazon ECR
+        id: build-image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: sfr_ingest_pipeline
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+
+      - name: Populate task definition for API container
+        id: render-api-container
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition: task-definition.json
+          container-name: sfr-api
+          image: ${{ steps.build-image.outputs.image }}
+
+      - name: Deploy task definition to ECS
+        run: aws ecs register-task-definition --cli-input-json file://task-definition.json
+
+      - name: Create new service in ECS cluster
+        env:
+          BRANCH_NAME: ${{ github.head_ref }}
+        run: aws ecs create-service \
+          --cluster sfr-pipeline-qa \
+          --service-name $BRANCH_NAME-qa \
+          --task-definition sfr-pipeline-testing \
+          --desired-count 1 \
+          --launch-type FARGATE \
+          --network-configuration awsvpcConfiguration={subnets=[subnet-42f2e16f,subnet-6b1edc23],securityGroups=[sg-016cf234aebd31f7d],assignPublicIp=ENABLED}
+
+      - name: Get ARN of branch QA task
+        id: get-task-arn
+        env:
+          BRANCH_NAME: ${{ github.head_ref }}
+        run: echo "::set-output name=task-arn::aws ecs list-tasks --cluster sfr-pipeline-qa --family $BRANCH_NAME-qa | jq '.taskArns[0]'"
+
+      - name: Get deployed URL for service
+        id: get-task-ip
+        env:
+          BRANCH_NAME: ${{ github.head_ref }}
+        run: echo "::set-output name=task-ip::aws ecs describe-tasks --cluster sfr-pipeline-qa --tasks ${{ steps.get-task-arn.outputs.task-arn }} | jq '.tasks[0].attachments[0].details[4].value'
+
+      - name: Add Task IP as comment to PR
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          body: |
+            This branch is deployed at the following locations:
+
+            [DRB Front End](${{ steps.get-task-ip.output.task-ip}}:3000)
+            [DRB API](${{ steps.get-task-ip.output.task-ip}})

--- a/.github/workflows/destroy-branch-qa.yaml
+++ b/.github/workflows/destroy-branch-qa.yaml
@@ -1,0 +1,25 @@
+# On merge to main destroy temporary feature branch QA environment
+name: Destroy Branch Environment
+on:
+  pull_request:
+    branches: [main]
+    types: [closed]
+
+jobs:
+  destroy_branch:
+    name: Remove temporary QA environment from ECS
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS credentials from QA account
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Delete Service from ECS cluster
+        run: |
+          aws ecs create-service \
+            --cluster sfr-pipeline-qa \
+            --service-name $BRANCH_NAME-qa \
+            --force

--- a/.github/workflows/destroy-branch-qa.yaml
+++ b/.github/workflows/destroy-branch-qa.yaml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Delete Service from ECS cluster
         run: |
-          aws ecs create-service \
+          aws ecs delete-service \
             --cluster sfr-pipeline-qa \
             --service-name $BRANCH_NAME-qa \
             --force

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # CHANGELOG
 
 ## unreleased -- v0.5.7
+### Added
+- Per-branch QA deployments
 ### Fixed
 - Escape special characters in search queries
 - Handle colons in the body of search queries

--- a/task-definition.json
+++ b/task-definition.json
@@ -1,0 +1,93 @@
+{
+    "family": "sfr-pipeline-testing",
+    "executionRoleArn": "ecsTaskExecutionRole",
+    "containerDefinitions": [
+        {
+            "name": "sfr-api",
+            "image": "946183545209.dkr.ecr.us-east-1.amazonaws.com/sfr_ingest_pipeline:latest",
+            "memory": 256,
+            "portMappings": [
+                {
+                    "containerPort": 80
+                }
+            ],
+            "essential": true,
+            "command": [
+                "--process", "APIProcess",
+                "--environment", "qa"
+            ],
+            "environment": [
+                {
+                    "name": "ENVIRONMENT",
+                    "value": "qa"
+                },
+                {
+                    "name": "ELASTICSEARCH_HOST",
+                    "value": "https://vpc-sfr-search-api-production-tom4zg45o45pfomgtasgskvx4e.us-east-1.es.amazonaws.com"
+                },
+                {
+                    "name": "ELASTICSEARCH_INDEX",
+                    "value": "drb_dcdw_qa"
+                }
+
+            ],
+            "secrets": [
+                {
+                    "name": "POSTGRES_USER",
+                    "valueFrom": "arn:aws:ssm:us-east-1:946183545209:parameter/drb/qa/postgres/user"
+                },
+		{
+		    "name": "POSTGRES_PSWD",
+		    "valueFrom": "arn:aws:ssm:us-east-1:946183545209:parameter/drb/qa/postgres/pswd"
+		}
+            ],
+            "logConfiguration": {
+                "logDriver": "awslogs",
+                "options": {
+		    "awslogs-group": "ECSLogGroup-sfr-pipeline-qa",
+		    "awslogs-region": "us-east-1",
+		    "awslogs-stream-prefix": "sfr-api"
+                }
+            }
+        },
+        {
+            "name": "sfr-webapp",
+            "image": "946183545209.dkr.ecr.us-east-1.amazonaws.com/sfr-front-end:latest",
+            "memory": 256,
+            "portMappings": [
+                {
+                    "containerPort": 3000
+                }
+            ],
+            "essential": true,
+            "environment": [
+                {
+                    "name": "APP_ENV",
+                    "value": "qa"
+                },
+		{
+		    "name": "API_URL",
+		    "value": "127.0.0.1"
+		}
+
+            ],
+            "logConfiguration": {
+                "logDriver": "awslogs",
+                "options": {
+		    "awslogs-group": "ECSLogGroup-sfr-pipeline-qa",
+		    "awslogs-region": "us-east-1",
+		    "awslogs-stream-prefix": "sfr-webapp"
+                }
+            }
+        }
+    ],
+    "requiresCompatibilities": [
+        "FARGATE"
+    ],
+    "tags": [
+        {
+            "key": "project",
+            "value": "sfr"
+        }
+    ]
+}

--- a/task-definition.json
+++ b/task-definition.json
@@ -1,6 +1,6 @@
 {
     "family": "sfr-pipeline-testing",
-    "executionRoleArn": "ecsTaskExecutionRole",
+    "executionRoleArn": "sfr-pipeline-qa-ECS-9M7V9E27MVNM-ECSTaskRole-ZJMOOIID9F41 ",
     "networkMode": "awsvpc",
     "cpu": "512",
     "memory": "1024",

--- a/task-definition.json
+++ b/task-definition.json
@@ -39,19 +39,11 @@
                     "name": "POSTGRES_USER",
                     "valueFrom": "arn:aws:ssm:us-east-1:946183545209:parameter/drb/qa/postgres/user"
                 },
-		{
-		    "name": "POSTGRES_PSWD",
-		    "valueFrom": "arn:aws:ssm:us-east-1:946183545209:parameter/drb/qa/postgres/pswd"
-		}
-            ],
-            "logConfiguration": {
-                "logDriver": "awslogs",
-                "options": {
-		    "awslogs-group": "ECSLogGroup-sfr-pipeline-qa",
-		    "awslogs-region": "us-east-1",
-		    "awslogs-stream-prefix": "sfr-api"
+                {
+                    "name": "POSTGRES_PSWD",
+                    "valueFrom": "arn:aws:ssm:us-east-1:946183545209:parameter/drb/qa/postgres/pswd"
                 }
-            }
+            ]
         },
         {
             "name": "sfr-webapp",
@@ -68,20 +60,12 @@
                     "name": "APP_ENV",
                     "value": "qa"
                 },
-		{
-		    "name": "API_URL",
-		    "value": "127.0.0.1"
-		}
-
-            ],
-            "logConfiguration": {
-                "logDriver": "awslogs",
-                "options": {
-		    "awslogs-group": "ECSLogGroup-sfr-pipeline-qa",
-		    "awslogs-region": "us-east-1",
-		    "awslogs-stream-prefix": "sfr-webapp"
+                {
+                    "name": "API_URL",
+                    "value": "127.0.0.1"
                 }
-            }
+
+            ]
         }
     ],
     "requiresCompatibilities": [

--- a/task-definition.json
+++ b/task-definition.json
@@ -1,6 +1,6 @@
 {
     "family": "sfr-pipeline-testing",
-    "executionRoleArn": "sfr-pipeline-qa-ECS-9M7V9E27MVNM-ECSTaskRole-ZJMOOIID9F41 ",
+    "executionRoleArn": "ecsTaskExecutionRole",
     "networkMode": "awsvpc",
     "cpu": "512",
     "memory": "1024",

--- a/task-definition.json
+++ b/task-definition.json
@@ -2,6 +2,8 @@
     "family": "sfr-pipeline-testing",
     "executionRoleArn": "ecsTaskExecutionRole",
     "networkMode": "awsvpc",
+    "cpu": 512,
+    "memory": 1024,
     "containerDefinitions": [
         {
             "name": "sfr-api",

--- a/task-definition.json
+++ b/task-definition.json
@@ -1,7 +1,7 @@
 {
     "family": "sfr-pipeline-testing",
     "executionRoleArn": "ecsTaskExecutionRole",
-    "networkMode": "FARGATE",
+    "networkMode": "awsvpc",
     "containerDefinitions": [
         {
             "name": "sfr-api",

--- a/task-definition.json
+++ b/task-definition.json
@@ -2,8 +2,8 @@
     "family": "sfr-pipeline-testing",
     "executionRoleArn": "ecsTaskExecutionRole",
     "networkMode": "awsvpc",
-    "cpu": 512,
-    "memory": 1024,
+    "cpu": "512",
+    "memory": "1024",
     "containerDefinitions": [
         {
             "name": "sfr-api",

--- a/task-definition.json
+++ b/task-definition.json
@@ -1,6 +1,7 @@
 {
     "family": "sfr-pipeline-testing",
     "executionRoleArn": "ecsTaskExecutionRole",
+    "networkMode": "FARGATE",
     "containerDefinitions": [
         {
             "name": "sfr-api",


### PR DESCRIPTION
This adds an action to add a service to the QA ECS cluster that deploys the current branch on a temporary basis. This has a bare IP address that is added as a comment to this PR. This can be used to QA specific changes to the front and back ends.