### PR TITLE
NOREF Close sessions after queries

### DIFF
--- a/.github/workflows/destroy-branch-qa.yaml
+++ b/.github/workflows/destroy-branch-qa.yaml
@@ -18,6 +18,8 @@ jobs:
           aws-region: us-east-1
 
       - name: Delete Service from ECS cluster
+        env:
+          BRANCH_NAME: ${{ github.head_ref }}
         run: |
           aws ecs delete-service \
             --cluster sfr-pipeline-qa \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Renamed tests.yaml as "tests-unit.yaml"
 - Remove changelog job from tests-regression.yaml
 - Fix allure-test command to include correct path
+- Remove lingering sessions after query completion
 
 
 ## 2021-04-15 -- v0.5.6

--- a/api/blueprints/drbLink.py
+++ b/api/blueprints/drbLink.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, request, current_app
+from flask import Blueprint, current_app
 from ..db import DBClient
 from ..utils import APIUtils
 from logger import createLog
@@ -12,18 +12,19 @@ def linkFetch(linkID):
     logger.info('Fetching Link #{}'.format(linkID))
 
     dbClient = DBClient(current_app.config['DB_CLIENT'])
+    dbClient.createSession()
 
     link = dbClient.fetchSingleLink(linkID)
 
     if link:
-        logger.debug('Link Fetch 200 on /link/{}'.format(linkID))
-
-        return APIUtils.formatResponseObject(
-            200, 'singleLink', APIUtils.formatLinkOutput(link)
-        )
+        statusCode = 200
+        responseObject = APIUtils.formatLinkOutput(link)
     else:
-        logger.warning('Link Fetch 404 on /link/{}'.format(linkID))
+        statusCode = 404
+        responseObject = {'message': 'Unable to locate link #{}'.format(linkID)}
 
-        return APIUtils.formatResponseObject(
-            404, 'singleLink', {'message': 'Unable to locate link #{}'.format(linkID)}
-        )
+    logger.debug('Link Fetch 200 on /link/{}'.format(linkID))
+
+    dbClient.closeSession()
+
+    return APIUtils.formatResponseObject(statusCode, 'singleLink', responseObject)

--- a/api/blueprints/drbOPDS2.py
+++ b/api/blueprints/drbOPDS2.py
@@ -31,6 +31,7 @@ def newPublications():
     pageSize = int(params.get('size', [25])[0])
 
     dbClient = DBClient(current_app.config['DB_CLIENT'])
+    dbClient.createSession()
 
     baseFeed = constructBaseFeed(request.full_path, 'New Publications: Digital Research Books', grouped=True)
 
@@ -39,6 +40,8 @@ def newPublications():
     addPagingOptions(baseFeed, request.full_path, pubCount, page=page+1, pageSize=pageSize)
 
     addPublications(baseFeed, newPubs, grouped=True)
+
+    dbClient.closeSession()
 
     return APIUtils.formatOPDS2Object(200, baseFeed)
 
@@ -61,6 +64,7 @@ def opdsSearch():
 
     esClient = ElasticClient(current_app.config['ES_CLIENT'])
     dbClient = DBClient(current_app.config['DB_CLIENT'])
+    dbClient.createSession()
 
     logger.info('Executing ES Query {}'.format(searchTerms))
 
@@ -81,6 +85,8 @@ def opdsSearch():
 
     addPublications(searchFeed, works, grouped=True)
 
+    dbClient.closeSession()
+
     return APIUtils.formatOPDS2Object(200, searchFeed)
 
 
@@ -89,6 +95,7 @@ def fetchPublication(uuid):
     logger.info('Returning OPDS2 publication for {}'.format(uuid))
 
     dbClient = DBClient(current_app.config['DB_CLIENT'])
+    dbClient.createSession()
 
     workRecord = dbClient.fetchSingleWork(uuid)
     
@@ -100,6 +107,8 @@ def fetchPublication(uuid):
     publication = createPublicationObject(workRecord, searchResult=False)
 
     publication.addLink({'rel': 'search', 'href': '/opds/search{?query,title,subject,author}', 'type': 'application/opds+json', 'templated': True})
+
+    dbClient.closeSession()
 
     return APIUtils.formatOPDS2Object(200, publication)
 

--- a/api/blueprints/drbSearch.py
+++ b/api/blueprints/drbSearch.py
@@ -12,6 +12,7 @@ search = Blueprint('search', __name__, url_prefix='/search')
 def standardQuery():
     esClient = ElasticClient(current_app.config['ES_CLIENT'])
     dbClient = DBClient(current_app.config['DB_CLIENT'])
+    dbClient.createSession()
 
     searchParams = APIUtils.normalizeQueryParams(request.args)
 
@@ -54,5 +55,7 @@ def standardQuery():
     }
 
     logger.debug('Search Query 200 on /search')
+
+    dbClient.closeSession()
 
     return APIUtils.formatResponseObject(200, 'searchResponse', dataBlock)

--- a/api/blueprints/drbUtils.py
+++ b/api/blueprints/drbUtils.py
@@ -28,9 +28,12 @@ def languageCounts():
 @utils.route('/counts', methods=['GET'])
 def totalCounts():
     dbClient = DBClient(current_app.config['DB_CLIENT'])
+    dbClient.createSession()
 
     totalResult = dbClient.fetchRowCounts()
 
     totalsSummary = APIUtils.formatTotals(totalResult)
+
+    dbClient.closeSession()
 
     return APIUtils.formatResponseObject(200, 'totalCounts', totalsSummary)


### PR DESCRIPTION
This refactors the API db connection/session structure so that sessions are closed after queries. This resolves a bug in the API that is returning a `TimeoutError` for too many connections.