### PR TITLE
Hotfix update temp url

### DIFF
--- a/.github/workflows/build-branch-qa.yaml
+++ b/.github/workflows/build-branch-qa.yaml
@@ -2,7 +2,7 @@
 name: Publish Branch
 on:
   pull_request:
-    branches: [main]
+    branches: [development]
     types: [opened, reopened, synchronize]
 
 jobs:
@@ -77,7 +77,6 @@ jobs:
             --network-configuration "awsvpcConfiguration={subnets=[subnet-42f2e16f,subnet-6b1edc23],securityGroups=[sg-016cf234aebd31f7d],assignPublicIp=ENABLED}"
 
       - name: Wait for Service to become stable
-        if: ${{ steps.task-present-check.outputs.existingtask == 'false' }}
         env:
           BRANCH_NAME: ${{ github.head_ref }}
         run: |
@@ -86,27 +85,31 @@ jobs:
             --services $BRANCH_NAME-qa
 
       - name: Get ARN of branch QA task
-        if: ${{ steps.task-present-check.outputs.existingtask == 'false' }}
         id: get-task-arn
         run: |
           taskarn=$(aws ecs list-tasks --cluster sfr-pipeline-qa --family sfr-pipeline-testing | jq '.taskArns[0]')
           echo "::set-output name=taskarn::$taskarn"
 
-      - name: Get deployed URL for service
-        if: ${{ steps.task-present-check.outputs.existingtask == 'false' }}
-        id: get-task-ip
+      - name: Get deployed ENI for service
+        id: get-task-eni
         run: |
-          tempip=$(aws ecs describe-tasks --cluster sfr-pipeline-qa --tasks ${{ steps.get-task-arn.outputs.taskarn }} | jq '.tasks[0].attachments[0].details[4].value')
+          tempeni=$(aws ecs describe-tasks --cluster sfr-pipeline-qa --tasks ${{ steps.get-task-arn.outputs.taskarn }} | jq '.tasks[0].attachments[0].details[1].value')
+          taskeni=$(echo $tempeni | tr -d '"')
+          echo "::set-output name=taskeni::$taskeni"
+
+      - name: Get Public IP address for service
+        id: get-public-ip
+        run: |
+          tempip=$(aws ec2 describe-network-interfaces --network-interface-ids ${{ steps.get-task-eni.outputs.taskeni }} | jq '.NetworkInterfaces[0].Association.PublicIp')
           taskip=$(echo $tempip | tr -d '"')
           echo "::set-output name=taskip::$taskip"
 
       - name: Add Task IP as comment to PR
-        if: ${{ steps.task-present-check.outputs.existingtask == 'false' }}
         uses: peter-evans/create-or-update-comment@v1
         with:
           issue-number: ${{ github.event.number }}
           body: |
             This branch is deployed at the following locations:
 
-            [DRB Front End](http://${{ steps.get-task-ip.outputs.taskip }}:3000)
-            [DRB API](http://${{ steps.get-task-ip.outputs.taskip }})
+            [DRB Front End](http://${{ steps.get-public-ip.outputs.taskip }}:3000)
+            [DRB API](http://${{ steps.get-public-ip.outputs.taskip }})

--- a/.github/workflows/build-branch-qa.yaml
+++ b/.github/workflows/build-branch-qa.yaml
@@ -2,7 +2,7 @@
 name: Publish Branch
 on:
   pull_request:
-    branches: [development]
+    branches: [main]
     types: [opened, reopened, synchronize]
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -77,7 +77,9 @@ To set up a Kubernetes cluster with these secrets copy the `manifests/secrets-ex
 
 ## Deployment
 
-This application can be deployed to any kubernetes cluster with the provided `production.yaml` manifest. However, in production the application does have additional dependencies, specifically external PostgreSQL and ElasticSearch database/index. This is to easy the work of maintaining persistent data instances in production, which is possible within kubernetes but is more complex, especially with the need to maintain and validate backups. These must be configured and placed in the production config file.
+This application is delpoyed via Github Actions to an ECS cluster. Opening a PR will give a temporary testing/QA environment (the IP address for the environment is added as a comment to the PR), which is torn down on merge. Once merged into QA changes are deployed to [the DRB QA Instance](http://drb-api-qa.nypl.org)
+
+Production delpoyments are to be made when releases are cut against `main` (Implementation TK)
 
 ## TODO
 
@@ -88,12 +90,12 @@ This application can be deployed to any kubernetes cluster with the provided `pr
   - ~~DOAB~~
   - ~~Project MUSE~~
   - MET Exhibition Catalogs
-- Add centralized logging process
+- ~~Add centralized logging process~~
 - Add commenting/documentation strings
 - Generate C4 diagrams for application
 - ~~Integrate ePub processor into standard processing flow~~
 - ~~Add cover fetching process~~
 - Create test suite, including:
-  - Unit tests for all components
+  - ~~Unit tests for all components~~
   - Functional tests for each process
   - Integration tests for the full cluster


### PR DESCRIPTION
This makes two fixes to the temp URL provided for the QA environment(s). This is now the public IP address for the service, so that users do not need to be on the vpn, and it updates with pushes, to ensure accuracy if the IP address changes