### PR TITLE
SFR-1115 ePub Storage Bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Handling of records without titles in clustering process
 - Don't split queries on commas within quotation marks
 - Correct path for sorting on `publication_date` in ElasticSearch
+- Parsing of some Gutenberg and DOAB ePub files on ingest
 
 ## 2021-05-11 -- v0.5.7
 ### Added

--- a/managers/s3.py
+++ b/managers/s3.py
@@ -63,7 +63,7 @@ class S3Manager:
             raise S3Error('Unable to store file in s3')
 
     def putExplodedEpubComponentsInBucket(self, obj, objKey, bucket):
-        keyRoot = objKey.split('.')[0] 
+        keyRoot = '.'.join(objKey.split('.')[:-1]) 
 
         with ZipFile(BytesIO(obj), 'r') as epubZip:
             for component in epubZip.namelist():

--- a/processes/gutenberg.py
+++ b/processes/gutenberg.py
@@ -111,7 +111,7 @@ class GutenbergProcess(CoreProcess):
             if flags['download'] is True:
                 bucketLocation = 'epubs/{}/{}_{}.epub'.format(source, gutenbergID, gutenbergType)
             else:
-                bucketLocation = 'epubs/{}/{}_{}/META-INF/content.xml'.format(source, gutenbergID, gutenbergType)
+                bucketLocation = 'epubs/{}/{}_{}/META-INF/container.xml'.format(source, gutenbergID, gutenbergType)
                 mediaType = 'application/epub+xml'
 
             s3URL = 'https://{}.s3.amazonaws.com/{}'.format(self.s3Bucket, bucketLocation)

--- a/tests/unit/test_gutenberg_process.py
+++ b/tests/unit/test_gutenberg_process.py
@@ -174,7 +174,7 @@ class TestGutenbergProcess:
         ])
         assert mockRecord.record.has_part == [
             '1|https://test_aws_bucket.s3.amazonaws.com/epubs/gutenberg/1_images.epub|gutenberg|application/epub+zip|{"download": true}',
-            '1|https://test_aws_bucket.s3.amazonaws.com/epubs/gutenberg/1_images/META-INF/content.xml|gutenberg|application/epub+xml|{"download": false}',
+            '1|https://test_aws_bucket.s3.amazonaws.com/epubs/gutenberg/1_images/META-INF/container.xml|gutenberg|application/epub+xml|{"download": false}',
             '2|https://test_aws_bucket.s3.amazonaws.com/epubs/gutenberg/2_noimages.epub|gutenberg|application/epub+zip|{"download": true}',
         ]
 

--- a/tests/unit/test_s3_manager.py
+++ b/tests/unit/test_s3_manager.py
@@ -130,11 +130,11 @@ class TestS3Manager:
 
         mockPut = mocker.patch.object(S3Manager, 'putObjectInBucket')
 
-        testInstance.putExplodedEpubComponentsInBucket(b'testObj', 'testKey.epub', 'testBucket')
+        testInstance.putExplodedEpubComponentsInBucket(b'testObj', '10.10/testKey.epub', 'testBucket')
 
         mockPut.assert_has_calls([
-            mocker.call('compBytes1', 'testKey/comp1', 'testBucket'),
-            mocker.call('compBytes2', 'testKey/comp2', 'testBucket')
+            mocker.call('compBytes1', '10.10/testKey/comp1', 'testBucket'),
+            mocker.call('compBytes2', '10.10/testKey/comp2', 'testBucket')
         ])
 
     def test_getObjectFromBucket_success(self, testInstance, mocker):


### PR DESCRIPTION
This resolves two issues with ePub files on ingest (when they are stored in s3):

* When ePub paths contain periods (as with DOI identifiers) the ePub manager failed to properly parse the location. This resulted in ePub files that could be loaded in the webreader. This updates the parser to handle multiple periods and resolve the issue.
* A regression affecting Gutenberg files caused their XML entrypoint files to be set as `content.xml` when the file should be `container.xml` which was fixed with a simple substitution.