### PR TITLE
HOTFIX showall boolean logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unreleased -- v0.6.2
+### Fixed
+- Correct reversed boolean logic with `showAll` filter
+
 ## 2021-06-07 -- v0.6.1
 ### Fixed
 - Loading bug for edition detail pages

--- a/api/utils.py
+++ b/api/utils.py
@@ -165,7 +165,7 @@ class APIUtils():
             for rec in records:
                 formattedRec = cls.formatRecord(rec, itemsByLink)
 
-                if showAll and len(formattedRec['items']) < 1:
+                if showAll is False and len(formattedRec['items']) < 1:
                     continue
 
                 editionDict['instances'].append(formattedRec)

--- a/tests/unit/test_api_utils.py
+++ b/tests/unit/test_api_utils.py
@@ -286,7 +286,7 @@ class TestAPIUtils:
         mockRecFormat = mocker.patch.object(APIUtils, 'formatRecord')
         mockRecFormat.side_effect = [{'id': 1, 'items': []}, {'id': 2, 'items': ['it1']}]
 
-        formattedEdition = APIUtils.formatEdition(testEdition, ['rec1', 'rec2'], showAll=True)
+        formattedEdition = APIUtils.formatEdition(testEdition, ['rec1', 'rec2'], showAll=False)
 
         assert len(formattedEdition['instances']) == 1
         assert formattedEdition['instances'][0]['id'] == 2


### PR DESCRIPTION
The logic for applying the `showAll` logic in edition detail was reversed, due to a backwards test case. This is resolved in this commit