### PR TITLE
HOTFIX Skip records without titles when clustering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unreleased -- v0.5.8
+### Fixed
+- Handling of records without titles in clustering process
+
 ## 2021-05-11 -- v0.5.7
 ### Added
 - MET Publication Ingest Process

--- a/processes/sfrCluster.py
+++ b/processes/sfrCluster.py
@@ -50,7 +50,11 @@ class ClusterProcess(CoreProcess):
             if rec is None:
                 break
 
-            self.clusterRecord(rec)
+            try:
+                self.clusterRecord(rec)
+            except ClusterError:
+                logger.warning('Skipping record {}'.format(rec))
+                self.updateMatchedRecordsStatus([rec.id])
 
         self.closeConnection()
 
@@ -192,7 +196,11 @@ class ClusterProcess(CoreProcess):
 
     @staticmethod
     def tokenizeTitle(title):
-        lowerTitle = title.lower()
+        try:
+            lowerTitle = title.lower()
+        except AttributeError:
+            logger.error('Unable to parse record title')
+            raise ClusterError('Invalid title received')
 
         titleTokens = re.findall(r'(\w+)', lowerTitle)
 
@@ -209,3 +217,6 @@ class ClusterProcess(CoreProcess):
             idenStrings.append(idenStr)
         
         return '{{{}}}'.format(','.join(idenStrings))
+
+
+class ClusterError(Exception): pass


### PR DESCRIPTION
In rare instances a record without a title can be created. When these are encountered an exception is raised and the record skipped from the clustering process