### PR TITLE
SFR-1082 Don't split queries on commas within quotation marks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased -- v0.5.8
 ### Fixed
 - Handling of records without titles in clustering process
+- Don't split queries on commas within quotation marks
 
 ## 2021-05-11 -- v0.5.7
 ### Added

--- a/api/utils.py
+++ b/api/utils.py
@@ -19,8 +19,7 @@ class APIUtils():
         outPairs = []
 
         for pairStr in pairs.get(param, []):
-            for pair in pairStr.split(','):
-
+            for pair in re.split(r',(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)', pairStr):
                 pairElements = pair.split(':')
 
                 if len(pairElements) == 1 or pairElements[0] not in cls.QUERY_TERMS:

--- a/api/utils.py
+++ b/api/utils.py
@@ -19,6 +19,9 @@ class APIUtils():
         outPairs = []
 
         for pairStr in pairs.get(param, []):
+            if len(re.findall(r'"', pairStr)) % 2 != 0:
+                pairStr = ''.join(pairStr.rsplit('"', 1))
+
             for pair in re.split(r',(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)', pairStr):
                 pairElements = pair.split(':')
 

--- a/tests/unit/test_api_utils.py
+++ b/tests/unit/test_api_utils.py
@@ -136,6 +136,17 @@ class TestAPIUtils:
 
         assert testPairs[0] == ('test', 'A Book: A Title')
 
+    def test_extractParamPairs_dangling_quotation(self):
+        testPairs = APIUtils.extractParamPairs('test', {'test': ['"A Title']})
+
+        assert testPairs[0] == ('test', 'A Title')
+
+    def test_extractParamPairs_dangling_quotation_multiple(self):
+        testPairs = APIUtils.extractParamPairs('test', {'test': ['"A Title",keyword:"other']})
+
+        assert testPairs[0] == ('test', '"A Title"')
+        assert testPairs[1] == ('keyword', 'other')
+
     def test_formatAggregationResult(self, testAggregationResp):
         testAggregations = APIUtils.formatAggregationResult(testAggregationResp)
 

--- a/tests/unit/test_api_utils.py
+++ b/tests/unit/test_api_utils.py
@@ -119,6 +119,13 @@ class TestAPIUtils:
         assert testPairs[0] == ('title', 'value')
         assert testPairs[1] == ('test', 'bareValue')
 
+    def test_extractParamPairs_comma_delimited_quotes(self):
+        testPairs = APIUtils.extractParamPairs('test', {'test': ['title:value,author:"Test, Author",other']})
+
+        assert testPairs[0] == ('title', 'value')
+        assert testPairs[1] == ('author', '"Test, Author"')
+        assert testPairs[2] == ('test', 'other')
+
     def test_extractParamPairs_semantic_semicolon(self):
         testPairs = APIUtils.extractParamPairs('test', {'test': ['title:A Book: A Title']})
 


### PR DESCRIPTION
To properly parse complex queries they must be split on commas. However this can cause issues when a comma is in a quoted phrase. This has two unintended consequences:

- The query is split when the user almost certainly wanted that search executed as a phrase
- The splitting results in a syntax error because it results in open quotation marks that cannot be resolved by ElasticSearch

This resolves these issues by implementing a regex to split the query string that takes quotation marks into account. Through this the semantic meaning of the quotes is preserved and the query is only split on intended commas.