### PR TITLE
HOTFIX Handle edge case error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Don't split queries on commas within quotation marks
 - Correct path for sorting on `publication_date` in ElasticSearch
 - Parsing of some Gutenberg and DOAB ePub files on ingest
+- Handle missing Gutenberg cover edge case
 
 ## 2021-05-11 -- v0.5.7
 ### Added

--- a/processes/gutenberg.py
+++ b/processes/gutenberg.py
@@ -7,6 +7,9 @@ import re
 from .core import CoreProcess
 from managers import GutenbergManager
 from mappings.gutenberg import GutenbergMapping
+from logger import createLog
+
+logger = createLog(__name__)
 
 
 class GutenbergProcess(CoreProcess):
@@ -93,8 +96,8 @@ class GutenbergProcess(CoreProcess):
 
             try:
                 self.addCoverAndStoreInS3(gutenbergRec, gutenbergYAML)
-            except AttributeError:
-                print('Unable to store cover for {}'.format(gutenbergRec.source_id))
+            except (KeyError, AttributeError):
+                logger.warning('Unable to store cover for {}'.format(gutenbergRec.record.source_id))
             
             self.addDCDWToUpdateList(gutenbergRec)
 

--- a/tests/unit/test_gutenberg_process.py
+++ b/tests/unit/test_gutenberg_process.py
@@ -128,7 +128,7 @@ class TestGutenbergProcess:
         assert mockManager.resetBatch.call_count == 2
 
     def test_processGutenbergBatch(self, testInstance, mocker):
-        mockGutenbergRec = mocker.MagicMock(name='MockRecord')
+        mockGutenbergRec = mocker.MagicMock(name='MockRecord', record=mocker.MagicMock(source_id=1))
         mockGutenbergInit = mocker.patch('processes.gutenberg.GutenbergMapping')
         mockGutenbergInit.return_value = mockGutenbergRec
 
@@ -138,6 +138,8 @@ class TestGutenbergProcess:
             addCoverAndStoreInS3=mocker.DEFAULT,
             addDCDWToUpdateList=mocker.DEFAULT
         )
+
+        processMocks['addCoverAndStoreInS3'].side_effect = [None, KeyError]
 
         testInstance.processGutenbergBatch([('rdf1', 'yaml1'), ('rdf2', 'yaml2')])
 


### PR DESCRIPTION
In very rare cases a `metadata.yml` file can be generated for a Gutenberg work without a cover reference. This simply handles the error raised in that case, logs the event and continues. While we would like covers for all works, we do not consider a missing cover a reason to block ingest of a record.