### PR TITLE
HOTFIX Resolve work merging method bug

### DIFF
--- a/managers/db.py
+++ b/managers/db.py
@@ -85,6 +85,13 @@ class DBManager:
             else:
                 logger.warning('Already retried batch, dropping')
 
+    def deleteRecordsByQuery(self, query):
+        try:
+            query.delete()
+        except OperationalError as oprErr:
+            logger.error('Deadlock in database layer, retry batch')
+            logger.debug(oprErr)
+
     @staticmethod
     def decryptEnvVar(envVar):
         encrypted = os.environ.get(envVar, None)

--- a/processes/sfrCluster.py
+++ b/processes/sfrCluster.py
@@ -5,7 +5,7 @@ from sqlalchemy.exc import DataError
 
 from .core import CoreProcess
 from managers import SFRRecordManager, KMeansManager, SFRElasticRecordManager
-from model import Record
+from model import Record, Work
 from logger import createLog
 
 logger = createLog(__name__)
@@ -109,6 +109,7 @@ class ClusterProcess(CoreProcess):
 
         deletedRecordUUIDs = recordManager.mergeRecords()
         self.deleteWorkRecords(deletedRecordUUIDs)
+        self.deleteRecordsByQuery(self.session.query(Work).filter(Work.uuid.in_(deletedRecordUUIDs)))
 
         return recordManager.work
     

--- a/tests/unit/test_sfrCluster_process.py
+++ b/tests/unit/test_sfrCluster_process.py
@@ -243,14 +243,21 @@ class TestSFRClusterProcess:
         mockManagerInst = mocker.patch('processes.sfrCluster.SFRRecordManager')
         mockManagerInst.return_value = mockRecManager
 
-        testInstance.session = 'testSession'
+        mockDeleteElastic = mocker.patch.object(ClusterProcess, 'deleteWorkRecords')
+        mockDeletePostgres = mocker.patch.object(ClusterProcess, 'deleteRecordsByQuery')
+
+        mockSession = mocker.MagicMock()
+        testInstance.session = mockSession
         testWork = testInstance.createWorkFromEditions('testEditions', 'testInstances')
 
         assert testWork == 'testWork'
-        mockManagerInst.assert_called_once_with('testSession', {})
+        mockManagerInst.assert_called_once_with(mockSession, {})
         mockRecManager.buildWork.assert_called_once_with('testInstances', 'testEditions')
         mockRecManager.saveWork.assert_called_once_with('testWorkData')
         mockRecManager.mergeRecords.assert_called_once()
+        mockDeleteElastic.assert_called_once()
+        mockDeletePostgres.assert_called_once()
+        mockSession.query().filter.assert_called_once()
 
     def test_queryIdens_success(self, testInstance, mocker):
         mockGetBatches = mocker.patch.object(ClusterProcess, 'getRecordBatches')

--- a/tests/unit/test_sfrRecord_manager.py
+++ b/tests/unit/test_sfrRecord_manager.py
@@ -71,32 +71,23 @@ class TestSFRRecordManager:
             mocker.MagicMock(identifiers=['id3'], items=secondEdItems, dcdw_uuids=['uuid4'])
         ]
         testInstance.work.identifiers = ['wo1', 'wo2', 'wo3']
+        testInstance.work.uuid = 1
 
-        testWork = mocker.MagicMock(id='wo1', uuid='uuid1')
-
-        matchingEditions = [
-            mocker.MagicMock(work_id=1, id='ed1', work=testWork, dcdw_uuids=['uuid1']),
-            mocker.MagicMock(work_id=1, id='ed2', work=testWork, dcdw_uuids=['uuid2']),
-            mocker.MagicMock(work_id=1, id='ed3', work=testWork, dcdw_uuids=['uuid3'])
+        matchingWorks = [
+            mocker.MagicMock(uuid=2, date_created='2020-01-01'),
+            mocker.MagicMock(uuid=3, date_created='2019-01-01'),
+            mocker.MagicMock(uuid=4, date_created='2018-01-01'),
         ]
-        testInstance.session.query().filter().all.return_value = matchingEditions
-        testInstance.session.merge.return_value = testInstance.work
+        testInstance.session.query().join().filter().filter().all.return_value = matchingWorks
 
         testUUIDsToDelete = testInstance.mergeRecords()
 
-        assert testUUIDsToDelete == set(['uuid1'])
+        assert testUUIDsToDelete == [4, 3, 2]
+        assert testInstance.work.uuid == 1
+        assert testInstance.work.date_created == '2018-01-01'
 
-        assert testInstance.work.id == 1
-        assert testInstance.work.identifiers == ['work1']
-        assert testInstance.work.editions[0].id == 'ed1'
-        assert testInstance.work.editions[1].identifiers == ['newEd3']
-        assert testInstance.work.editions[0].items[0].identifiers == ['item1']
-        assert testInstance.work.editions[1].items[1].links == ['url4']
-
-        testInstance.session.query().filter().all.assert_called_once()
-        testInstance.session.delete.assert_called_once_with(testWork)
-
-        testInstance.session.merge.assert_called_once_with(testInstance.work)
+        testInstance.session.query().join().filter().filter().all.assert_called_once()
+        testInstance.session.add.assert_called_once_with(testInstance.work)
 
     def test_dedupeIdentifiers(self, testInstance, mocker):
         testExistingIDs = {}


### PR DESCRIPTION
The current method for updating work records makes a faulty assumption about how the sqlalchemy `merge` method works. This is simply replaced with a different approach that deletes pre-existing records that are updated and assigns the oldest relevant created date to the newly created work record. This better reflects the process and should be faster.