### PR TITLE
SFR-1098 Format Link Filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Fixed
 - Handling of records without titles in clustering process
 - Correct path for sorting on `publication_date` in ElasticSearch
+- Filter non-matching links when format filter is applied
 
 ## 2021-05-11 -- v0.5.7
 ### Added

--- a/api/blueprints/drbSearch.py
+++ b/api/blueprints/drbSearch.py
@@ -41,6 +41,11 @@ def standardQuery():
         for r in searchResult.hits
     ]
 
+    filteredFormats = [
+        APIUtils.FORMAT_CROSSWALK[f[1]]
+        for f in list(filter(lambda x: x[0] == 'format', terms['filter']))
+    ]
+
     logger.info('Executing DB Query for {} editions'.format(len(resultIds)))
 
     works = dbClient.fetchSearchedWorks(resultIds)
@@ -49,7 +54,7 @@ def standardQuery():
 
     dataBlock = {
         'totalWorks': searchResult.hits.total,
-        'works': APIUtils.formatWorkOutput(works, resultIds),
+        'works': APIUtils.formatWorkOutput(works, resultIds, formats=filteredFormats),
         'paging': paging,
         'facets': facets
     }

--- a/api/blueprints/drbSearch.py
+++ b/api/blueprints/drbSearch.py
@@ -42,8 +42,8 @@ def standardQuery():
     ]
 
     filteredFormats = [
-        APIUtils.FORMAT_CROSSWALK[f[1]]
-        for f in list(filter(lambda x: x[0] == 'format', terms['filter']))
+        mediaType for f in list(filter(lambda x: x[0] == 'format', terms['filter']))
+        for mediaType in APIUtils.FORMAT_CROSSWALK[f[1]]
     ]
 
     logger.info('Executing DB Query for {} editions'.format(len(resultIds)))

--- a/api/elastic.py
+++ b/api/elastic.py
@@ -1,8 +1,10 @@
 from copy import deepcopy
+from elasticsearch_dsl import Search, Q, A
 import os
 import re
 
-from elasticsearch_dsl import Search, Q, A
+from .utils import APIUtils
+
 
 class ElasticClient():
     ROLE_BLOCKLIST = ['arl', 'binder', 'binding designer', 'book designer',
@@ -15,15 +17,6 @@ class ElasticClient():
         'publishing director', 'retager', 'secretary', 'sponsor', 'stereotyper',
         'thesis advisor', 'transcriber', 'typographer', 'woodcutter',
     ]
-
-    FORMAT_CROSSWALK = {
-        'epub_zip': 'application/epub+zip',
-        'epub_xml': 'application/epub+xml',
-        'html': 'text/html',
-        'html_edd': 'application/html+edd',
-        'pdf': 'application/pdf',
-        'webpub_json': 'application/webpub+json'
-    }
 
     def __init__(self, esClient):
         self.client = esClient
@@ -207,7 +200,7 @@ class ElasticClient():
             formats = []
             for format in formatFilters:
                 try:
-                    formats.append(self.FORMAT_CROSSWALK[format[1]])
+                    formats.append(APIUtils.FORMAT_CROSSWALK[format[1]])
                 except KeyError:
                     raise ElasticClientError('Invalid format filter {} received'.format(format[1]))
 

--- a/api/elastic.py
+++ b/api/elastic.py
@@ -200,7 +200,7 @@ class ElasticClient():
             formats = []
             for format in formatFilters:
                 try:
-                    formats.append(APIUtils.FORMAT_CROSSWALK[format[1]])
+                    formats.extend(APIUtils.FORMAT_CROSSWALK[format[1]])
                 except KeyError:
                     raise ElasticClientError('Invalid format filter {} received'.format(format[1]))
 

--- a/api/utils.py
+++ b/api/utils.py
@@ -11,12 +11,12 @@ class APIUtils():
     ]
 
     FORMAT_CROSSWALK = {
-        'epub_zip': 'application/epub+zip',
-        'epub_xml': 'application/epub+xml',
-        'html': 'text/html',
-        'html_edd': 'application/html+edd',
-        'pdf': 'application/pdf',
-        'webpub_json': 'application/webpub+json'
+        'epub_zip': ['application/epub+zip', 'application/epub+xml'],
+        'epub_xml': ['application/epub+zip', 'application/epub+xml'],
+        'html': ['text/html'],
+        'html_edd': ['application/html+edd'],
+        'pdf': ['application/pdf'],
+        'webpub_json': ['application/webpub+json']
     }
 
     @staticmethod
@@ -142,6 +142,8 @@ class APIUtils():
                 {'source': r.source, 'license': r.license, 'rightsStatement': r.rights_statement}
                 for r in item.rights
             ]
+
+            if len(itemDict['links']) < 1: continue
 
             editionDict['items'].append(itemDict)
 

--- a/tests/unit/test_api_search_blueprint.py
+++ b/tests/unit/test_api_search_blueprint.py
@@ -68,7 +68,7 @@ class TestSearchBlueprint:
         mockUtils['normalizeQueryParams'].return_value = queryParams
             
         mockUtils['extractParamPairs'].side_effect = [
-            ['testQueryTerms'], ['testSortTerms'], ['testFilterTerms'], ['testShowAll']
+            ['testQueryTerms'], ['testSortTerms'], [('format', 'html')], ['testShowAll']
         ]
         mockUtils['formatAggregationResult'].return_value = 'testFacets'
         mockUtils['formatPagingOptions'].return_value = 'testPaging'
@@ -101,16 +101,21 @@ class TestSearchBlueprint:
                 mocker.call('showAll', queryParams)
             ])
             mockES.searchQuery.assert_called_once_with(
-                {'query': ['testQueryTerms'], 'sort': ['testSortTerms'], 'filter': ['testFilterTerms', 'testShowAll']},
+                {'query': ['testQueryTerms'], 'sort': ['testSortTerms'], 'filter': [('format', 'html'), 'testShowAll']},
                 page=0, perPage=5
             )
-            mockDB.fetchSearchedWorks.assert_called_once_with([
+            testResultIds = [
                 ('uuid1', ['ed1', 'ed2']), ('uuid2', ['ed3']),
                 ('uuid3', ['ed4', 'ed5', 'ed6']), ('uuid4', ['ed7']), ('uuid5', ['ed8'])
-            ])
+            ]
+            mockDB.fetchSearchedWorks.assert_called_once_with(testResultIds)
             mockUtils['formatAggregationResult'].assert_called_once_with({'aggs': []})
             mockUtils['formatPagingOptions'].assert_called_once_with(1, 5, 5)
-            mockUtils['formatWorkOutput'].assert_called_once
+            mockUtils['formatWorkOutput'].assert_called_once_with(
+                ['work1', 'work2', 'work3', 'work4', 'work5'],
+                testResultIds,
+                formats=['text/html']
+            )
 
             mockUtils['formatResponseObject'].assert_called_once_with(
                 200, 'searchResponse',

--- a/tests/unit/test_api_utils.py
+++ b/tests/unit/test_api_utils.py
@@ -290,6 +290,7 @@ class TestAPIUtils:
 
         formattedEdition = APIUtils.formatEdition(testEdition, formats=['application/test'])
 
+        assert len(formattedEdition['items']) == 1
         assert len(formattedEdition['items'][0]['links']) == 1
         assert formattedEdition['items'][0]['links'][0]['link_id'] == 'li1'
 

--- a/tests/unit/test_api_utils.py
+++ b/tests/unit/test_api_utils.py
@@ -76,6 +76,10 @@ class TestAPIUtils:
         return MockDBObject(id='li1', media_type='application/test', url='testURI')
 
     @pytest.fixture
+    def testFilterLink(self, MockDBObject):
+        return MockDBObject(id='li2', media_type='application/other', url='testURI')
+
+    @pytest.fixture
     def testRights(self, MockDBObject):
         return MockDBObject(id='ri1', source='test', license='testLicense', rights_statement='testStatement')
 
@@ -179,7 +183,8 @@ class TestAPIUtils:
 
         assert outWorks == ['formattedWork1', 'formattedWork2']
         mockFormat.assert_has_calls([
-            mocker.call(testWorks[0], 1, True), mocker.call(testWorks[1], 2, True)
+            mocker.call(testWorks[0], 1, True, formats=None),
+            mocker.call(testWorks[1], 2, True, formats=None)
         ])
 
     def test_formatWork_showAll(self, testWork, mocker):
@@ -277,6 +282,16 @@ class TestAPIUtils:
             mocker.call('rec1', {'testURI': testItemDict}),
             mocker.call('rec2', {'testURI': testItemDict})
         ])
+
+    def test_formatEdition_w_format_filter(self, testEdition, testFilterLink, mocker):
+        testEdition.items[0].links.insert(0, testFilterLink)
+        mockRecFormat = mocker.patch.object(APIUtils, 'formatRecord')
+        mockRecFormat.side_effect = [1, 2]
+
+        formattedEdition = APIUtils.formatEdition(testEdition, formats=['application/test'])
+
+        assert len(formattedEdition['items'][0]['links']) == 1
+        assert formattedEdition['items'][0]['links'][0]['link_id'] == 'li1'
 
     def test_formatRecord(self, testRecord, mocker):
         testLinkItems = {


### PR DESCRIPTION
This removes links that do not match the currently configured format filter (and still return all links if no filter is set). This ensures that users see the expected results when they select a filter.

This is fairly simply due to the fact that the filter already removes any `Item` records that do not contain a valid link. So this must simply remove any other links on the records that are included.