### PR TITLE
SFR-1094 Author Role Update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2021-06-08 -- v0.6.2
 ### Fixed
 - Correct reversed boolean logic with `showAll` filter
+- Replaced author blocklist with allowlist for search queries
 
 ## 2021-06-07 -- v0.6.1
 ### Fixed

--- a/api/elastic.py
+++ b/api/elastic.py
@@ -7,15 +7,14 @@ from .utils import APIUtils
 
 
 class ElasticClient():
-    ROLE_BLOCKLIST = ['arl', 'binder', 'binding designer', 'book designer',
-        'book producer', 'bookseller', 'collector', 'consultant', 'contractor',
-        'corrector', 'dedicatee', 'donor', 'copyright holder', 'court reporter',
-        'electrotyper', 'engineer', 'engraver', 'expert', 'former owner', 'funder',
-        'honoree', 'host institution', 'imprint', 'inscriber', 'other', 'patron',
-        'performer', 'presenter', 'producer', 'production company', 'publisher',
-        'printer', 'printer of plates', 'printmaker', 'proofreader',
-        'publishing director', 'retager', 'secretary', 'sponsor', 'stereotyper',
-        'thesis advisor', 'transcriber', 'typographer', 'woodcutter',
+    ROLE_ALLOWLIST = [
+        'author of afterwor, colophon, etc.', 'author of dialog',
+        'author of introduction, etc.', 'author', 'colorist', 'composer',
+        'compiler', 'creator', 'contributor', 'editor', 'film director',
+        'film producer', 'illustrator', 'illuminator', 'interviewer',
+        'interviewee', 'lyricist', 'translator', 'videographer',
+        'writer of introduction', 'writer of preface',
+        'writer of supplementary textual content'
     ]
 
     def __init__(self, esClient):
@@ -99,12 +98,16 @@ class ElasticClient():
     @classmethod
     def authorQuery(cls, authorText):
         workAgentQuery = Q('bool',
-            must=[Q('query_string', query=authorText, fields=['agents.name'], default_operator='and')],
-            must_not=[Q('terms', agents__roles=cls.ROLE_BLOCKLIST)]
+            must=[
+                Q('query_string', query=authorText, fields=['agents.name'], default_operator='and'),
+                Q('terms', agents__roles=cls.ROLE_ALLOWLIST)
+            ]
         )
         editionAgentQuery = Q('bool',
-            must=[Q('query_string', query=authorText, fields=['editions.agents.name'], default_operator='and')],
-            must_not=[Q('terms', editions__agents__roles=cls.ROLE_BLOCKLIST)]
+            must=[
+                Q('query_string', query=authorText, fields=['editions.agents.name'], default_operator='and'),
+                Q('terms', editions__agents__roles=cls.ROLE_ALLOWLIST)
+            ]
         )
 
         return Q('bool',

--- a/tests/unit/test_api_es.py
+++ b/tests/unit/test_api_es.py
@@ -316,11 +316,11 @@ class TestElasticClient:
         assert testQuery['bool']['should'][0]['nested']['path'] == 'agents'
         assert testQuery['bool']['should'][0]['nested']['query']['bool']['must'][0]['query_string']['query'] == 'testAuthor'
         assert testQuery['bool']['should'][0]['nested']['query']['bool']['must'][0]['query_string']['fields'] == ['agents.name']
-        assert testQuery['bool']['should'][0]['nested']['query']['bool']['must_not'][0]['terms']['agents.roles'] == ElasticClient.ROLE_BLOCKLIST
+        assert testQuery['bool']['should'][0]['nested']['query']['bool']['must'][1]['terms']['agents.roles'] == ElasticClient.ROLE_ALLOWLIST
         assert testQuery['bool']['should'][1]['nested']['path'] == 'editions.agents'
         assert testQuery['bool']['should'][1]['nested']['query']['bool']['must'][0]['query_string']['query'] == 'testAuthor'
         assert testQuery['bool']['should'][1]['nested']['query']['bool']['must'][0]['query_string']['fields'] == ['editions.agents.name']
-        assert testQuery['bool']['should'][1]['nested']['query']['bool']['must_not'][0]['terms']['editions.agents.roles'] == ElasticClient.ROLE_BLOCKLIST
+        assert testQuery['bool']['should'][1]['nested']['query']['bool']['must'][1]['terms']['editions.agents.roles'] == ElasticClient.ROLE_ALLOWLIST
 
     def test_authorityQuery(self):
         testQueryES = ElasticClient.authorityQuery('testAuth', 'testID')


### PR DESCRIPTION
The currently implemented blocklist was not properly filtering roles during author searches. This resulted in unexpected results for author searches. Because it is difficult to predict what role will be used in metadata records, this block list is replaced with an allowlist that explicitly defines the roles that are considered valid for an author search.

This is more restrictive but should be consistent in the long term regarding what is matched for such searches. The list can be extended if necessary.