### PR TITLE
SFR-1123 Author Paren Search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2021-06-08 -- v0.6.2
 ### Fixed
 - Correct reversed boolean logic with `showAll` filter
+- Improve search query parsing for multi-field search and commas
 
 ## 2021-06-07 -- v0.6.1
 ### Fixed

--- a/api/utils.py
+++ b/api/utils.py
@@ -32,15 +32,26 @@ class APIUtils():
             if len(re.findall(r'"', pairStr)) % 2 != 0:
                 pairStr = ''.join(pairStr.rsplit('"', 1))
 
-            for pair in re.split(r',(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)', pairStr):
-                pairElements = pair.split(':')
+            # Regex to split query string on field terms
+            queryTermRegex = ',*({}):'.format('|'.join(cls.QUERY_TERMS))\
+                .encode('unicode-escape').decode()
+
+            pairs = list(filter(lambda x: x != '', re.split(queryTermRegex, pairStr)))
+
+            i = 0 
+            while True:
+                pairElements = pairs[i:i+2]
 
                 if len(pairElements) == 1 or pairElements[0] not in cls.QUERY_TERMS:
-                    pairSet = (param, pair)
+                    pairSet = (param, pairs[i])
+                    i += 1
                 else:
                     pairSet = (pairElements[0], ':'.join(pairElements[1:]))
+                    i += 2
 
                 outPairs.append(pairSet)
+
+                if i >= len(pairs): break
 
         return outPairs
 

--- a/tests/unit/test_api_utils.py
+++ b/tests/unit/test_api_utils.py
@@ -122,17 +122,16 @@ class TestAPIUtils:
         assert testPairs[1] == ('test', 'bareValue')
 
     def test_extractParamPairs_comma_delimited(self):
-        testPairs = APIUtils.extractParamPairs('test', {'test': ['title:value,bareValue']})
+        testPairs = APIUtils.extractParamPairs('test', {'test': ['title:value,subject:value']})
 
         assert testPairs[0] == ('title', 'value')
-        assert testPairs[1] == ('test', 'bareValue')
+        assert testPairs[1] == ('subject', 'value')
 
     def test_extractParamPairs_comma_delimited_quotes(self):
         testPairs = APIUtils.extractParamPairs('test', {'test': ['title:value,author:"Test, Author",other']})
 
         assert testPairs[0] == ('title', 'value')
-        assert testPairs[1] == ('author', '"Test, Author"')
-        assert testPairs[2] == ('test', 'other')
+        assert testPairs[1] == ('author', '"Test, Author",other')
 
     def test_extractParamPairs_semantic_semicolon(self):
         testPairs = APIUtils.extractParamPairs('test', {'test': ['title:A Book: A Title']})


### PR DESCRIPTION
Previously query strings were split on commas (except for those contained in quotation marks). But this can still have unintended behavior when commas are part of a query. This resolves the issue by instead only splitting queries when a query term is present (e.g. `title:` or `subject:`). If a non-prefixed query is present or is first in a query string that is properly parsed. This should not impact any queries made by any existing applications and should only marginally impact any queries as most (if not all) users will expect this behavior.