### PR TITLE
HOTFIX Simplify Work persistence and merging

### DIFF
--- a/managers/sfrRecord.py
+++ b/managers/sfrRecord.py
@@ -52,7 +52,7 @@ class SFRRecordManager:
         if len(matchedWorks) > 0:
             self.work.date_created = matchedWorks[0][1]
 
-        self.session.add(self.work)
+        self.work = self.session.merge(self.work)
 
         return [w[0] for w in matchedWorks]
 

--- a/tests/unit/test_sfrRecord_manager.py
+++ b/tests/unit/test_sfrRecord_manager.py
@@ -79,6 +79,7 @@ class TestSFRRecordManager:
             mocker.MagicMock(uuid=4, date_created='2018-01-01'),
         ]
         testInstance.session.query().join().filter().filter().all.return_value = matchingWorks
+        testInstance.session.merge.return_value = testInstance.work
 
         testUUIDsToDelete = testInstance.mergeRecords()
 
@@ -87,7 +88,7 @@ class TestSFRRecordManager:
         assert testInstance.work.date_created == '2018-01-01'
 
         testInstance.session.query().join().filter().filter().all.assert_called_once()
-        testInstance.session.add.assert_called_once_with(testInstance.work)
+        testInstance.session.merge.assert_called_once_with(testInstance.work)
 
     def test_dedupeIdentifiers(self, testInstance, mocker):
         testExistingIDs = {}


### PR DESCRIPTION
Previous iterations of the matching and merging of work records after they have been clustered relied on a number of tricks. This simplifies the process such that new works simply overwrite older works, copying over the creation date for continuity.

This fix updates the deletion process to ensure that records are properly deleted and that identifiers are not removed mistakenly during indexing