### PR TITLE
SFR-1121 Fix Language Filter Bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Correct path for sorting on `publication_date` in ElasticSearch
 - Parsing of some Gutenberg and DOAB ePub files on ingest
 - Handle missing Gutenberg cover edge case
+- Regression in filtering language aggregation buckets
 
 ## 2021-05-11 -- v0.5.7
 ### Added

--- a/api/elastic.py
+++ b/api/elastic.py
@@ -190,7 +190,7 @@ class ElasticClient():
 
         dateFilter, dateAggregation = (None, None)
         formatFilter, formatAggregation = (None, None)
-        displayFilter, displayAggregation = (Q('exists', field='editions.formats'),A('filter', **{'exists': {'field': 'editions.formats'}}))
+        displayFilter, displayAggregation = (Q('exists', field='editions.formats'), A('filter', **{'exists': {'field': 'editions.formats'}}))
 
         if len(languageFilters) > 0:
             self.languageFilters = [
@@ -219,7 +219,7 @@ class ElasticClient():
             displayAggregation = None
         
         self.appliedFilters = list(filter(None, [dateFilter, formatFilter, displayFilter]))
-        self.aggregationFilters = list(filter(None, [dateAggregation, formatAggregation, displayAggregation]))
+        self.appliedAggregations = list(filter(None, [dateAggregation, formatAggregation, displayAggregation]))
 
     def addFiltersAndAggregations(self, innerHits):
         self.applyFilters(size=innerHits)

--- a/tests/unit/test_api_es.py
+++ b/tests/unit/test_api_es.py
@@ -464,7 +464,7 @@ class TestElasticClient:
         mockAgg.assert_called_once_with('filter', exists={'field': 'editions.formats'})
 
         assert testInstance.appliedFilters == ['formatFilter']
-        assert testInstance.aggregationFilters == ['formatAggregation']
+        assert testInstance.appliedAggregations == ['formatAggregation']
 
     def test_createFilterClausesAndAggregations_w_date(self, testInstance, mocker):
         mockQuery = mocker.patch('api.elastic.Q')
@@ -487,7 +487,7 @@ class TestElasticClient:
         ])
 
         assert testInstance.appliedFilters == ['formatFilter', 'dateFilter']
-        assert testInstance.aggregationFilters == ['formatAggregation', 'dateAggregation']
+        assert testInstance.appliedAggregations == ['formatAggregation', 'dateAggregation']
 
     def test_createFilterClausesAndAggregations_w_format(self, testInstance, mocker):
         mockQuery = mocker.patch('api.elastic.Q')
@@ -507,7 +507,7 @@ class TestElasticClient:
         ])
 
         assert testInstance.appliedFilters == ['formatFilter', 'displayFilter']
-        assert testInstance.aggregationFilters == ['formatAggregation', 'displayAggregation']
+        assert testInstance.appliedAggregations == ['formatAggregation', 'displayAggregation']
 
     def test_createFilterClausesAndAggregations_w_format_error(self, testInstance):
         with pytest.raises(ElasticClientError):
@@ -532,7 +532,7 @@ class TestElasticClient:
 
         assert testInstance.languageFilters == ['languageFilter']
         assert testInstance.appliedFilters == ['displayFilter']
-        assert testInstance.aggregationFilters == ['displayAggregation']
+        assert testInstance.appliedAggregations == ['displayAggregation']
 
     def test_createFilterClausesAndAggregations_no_filters(self, testInstance, mocker):
         mockQuery = mocker.patch('api.elastic.Q')
@@ -548,7 +548,7 @@ class TestElasticClient:
         ])
 
         assert testInstance.appliedFilters == []
-        assert testInstance.aggregationFilters == []
+        assert testInstance.appliedAggregations == []
 
     def test_addFiltersAndAggregations(self, testInstance, mocker):
         mockFilters = mocker.patch.object(ElasticClient, 'applyFilters')


### PR DESCRIPTION
A regression in the ElasticSearch query class prevented set filters from being applied to aggregation buckets. This meant that the buckets displayed inaccurate counts of works returned in the search.

This was due to a misnamed variable, correcting that issue resolves the bug