### PR TITLE
SFR-1133 Order Editions on Work Detail Page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unreleased -- v0.6.3
+### Fixed
+- Order edition records in ascending date order in work detail pages
+
 ## 2021-06-08 -- v0.6.2
 ### Fixed
 - Correct reversed boolean logic with `showAll` filter

--- a/api/utils.py
+++ b/api/utils.py
@@ -91,7 +91,10 @@ class APIUtils():
             
             return outWorks
         else:
-            return cls.formatWork(works, None, showAll)
+            formattedWork =  cls.formatWork(works, None, showAll)
+            formattedWork['editions'].sort(key=lambda x: x['publication_date'] if x['publication_date'] else 9999)
+
+            return formattedWork
 
     @classmethod
     def formatWork(cls, work, editionIds, showAll, formats=None):

--- a/tests/unit/test_api_utils.py
+++ b/tests/unit/test_api_utils.py
@@ -188,11 +188,20 @@ class TestAPIUtils:
 
     def test_formatWorkOutput_single_work(self, mocker):
         mockFormat = mocker.patch.object(APIUtils, 'formatWork')
-        mockFormat.return_value = 'formattedWork'
+        mockFormat.return_value = {
+            'uuid': 1,
+            'editions': [
+                {'id': 'ed1', 'publication_date': None},
+                {'id': 'ed2', 'publication_date': 2000},
+                {'id': 'ed3', 'publication_date': 1900}
+            ]
+        }
 
         outWork = APIUtils.formatWorkOutput('testWork', None)
 
-        assert outWork == 'formattedWork'
+        assert outWork['uuid'] == 1
+        assert outWork['editions'][0]['id'] == 'ed3'
+        assert outWork['editions'][2]['id'] == 'ed1'
         mockFormat.assert_called_once_with('testWork', None, True)
 
     def test_formatWorkOutput_multiple_works(self, mocker):


### PR DESCRIPTION
This fix consistently sorts editions within work detail pages. This ensures that users have a consistent and logical experience when looking at work details.