### PR TITLE
SFR-955 Create MET Process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased -- v0.5.7
 ### Added
+- MET Publication Ingest Process
 - Per-branch QA deployments on feature branches
 ### Fixed
 - Escape special characters in search queries

--- a/managers/oclcClassify.py
+++ b/managers/oclcClassify.py
@@ -63,6 +63,7 @@ class ClassifyManager:
             self.generateAuthorTitleURL()
         else:
             print('Cannot Classify work without identifier or title/author')
+            raise ClassifyError('Record lacks identifier or title/author pair')
 
     @staticmethod
     def cleanStr(string):
@@ -113,9 +114,8 @@ class ClassifyManager:
             Classify response.
         """
         classifyResp = requests.get(self.query)
-        if classifyResp.status_code != 200:
-            print('OCLC Classify Request failed')
-            raise Exception
+
+        classifyResp.raise_for_status()
 
         self.rawXML = classifyResp.text
     

--- a/managers/oclcClassify.py
+++ b/managers/oclcClassify.py
@@ -42,7 +42,7 @@ class ClassifyManager:
     def __init__(self, iden=None, idenType=None, title=None, author=None, start=0):
         self.identifier = iden
         self.identifierType = idenType
-        self.title = ClassifyManager.cleanStr(title)
+        self.title = ClassifyManager.cleanStr(title) if title else None
         self.author = ClassifyManager.cleanStr(author) if author else None
         self.start = start
 

--- a/mappings/json.py
+++ b/mappings/json.py
@@ -1,0 +1,39 @@
+from .core import Core
+
+
+class JSONMapping(Core):
+    def __init__(self, source, statics):
+        super().__init__(source, statics)
+
+    def applyMapping(self):
+        self.record = self.initEmptyRecord()
+
+        for field, structure in self.mapping.items():
+            if isinstance(structure, list):
+                formattedValue = list(filter(None, [self.formatString(s) for s in structure]))
+            else:
+                formattedValue = self.formatString(structure)
+            
+            setattr(self.record, field, formattedValue)
+        
+        self.applyFormatting()
+
+    # TODO Implement means of parsing nested JSON objects
+    def formatString(self, structure):
+        if isinstance(structure[0], list):
+            values = [self.source.get(s, None) for s in structure[0]]
+        else:
+            values = [self.source.get(structure[0], None)]
+
+        cleanValues = list(filter(lambda x: x not in [[], {}, None, ''], values))
+
+        if len(cleanValues) > 0 and all([isinstance(v, list) for v in cleanValues]):
+            return [
+                structure[1].format(*s) if isinstance(s, list) else structure[1].format(s)
+                for v in cleanValues for s in v
+            ]
+        elif len(cleanValues) > 0:
+            return structure[1].format(*cleanValues)
+
+        return None
+

--- a/mappings/met.py
+++ b/mappings/met.py
@@ -59,5 +59,5 @@ class METMapping(JSONMapping):
         # Set PDF download link
         pdfURL = self.PDF_LINK.format(self.source['dmrecord'])
         self.record.has_part.append(
-            '|'.join(['1', pdfURL, 'met', 'application/pdf', '{{}}'])
+            '|'.join(['1', pdfURL, 'met', 'application/pdf', '{}'])
         )

--- a/mappings/met.py
+++ b/mappings/met.py
@@ -1,0 +1,63 @@
+
+from .json import JSONMapping
+
+class METMapping(JSONMapping):
+    PDF_LINK = 'https://libmma.contentdm.oclc.org/digital/api/collection/p15324coll10/id/{}/download'
+    def __init__(self, source):
+        super().__init__(source, {})
+        self.mapping = self.createMapping()
+    
+    def createMapping(self):
+        return {
+            'title': ('title', '{0}'),
+            'alternate': [('titlea', '{0}')],
+            'authors': [('creato', '{0}|||true')],
+            'languages': [('langua', '{0}||')],
+            'dates': [('date', '{0}|publication_date')],
+            'publisher': [('publis', '{0}')],
+            'identifiers': [
+                ('dmrecord', '{0}|met'),
+                ('identi', '{0}|met'),
+                ('digiti', '{0}|met'),
+                ('dmcoclcno', '{0}|oclc')
+            ],
+            'contributors': [
+                ('contri', '{0}|||contributor'),
+                ('physic', '{0}|||repository'),
+                ('source', '{0}|||provider')
+            ],
+            'extent': ('format', '{0}'),
+            'is_part_of': [('relatig', '{0}|collection')],
+            'abstract': [
+                ('transc', '{0}'),
+                ('descri', '{0}')
+            ],
+            'subjects': [('subjec', '{0}||')],
+            'rights': (['rights', 'copyra', 'copyri'], 'met|{0}|{1}|{2}|'),
+            'has_part': [('link', '1|{0}|met|text/html|{{}}')]
+        }
+
+    def applyFormatting(self):
+        self.record.source = 'met'
+        self.record.source_id = self.record.identifiers[0]
+
+        # Clean up subjects
+        try:
+            subjString = self.record.subjects[0].split('|')[0]
+            subjects = subjString.split(';')
+            self.record.subjects = ['{}||'.format(s.strip()) for s in subjects]
+        except IndexError:
+            self.record.subjects = None
+
+        # Select best abstract
+        try:
+            abstracts = self.record.abstract
+            self.record.abstract = list(filter(lambda x: x != '', abstracts))[0]
+        except IndexError:
+            self.record.abstract = None
+
+        # Set PDF download link
+        pdfURL = self.PDF_LINK.format(self.source['dmrecord'])
+        self.record.has_part.append(
+            '|'.join(['1', pdfURL, 'met', 'application/pdf', '{{}}'])
+        )

--- a/processes/__init__.py
+++ b/processes/__init__.py
@@ -11,3 +11,4 @@ from .s3Files import S3Process
 from .api import APIProcess
 from .muse import MUSEProcess
 from .ingestReport import IngestReportProcess
+from .met import METProcess

--- a/processes/core.py
+++ b/processes/core.py
@@ -59,7 +59,7 @@ class CoreProcess(DBManager, NyplApiManager, RabbitMQManager, RedisManager, Stat
             lastID = queryChunk[-1][-1]
 
             for row in queryChunk:
-                yield row[0] if singleEntity else row[0:-1]
+                yield row[0] if singleEntity else row[0:-2]
     
     def saveRecords(self):
         self.bulkSaveObjects(self.records)

--- a/processes/met.py
+++ b/processes/met.py
@@ -1,0 +1,144 @@
+from datetime import datetime, timedelta
+import json
+import mimetypes
+import os
+import re
+from time import strptime
+import requests
+
+from .core import CoreProcess
+from mappings.gutenberg import GutenbergMapping
+
+
+class METProcess(CoreProcess):
+    # The format for this query is documented here: https://help.oclc.org/Metadata_Services/CONTENTdm/Advanced_website_customization/API_Reference/CONTENTdm_API/CONTENTdm_Server_API_Functions_-_dmwebservices
+    LIST_QUERY = 'https://libmma.contentdm.oclc.org/digital/bl/dmwebservices/index.php?q=dmQuery/p15324coll10/CISOSEARCHALL/title!dmmodified!dmcreated/dmmodified/{}/{}/1/0/0/00/0/json'
+    DETAIL_QUERY = 'https://libmma.contentdm.oclc.org/digital/bl/dmwebservices/index.php?q=dmGetItemInfo/p15324coll10/{}/json'
+
+    def __init__(self, *args):
+        super(METProcess, self).__init__(*args[:4])
+
+        self.ingestOffset = int(args[5] or 0)
+        self.ingestLimit = (int(args[4]) + self.ingestOffset) if args[4] else 5000
+        self.fullImport = self.process == 'complete'
+        self.startTimestamp = None
+
+        # Connect to database
+        self.generateEngine()
+        self.createSession()
+
+        # Connect to file processing queue
+        self.fileQueue = os.environ['FILE_QUEUE']
+        self.fileRoute = os.environ['FILE_ROUTING_KEY']
+        # self.createRabbitConnection()
+        # self.createOrConnectQueue(self.fileQueue, self.fileRoute)
+
+        # S3 Configuration
+        self.s3Bucket = os.environ['FILE_BUCKET']
+
+    def runProcess(self):
+        self.setStartTime()
+        self.importDCRecords()
+
+        self.saveRecords()
+        self.commitChanges()
+
+    def setStartTime(self):
+        if not self.fullImport:
+            if not self.ingestPeriod:
+                self.startTimestamp = datetime.utcnow() - timedelta(days=1)
+            else:
+                self.startTimestamp = datetime.strptime(self.ingestPeriod, '%Y-%m-%dT%H:%M:%S')
+    
+    def importDCRecords(self):
+        currentPosition = self.ingestOffset
+        pageSize = 10
+
+        while True:
+            batchQuery = self.LIST_QUERY.format(pageSize, currentPosition)
+
+            batchResponse = self.queryMetAPI(batchQuery)
+
+            batchRecords = batchResponse['records']
+
+            self.processMetBatch(batchRecords)
+
+            if len(batchRecords) < 0 or currentPosition >= self.ingestLimit: break
+
+            currentPosition += pageSize
+            break
+
+    def processMetBatch(self, metRecords):
+        for record in metRecords:
+
+            if self.startTimestamp \
+                and strptime(record['dmmodified'], '%Y-%m-%d') >= self.startTimestamp:
+                continue
+
+            detailQuery = self.DETAIL_QUERY.format(record['pointer'])
+            metDetail = self.queryMetAPI(detailQuery)
+
+            print(metDetail)
+            
+            # self.addDCDWToUpdateList(gutenbergRec)
+
+    def storeEpubsInS3(self, gutenbergRec):
+        for i, epubItem in enumerate(gutenbergRec.record.has_part):
+            pos, gutenbergURL, source, mediaType, flagStr = epubItem.split('|')
+
+            epubIDParts = re.search(r'\/([0-9]+).epub.([a-z]+)$', gutenbergURL)
+            gutenbergID = epubIDParts.group(1)
+            gutenbergType = epubIDParts.group(2)
+
+            flags = json.loads(flagStr)
+
+            if flags['download'] is True:
+                bucketLocation = 'epubs/{}/{}_{}.epub'.format(source, gutenbergID, gutenbergType)
+            else:
+                bucketLocation = 'epubs/{}/{}_{}/META-INF/content.xml'.format(source, gutenbergID, gutenbergType)
+                mediaType = 'application/epub+xml'
+
+            s3URL = 'https://{}.s3.amazonaws.com/{}'.format(self.s3Bucket, bucketLocation)
+
+            gutenbergRec.record.has_part[i] = '|'.join([pos, s3URL, source, mediaType, flagStr])
+
+            if flags['download'] is True:
+                self.sendFileToProcessingQueue(gutenbergURL, bucketLocation)
+
+    def addCoverAndStoreInS3(self, gutenbergRec, yamlData):
+        for coverData in yamlData['covers']:
+            if coverData['cover_type'] == 'generated': continue
+
+            mimeType, _ = mimetypes.guess_type(coverData['image_path'])
+            gutenbergID = yamlData['identifiers']['gutenberg']
+
+            fileExt = re.search(r'(\.[a-zA-Z0-9]+)$', coverData['image_path']).group(1)
+            bucketLocation = 'covers/gutenberg/{}{}'.format(gutenbergID, fileExt)
+
+            s3URL = 'https://{}.s3.amazonaws.com/{}'.format(self.s3Bucket, bucketLocation)
+
+            gutenbergRec.record.has_part.append(
+                '|'.join(['', s3URL, 'gutenberg', mimeType, json.dumps({'cover': True})])
+            )
+
+            sourceRoot = yamlData['url'].replace('ebooks', 'files')
+            sourceURL = '{}/{}'.format(sourceRoot, coverData['image_path'])
+
+            self.sendFileToProcessingQueue(sourceURL, bucketLocation)
+
+    def sendFileToProcessingQueue(self, fileURL, s3Location):
+        s3Message = {
+            'fileData': {
+                'fileURL': fileURL,
+                'bucketPath': s3Location
+            }
+        }
+        self.sendMessageToQueue(self.fileQueue, self.fileRoute, s3Message)
+
+    @staticmethod
+    def queryMetAPI(query):
+        response = requests.get(query, timeout=30)
+
+        response.raise_for_status()
+
+        return response.json()

--- a/tests/unit/test_core_process.py
+++ b/tests/unit/test_core_process.py
@@ -110,7 +110,7 @@ class TestCoreProcess:
         mockQuery = mocker.MagicMock(is_single_entity=False)
         mockQuery.add_column().order_by.return_value = mockQuery
         mockQuery.filter.return_value = mockQuery
-        mockQuery.limit().all.side_effect = [[('rec1', 1), ('rec2', 2), ('rec3', 3)], None]
+        mockQuery.limit().all.side_effect = [[('rec1', 1, 1), ('rec2', 2, 2), ('rec3', 3, 3)], None]
 
         coreInstance.ingestLimit = None
         assert list(coreInstance.windowedQuery(mocker.MagicMock(id=1), mockQuery)) == [('rec1',), ('rec2',), ('rec3',)]

--- a/tests/unit/test_json_mapping.py
+++ b/tests/unit/test_json_mapping.py
@@ -1,0 +1,88 @@
+import pytest
+
+from mappings.json import JSONMapping
+
+
+class TestJSONMapping:
+    @pytest.fixture
+    def testMapping(self):
+        return {
+            'title': ('title', '{0}'),
+            'alt_title': ('alternates', '{0}'),
+            'series': (['series_title', 'position'], '{0}|{1}'),
+            'authors': [
+                ('creator', '{0}'), ('author', '{0}')
+            ],
+            'subjects': [(['heading', 'authority'], '{0}|{1}')],
+        }
+
+    @pytest.fixture
+    def testDocument(self):
+        return {
+            'title': 'Test Title',
+            'alternates': ['Alt 1', 'Alt 2'],
+            'series_title': 'Series Title',
+            'position': 'Volume I',
+            'creator': 'Tester',
+            'author': 'Test Author',
+            'heading': 'Subject',
+            'authority': 'Auth'
+        }
+
+    @pytest.fixture
+    def testMapper(self, testMapping, testDocument, mocker):
+        class TestJSON(JSONMapping):
+            def __init__(self, source, mapping, statics):
+                self.source = source
+                self.mapping = mapping
+                self.statics = statics
+
+            def createMapping(self):
+                pass
+
+            def initEmptyRecord(self):
+                return mocker.MagicMock(name='mockRecord')
+        
+        return TestJSON(testDocument, testMapping, {})
+
+    def test_applyMapping_full_document(self, testMapper, mocker):
+        mockFormatting = mocker.patch.object(JSONMapping, 'applyFormatting')
+
+        mockFormat = mocker.patch.object(JSONMapping, 'formatString')
+
+        mockFormat.side_effect = [
+            'title', 'alt_title', 'series', 'creator', 'author', 'subjects'
+        ]
+
+        testMapper.applyMapping()
+
+        assert testMapper.record.title == 'title'
+        assert testMapper.record.alt_title == 'alt_title'
+        assert testMapper.record.series == 'series'
+        assert testMapper.record.authors == ['creator', 'author']
+        assert testMapper.record.subjects == ['subjects']
+
+        mockFormatting.assert_called_once()
+        mockFormat.assert_has_calls([
+            mocker.call(('title', '{0}')),
+            mocker.call(('alternates', '{0}')),
+            mocker.call((['series_title', 'position'], '{0}|{1}')),
+            mocker.call(('creator', '{0}')),
+            mocker.call(('author', '{0}')),
+            mocker.call((['heading', 'authority'], '{0}|{1}'))
+        ])
+
+    def test_formatString_single_field(self, testMapper, testMapping):
+        titleStruct = testMapping['title']
+
+        assert testMapper.formatString(titleStruct) == 'Test Title'
+
+    def test_formatString_multi_field(self, testMapper, testMapping):
+        subjectStruct = testMapping['subjects'][0]
+
+        assert testMapper.formatString(subjectStruct) == 'Subject|Auth'
+
+    def test_formatString_array(self, testMapper, testMapping):
+        altStruct = testMapping['alt_title']
+
+        assert testMapper.formatString(altStruct) == ['Alt 1', 'Alt 2']

--- a/tests/unit/test_met_mapping.py
+++ b/tests/unit/test_met_mapping.py
@@ -1,0 +1,57 @@
+import pytest
+
+from mappings.met import METMapping
+
+
+class TestMETMapping:
+    @pytest.fixture
+    def testMapping(self):
+        class TestMET(METMapping):
+            def __init__(self):
+                self.source = {'dmrecord': 1}
+                self.mapping = None
+        
+        return TestMET()
+
+    @pytest.fixture
+    def testRecordStandard(self, mocker):
+        return mocker.MagicMock(
+            identifiers=['1|met', '2|test', '3|oclc'],
+            subjects=['first ; second||'],
+            has_part=[],
+            abstract = ['', 'test abstract']
+        )
+
+    def test_createMapping(self, testMapping):
+        recordMapping = testMapping.createMapping()
+
+        assert list(recordMapping.keys()) == [
+            'title', 'alternate', 'authors', 'languages', 'dates', 'publisher',
+            'identifiers', 'contributors', 'extent', 'is_part_of', 'abstract',
+            'subjects', 'rights', 'has_part'
+        ]
+        assert recordMapping['title'] == ('title', '{0}')
+
+    def test_applyFormatting_standard(self, testMapping, testRecordStandard):
+        testMapping.record = testRecordStandard
+
+        testMapping.applyFormatting()
+
+        assert testMapping.record.source == 'met'
+        assert testMapping.record.source_id == '1|met'
+        assert testMapping.record.subjects == ['first||', 'second||']
+        assert testMapping.record.abstract == 'test abstract'
+        assert testMapping.record.has_part == [
+            '1|https://libmma.contentdm.oclc.org/digital/api/collection/p15324coll10/id/1/download|met|application/pdf|{}',
+        ]
+
+    def test_applyFormatting_missing_fields(self, testMapping, testRecordStandard):
+        testRecordStandard.abstract = ['', '']
+        testRecordStandard.subjects = []
+        testMapping.record = testRecordStandard
+
+        testMapping.applyFormatting()
+
+        assert testMapping.record.subjects is None
+        assert testMapping.record.abstract is None
+

--- a/tests/unit/test_met_process.py
+++ b/tests/unit/test_met_process.py
@@ -1,0 +1,254 @@
+from datetime import datetime
+import pytest
+
+from mappings.core import MappingError
+from processes.met import METProcess, METError
+from tests.helper import TestHelpers
+
+
+class TestMUSEProcess:
+    @classmethod
+    def setup_class(cls):
+        TestHelpers.setEnvVars()
+
+    @classmethod
+    def teardown_class(cls):
+        TestHelpers.clearEnvVars()
+
+    @pytest.fixture
+    def testProcess(self):
+        class TestMET(METProcess):
+            def __init__(self):
+                self.s3Bucket = 'test_aws_bucket'
+                self.fileQueue = 'test_file_queue'
+                self.fileRoute = 'test_file_key'
+        
+        return TestMET()
+
+    @pytest.fixture
+    def testRecords(self, mocker):
+        return [
+            {'dmmodified': '2020-01-01', 'rights': 'public', 'pointer': 1},
+            {'dmmodified': '2020-01-01', 'rights': 'copyrighted', 'pointer': 2},
+            {'dmmodified': '2019-01-01', 'rights': 'public', 'pointer': 3},
+            {'dmmodified': '2020-01-01', 'rights': 'public', 'pointer': 4}
+        ]
+
+    def test_runProcess(self, testProcess, mocker):
+        runMocks = mocker.patch.multiple(
+            METProcess,
+            setStartTime=mocker.DEFAULT,
+            importDCRecords=mocker.DEFAULT,
+            saveRecords=mocker.DEFAULT,
+            commitChanges=mocker.DEFAULT
+        )
+
+        testProcess.runProcess()
+
+        runMocks['setStartTime'].assert_called_once()
+        runMocks['importDCRecords'].assert_called_once()
+        runMocks['saveRecords'].assert_called_once()
+        runMocks['commitChanges'].assert_called_once()
+
+    def test_setStartTime_fullImport_true(self, testProcess):
+        testProcess.fullImport = True
+        testProcess.startTimestamp = None
+
+        testProcess.setStartTime()
+
+        assert testProcess.startTimestamp is None
+
+    def test_setStartTime_fullImport_false_daily(self, testProcess, mocker):
+        testProcess.fullImport = False
+        testProcess.startTimestamp = None
+        testProcess.ingestPeriod = None
+
+        mockDatetime = mocker.patch('processes.met.datetime')
+        mockDatetime.utcnow.return_value = datetime(1900, 1, 2, 12, 0, 0)
+
+        testProcess.setStartTime()
+
+        assert testProcess.startTimestamp == datetime(1900, 1, 1, 12, 0, 0)
+
+    def test_setStartTime_fullImport_false_custom(self, testProcess, mocker):
+        testProcess.fullImport = False
+        testProcess.startTimestamp = None
+        testProcess.ingestPeriod = '2000-01-01T12:00:00'
+
+        testProcess.setStartTime()
+
+        assert testProcess.startTimestamp == datetime(2000, 1, 1, 12, 0, 0)
+
+    def test_importDCRecords(self, testProcess, mocker):
+        testProcess.ingestOffset = 0
+        testProcess.ingestLimit = 1000
+
+        mockQuery = mocker.patch.object(METProcess, 'queryMetAPI')
+        mockProcess = mocker.patch.object(METProcess, 'processMetBatch')
+
+        mockQuery.side_effect = [{'records': ['rec1', 'rec2', 'rec3']}, {'records': []}]       
+
+        testProcess.importDCRecords()
+
+        mockQuery.assert_has_calls([
+            mocker.call('https://libmma.contentdm.oclc.org/digital/bl/dmwebservices/index.php?q=dmQuery/p15324coll10/CISOSEARCHALL/title!dmmodified!dmcreated!rights/dmmodified/50/0/1/0/0/00/0/json'),
+            mocker.call('https://libmma.contentdm.oclc.org/digital/bl/dmwebservices/index.php?q=dmQuery/p15324coll10/CISOSEARCHALL/title!dmmodified!dmcreated!rights/dmmodified/50/50/1/0/0/00/0/json')
+        ])
+
+        mockProcess.assert_has_calls([mocker.call(['rec1', 'rec2', 'rec3']), mocker.call([])])
+
+    def test_processMetBatch(self, testProcess, testRecords, mocker):
+        testProcess.startTimestamp = datetime(2020, 1, 1, 0, 0, 0)
+        mockProcess = mocker.patch.object(METProcess, 'processMetRecord')
+        mockProcess.side_effect = [None, METError]
+
+        testProcess.processMetBatch(testRecords)
+
+        mockProcess.assect_has_calls([
+            mocker.call(testRecords[0]), mocker.call(testRecords[3])
+        ])
+
+    def test_processMetRecord_success(self, testProcess, mocker):
+        processMocks = mocker.patch.multiple(METProcess,
+            queryMetAPI=mocker.DEFAULT,
+            storePDFManifest=mocker.DEFAULT,
+            addCoverAndStoreInS3=mocker.DEFAULT,
+            addDCDWToUpdateList=mocker.DEFAULT
+        )
+        processMocks['queryMetAPI'].return_value = 'testDetail'
+
+        mockMapping = mocker.MagicMock(record='testRecord')
+        mockMapper = mocker.patch('processes.met.METMapping')
+        mockMapper.return_value = mockMapping
+
+        testProcess.processMetRecord({'pointer': 1, 'filetype': 'tst'})
+
+        processMocks['queryMetAPI'].assert_called_once_with(
+            'https://libmma.contentdm.oclc.org/digital/bl/dmwebservices/index.php?q=dmGetItemInfo/p15324coll10/1/json'
+        )
+
+        mockMapper.assert_called_once_with('testDetail')
+        mockMapping.applyMapping.assert_called_once()
+
+        processMocks['storePDFManifest'].assert_called_once_with('testRecord')
+        processMocks['addCoverAndStoreInS3'].assert_called_once_with('testRecord', 'tst')
+        processMocks['addDCDWToUpdateList'].assert_called_once_with(mockMapping)
+
+    def test_processMetRecord_error(self, testProcess, mocker):
+        mockQuery = mocker.patch.object(METProcess, 'queryMetAPI')
+        mockQuery.return_value = 'testDetail'
+
+        mockMapper = mocker.patch('processes.met.METMapping')
+        mockMapper.side_effect = MappingError('testError')
+
+        with pytest.raises(METError):
+            testProcess.processMetRecord(mocker.MagicMock(pointer=1, filetype='tst'))
+
+    def test_addCoverAndStoreInS3(self, testProcess, mocker):
+        mockSetPath = mocker.patch.object(METProcess, 'setCoverPath')
+        mockSetPath.return_value = 'testPath.jpg'
+        mockSendFile = mocker.patch.object(METProcess, 'sendFileToProcessingQueue')
+
+        testRecord = mocker.MagicMock(has_part=[], identifiers=['1|met'])
+        testProcess.addCoverAndStoreInS3(testRecord, 'testType')
+
+        assert testRecord.has_part[0] == '|https://test_aws_bucket.s3.amazonaws.com/covers/met/1.jpg|met|image/jpeg|{"cover": true}'
+        mockSetPath.assert_called_once_with('testType', '1')
+        mockSendFile.assert_called_once_with('https://libmma.contentdm.oclc.org/digital/testPath.jpg', 'covers/met/1.jpg')
+
+    def test_setCoverPath_compound(self, testProcess, mocker):
+        mockQuery = mocker.patch.object(METProcess, 'queryMetAPI')
+        mockQuery.side_effect = [{'page': [{'pageptr': 1}]}, {'imageUri': 'testURI'}]
+
+        assert testProcess.setCoverPath('cpd', 1) == 'testURI'
+        mockQuery.assert_has_calls([
+            mocker.call('https://libmma.contentdm.oclc.org/digital/bl/dmwebservices/index.php?q=dmGetCompoundObjectInfo/p15324coll10/1/json'),
+            mocker.call('https://libmma.contentdm.oclc.org/digital/api/singleitem/collection/p15324coll10/id/1')
+        ])
+
+    def test_setCoverPath(self, testProcess):
+        assert testProcess.setCoverPath('pdf', 1) == 'api/singleitem/image/pdf/p15324coll10/1/default.png'
+
+    def test_sendFileToProcessingQueue(self, testProcess, mocker):
+        mockSendMessage = mocker.patch.object(METProcess, 'sendMessageToQueue')
+
+        testProcess.sendFileToProcessingQueue('testURL', 'testLocation')
+
+        mockSendMessage.assert_called_once_with(
+            'test_file_queue', 'test_file_key',
+            {'fileData': {'fileURL': 'testURL', 'bucketPath': 'testLocation'}}
+        )
+
+    def test_storePDFManifest(self, testProcess, mocker):
+        mockRecord = mocker.MagicMock(identifiers=['1|met'])
+        mockRecord.has_part = [
+            '1|testURI|met|text/html|{}',
+            '1|testURI|met|application/pdf|{}',
+            '2|testURIOther|met|application/pdf|{}',
+        ]
+
+        mockGenerateMan = mocker.patch.object(METProcess, 'generateManifest')
+        mockGenerateMan.return_value = 'testJSON'
+        mockCreateMan = mocker.patch.object(METProcess, 'createManifestInS3')
+
+        testProcess.storePDFManifest(mockRecord)
+
+        testManifestURI = 'https://test_aws_bucket.s3.amazonaws.com/manifests/met/1.json'
+        assert mockRecord.has_part[0] == '1|{}|met|application/webpub+json|{{}}'.format(testManifestURI)
+
+        mockGenerateMan.assert_called_once_with(mockRecord, 'testURI', testManifestURI)
+        mockCreateMan.assert_called_once_with('manifests/met/1.json', 'testJSON')
+
+    def test_createManifestInS3(self, testProcess, mocker):
+        mockPut = mocker.patch.object(METProcess, 'putObjectInBucket')
+        
+        testProcess.createManifestInS3('testPath', '{"data": "testJSON"}')
+
+        mockPut.assert_called_once_with(b'{"data": "testJSON"}', 'testPath', 'test_aws_bucket')
+
+    def test_generateManifest(self, mocker):
+        mockManifest = mocker.MagicMock(links=[])
+        mockManifest.toJson.return_value = 'testJSON'
+        mockManifestConstructor = mocker.patch('processes.met.WebpubManifest')
+        mockManifestConstructor.return_value = mockManifest
+
+        mockRecord = mocker.MagicMock(title='Test')
+        testManifest = METProcess.generateManifest(mockRecord, 'sourceURI', 'manifestURI')
+
+        assert testManifest == 'testJSON'
+        assert mockManifest.links[0] == {'rel': 'self', 'href': 'manifestURI', 'type': 'application/webpub+json'}
+
+        mockManifest.addMetadata.assert_called_once_with(mockRecord)
+        mockManifest.addChapter.assert_called_once_with('sourceURI', 'Test')
+
+    def test_queryMetAPI_success_non_head(self, mocker):
+        mockResponse = mocker.MagicMock()
+        mockRequests = mocker.patch('processes.met.requests')
+        mockRequests.request.return_value = mockResponse
+
+        mockResponse.json.return_value = 'testResponse'
+
+        assert METProcess.queryMetAPI('testQuery') == 'testResponse'
+
+        mockRequests.request.assert_called_once_with('GET', 'testQuery', timeout=30)
+
+    def test_queryMetAPI_success_head(self, mocker):
+        mockResponse = mocker.MagicMock(status_code=200)
+        mockRequests = mocker.patch('processes.met.requests')
+        mockRequests.request.return_value = mockResponse
+
+        assert METProcess.queryMetAPI('testQuery', method='head') == 200
+
+        mockRequests.request.assert_called_once_with('HEAD', 'testQuery', timeout=30)
+
+    def test_queryMetAPI_error(self, mocker):
+        mockResponse = mocker.MagicMock()
+        mockRequests = mocker.patch('processes.met.requests')
+        mockRequests.request.return_value = mockResponse
+
+        mockResponse.raise_for_status.side_effect = Exception
+
+        with pytest.raises(Exception):
+            METProcess.queryMetAPI('testQuery')
+
+

--- a/tests/unit/test_oclcClassify_manager.py
+++ b/tests/unit/test_oclcClassify_manager.py
@@ -67,13 +67,12 @@ class TestClassifyManager:
         mockGenerators['generateIdentifierURL'].assert_not_called
         mockGenerators['generateAuthorTitleURL'].assert_called_once
     
-    def test_generateQueryURL_wo_query_options(self, testInstance, mockGenerators):
+    def test_generateQueryURL_wo_query_options(self, testInstance):
         testInstance.identifier = None
         testInstance.title = None
-        testInstance.generateQueryURL()
 
-        mockGenerators['generateIdentifierURL'].assert_not_called
-        mockGenerators['generateAuthorTitleURL'].assert_not_called
+        with pytest.raises(ClassifyError):
+            testInstance.generateQueryURL()
 
     def test_cleanStr(self):
         assert ClassifyManager.cleanStr('hello\n line\r') == 'hello line'
@@ -121,6 +120,7 @@ class TestClassifyManager:
         mockRequest.get.return_value = mockResponse
 
         mockResponse.status_code = 500
+        mockResponse.raise_for_status.side_effect = Exception
 
         with pytest.raises(Exception):
             testInstance.query = 'testQuery'

--- a/tests/unit/test_oclcClassify_process.py
+++ b/tests/unit/test_oclcClassify_process.py
@@ -238,6 +238,20 @@ class TestOCLCClassifyProcess:
         mockIdentifiers.assert_called_once_with(testRecord.identifiers)
         mockRedisCheck.assert_called_once_with('classify', '1', 'test')
         mockClassifyRec.assert_not_called
+
+    def test_frbrizeRecord_identifier_missing(self, testInstance, testRecord, mocker):
+        mockIdentifiers = mocker.patch.object(ClassifyManager, 'getQueryableIdentifiers')
+        mockIdentifiers.return_value = []
+
+        mockRedisCheck = mocker.patch.object(ClassifyProcess, 'checkSetRedis')
+
+        mockClassifyRec = mocker.patch.object(ClassifyProcess, 'classifyRecordByMetadata')
+
+        testInstance.frbrizeRecord(testRecord)
+
+        mockIdentifiers.assert_called_once_with(testRecord.identifiers)
+        mockRedisCheck.assert_not_called()
+        mockClassifyRec.assert_called_once_with(None, None, 'Author, Test', 'Test Record')
         
     def test_classifyRecordByMetadata_success(self, testInstance, mocker):
         mockClassifier = mocker.patch('processes.oclcClassify.ClassifyManager')


### PR DESCRIPTION
This adds a new process for ingesting MET Publications into the DRB collection. These publications are available as PDF files via the MET's CMS (which is powered by OCLC's Contentdm product).

The data is available as JSON documents, so a new mapping format has been created to handle the records. At the moment this mapping is fairly bare-bones and only supports strings and arrays as values in tho documents. For full support the ability to parse nested objects in the document will need to be added in the future.

The MET API does not allow for sorting/filtering on modified dates for their records, though the field is present. In order to provide regular updates then the full collection (roughly 3,000 records) must be iterated with old/outdated records skipped.

This addition represents the last data source from the "old" version of DRB and should bring the collection essentially into parity with the previous version.