### PR TITLE
SFR-1113 & SFR-1124 Edition Detail Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,17 @@
 # CHANGELOG
 
-## unreleased -- v0.5.7
+## unreleased -- v0.5.8
 ### Fixed
 - Add Slack notifications for automation regression tests
-
-## unreleased -- v0.5.7
 - Handling of records without titles in clustering process
 - Don't split queries on commas within quotation marks
 - Correct path for sorting on `publication_date` in ElasticSearch
 - Filter non-matching links when format filter is applied
 - Parsing of some Gutenberg and DOAB ePub files on ingest
 - Handle missing Gutenberg cover edge case
-<<<<<<< HEAD
 - Regression in filtering language aggregation buckets
-=======
 - Enforce Google Books PDF download exclusion
->>>>>>> main
+- Resolve bugs in Edition detail view
 
 ## 2021-05-11 -- v0.5.7
 ### Added

--- a/api/utils.py
+++ b/api/utils.py
@@ -115,10 +115,10 @@ class APIUtils():
 
     @classmethod
     def formatEditionOutput(cls, edition, records=None, showAll=False):
-        return cls.formatEdition(edition, records)
+        return cls.formatEdition(edition, records, showAll=showAll)
 
     @classmethod
-    def formatEdition(cls, edition, records=None, formats=None):
+    def formatEdition(cls, edition, records=None, formats=None, showAll=False):
         editionDict = dict(edition)
         editionDict['edition_id'] = edition.id
         editionDict['work_uuid'] = edition.work.uuid
@@ -154,7 +154,15 @@ class APIUtils():
             for item in editionDict['items']:
                 for link in item['links']:
                     itemsByLink[link['url']] = item
-            editionDict['instances'] = [cls.formatRecord(rec, itemsByLink) for rec in records]
+            
+            editionDict['instances'] = []
+            for rec in records:
+                formattedRec = cls.formatRecord(rec, itemsByLink)
+
+                if showAll and len(formattedRec['items']) < 1:
+                    continue
+
+                editionDict['instances'].append(formattedRec)
 
             del editionDict['items']
 

--- a/api/utils.py
+++ b/api/utils.py
@@ -190,7 +190,9 @@ class APIUtils():
         for hasPart in record.has_part:
             _, url, *_ = hasPart.split('|')
             urlItem = itemsByLink.get(re.sub(r'https?:\/\/', '', url), None)
-            recordItems[urlItem['item_id']] = urlItem
+            
+            if urlItem:
+                recordItems[urlItem['item_id']] = urlItem
         
         outRecord['items'] = [item for _, item in recordItems.items()]
 

--- a/tests/unit/test_api_utils.py
+++ b/tests/unit/test_api_utils.py
@@ -68,7 +68,7 @@ class TestAPIUtils:
             dates=['date1', 'date2'],
             languages=['lang1'],
             identifiers=['id1', 'id2', 'id3'],
-            has_part=['1|url1|', '2|url2|']
+            has_part=['1|url1|', '2|url2|', '3|url3|']
         )
 
     @pytest.fixture

--- a/tests/unit/test_api_utils.py
+++ b/tests/unit/test_api_utils.py
@@ -257,7 +257,7 @@ class TestAPIUtils:
 
         assert APIUtils.formatEditionOutput(1, records='testRecords', showAll=True) == 'testEdition'
 
-        mockFormatEdition.assert_called_once_with(1, 'testRecords')
+        mockFormatEdition.assert_called_once_with(1, 'testRecords', showAll=True)
 
     def test_formatEdition_no_records(self, testEdition):
         formattedEdition = APIUtils.formatEdition(testEdition)
@@ -278,13 +278,14 @@ class TestAPIUtils:
         assert formattedEdition['items'][0]['rights'][0]['rightsStatement'] == 'testStatement'
         assert formattedEdition.get('instances', None) == None
 
-    def test_formatEdition_w_records(self, testEdition, testItem, mocker):
+    def test_formatEdition_w_records(self, testEdition, mocker):
         mockRecFormat = mocker.patch.object(APIUtils, 'formatRecord')
-        mockRecFormat.side_effect = [1, 2]
+        mockRecFormat.side_effect = [{'id': 1, 'items': []}, {'id': 2, 'items': ['it1']}]
 
-        formattedEdition = APIUtils.formatEdition(testEdition, ['rec1', 'rec2'])
+        formattedEdition = APIUtils.formatEdition(testEdition, ['rec1', 'rec2'], showAll=True)
 
-        assert formattedEdition['instances'] == [1, 2]
+        assert len(formattedEdition['instances']) == 1
+        assert formattedEdition['instances'][0]['id'] == 2
         assert formattedEdition.get('items', None) == None
 
         testItemDict = {


### PR DESCRIPTION
This corrects two bugs with the edition detail view:

- In the context of an edition detail the `showAll` filter was not being passed to the proper method. Asa result the corresponding function on the front end did not update the detail page. This passes the variable to the correct function and applies the logic when iterating through the component records of an edition.
- Some `record` entries have `has_part` items that are not present as links. These need to be filtered out from responses. This was already being detected but not properly filtered from the final array. This simply enforces a `None` check to make this method behave properly.