### PR TITLE
HOTFIX Block downloads for Google digitized books

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Correct path for sorting on `publication_date` in ElasticSearch
 - Parsing of some Gutenberg and DOAB ePub files on ingest
 - Handle missing Gutenberg cover edge case
+- Enforce Google Books PDF download exclusion
 
 ## 2021-05-11 -- v0.5.7
 ### Added

--- a/mappings/hathitrust.py
+++ b/mappings/hathitrust.py
@@ -88,14 +88,17 @@ class HathiMapping(CSVMapping):
             'text/html',
             json.dumps({'reader': False, 'download': False, 'catalog': False})
         )
-        downloadLink = '{}|{}|{}|{}|{}'.format(
-            1,
-            'https://babel.hathitrust.org/cgi/imgsrv/download/pdf?id={}'.format(self.source[0]),
-            'hathitrust',
-            'application/pdf',
-            json.dumps({'reader': False, 'download': True, 'catalog': False})
-        ) 
-        self.record.has_part = [readOnlineLink, downloadLink]
+
+        self.record.has_part = [readOnlineLink]
+
+        if self.source[23].lower() != 'google':
+            self.record.has_part.append('{}|{}|{}|{}|{}'.format(
+                1,
+                'https://babel.hathitrust.org/cgi/imgsrv/download/pdf?id={}'.format(self.source[0]),
+                'hathitrust',
+                'application/pdf',
+                json.dumps({'reader': False, 'download': True, 'catalog': False})
+            )) 
 
         # Parse spatial (pub place) codes
         self.record.spatial = self.record.spatial or ''

--- a/tests/unit/test_hathitrust_mapping.py
+++ b/tests/unit/test_hathitrust_mapping.py
@@ -52,7 +52,8 @@ class TestHathingMapping:
 
     def test_applyFormatting(self, testMapping, testRecord_standard):
         testMapping.record = testRecord_standard
-        testMapping.source = ['recordID']
+        testMapping.source = [''] * 24
+        testMapping.source[0] = 'recordID'
 
         testMapping.applyFormatting()
 
@@ -72,10 +73,22 @@ class TestHathingMapping:
     def test_applyFormatting_no_pub_date(self, testMapping, testRecord_standard):
         testRecord_standard.dates = ['|publication_date']
         testMapping.record = testRecord_standard
-        testMapping.source = ['recordID']
+        testMapping.source = [''] * 24
 
         testMapping.applyFormatting()
 
         assert testMapping.record.dates == []
         assert testMapping.record.publisher == ['||']
-        
+
+    def test_applyFormatting_google(self, testMapping, testRecord_standard):
+        testMapping.record = testRecord_standard
+        testMapping.source = [''] * 24
+        testMapping.source[0] = 'recordID'
+        testMapping.source[23] = 'Google'
+
+        testMapping.applyFormatting()
+
+        assert len(testMapping.record.has_part) == 1
+        assert testMapping.record.has_part == [
+            '1|https://babel.hathitrust.org/cgi/pt?id=recordID|hathitrust|text/html|{"reader": false, "download": false, "catalog": false}'
+        ]


### PR DESCRIPTION
Google disallows downloads for their digitized volumes in HathiTrust. These were being made available and needed to be removed. This institutes a simple block to enforce this.