### PR TITLE
SFR-1097 Remove webpub pdfs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Fixed
 - Handling of records without titles in clustering process
 - Correct path for sorting on `publication_date` in ElasticSearch
+- Temporarily block the display of webpub manifests in the API response
 
 ## 2021-05-11 -- v0.5.7
 ### Added

--- a/api/utils.py
+++ b/api/utils.py
@@ -128,6 +128,12 @@ class APIUtils():
                 for l in item.links
             ]
 
+            # TEMPORARY: Remove application/webpub+json files
+            # while new reader is under development. Remove any items that have
+            # no links as a result
+            itemDict['links'] = list(filter(lambda x: x['mediaType'] != 'application/webpub+json', itemDict['links']))
+            if len(itemDict['links']) < 1: continue
+
             itemDict['rights'] = [
                 {'source': r.source, 'license': r.license, 'rightsStatement': r.rights_statement}
                 for r in item.rights

--- a/tests/unit/test_api_utils.py
+++ b/tests/unit/test_api_utils.py
@@ -305,7 +305,6 @@ class TestAPIUtils:
             mocker.call('rec2', {'testURI': testItemDict})
         ])
 
-<<<<<<< HEAD
     def test_formatEdition_filter_webpubs_temp(self, testEdition, testWebpubItem):
         testEdition.items.append(testWebpubItem)
 
@@ -314,18 +313,6 @@ class TestAPIUtils:
         assert len(formattedEdition['items']) == 1
         assert formattedEdition['items'][0]['item_id'] == 'it1'
         assert formattedEdition['items'][0]['links'][0]['mediaType'] == 'application/test'
-=======
-    def test_formatEdition_w_format_filter(self, testEdition, testFilterLink, mocker):
-        testEdition.items[0].links.insert(0, testFilterLink)
-        mockRecFormat = mocker.patch.object(APIUtils, 'formatRecord')
-        mockRecFormat.side_effect = [1, 2]
-
-        formattedEdition = APIUtils.formatEdition(testEdition, formats=['application/test'])
-
-        assert len(formattedEdition['items']) == 1
-        assert len(formattedEdition['items'][0]['links']) == 1
-        assert formattedEdition['items'][0]['links'][0]['link_id'] == 'li1'
->>>>>>> main
 
     def test_formatRecord(self, testRecord, mocker):
         testLinkItems = {


### PR DESCRIPTION
In anticipation of the new webreader, many files (primarily from Project MUSE and DOAB) have been stored as Webpub manifests, which can make PDF files readable through several means. However, this reader is not yet available, meaning that these files can throw errors. This blocks them from being included in API responses until the reader is ready.

When it is, a single line (and corresponding test) will need to be removed to re-enable this functionality

