### PR TITLE
SFR-1156 Simplify ES Client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unreleased -- v0.6.4
+### Fixed
+- Improved ElasticSearch connection in local client
+
 ## 2021-06-15 -- v0.6.3
 ### Fixed
 - Order edition records in ascending date order in work detail pages

--- a/api/app.py
+++ b/api/app.py
@@ -15,11 +15,11 @@ logger = createLog(__name__)
 
 
 class FlaskAPI:
-    def __init__(self, client, dbEngine):
+    def __init__(self, dbEngine):
         self.app = Flask(__name__)
         CORS(self.app)
         Swagger(self.app, template=json.load(open('swagger.v4.json', 'r')))
-        self.app.config['ES_CLIENT'] = client
+
         self.app.config['DB_CLIENT'] = dbEngine
 
         self.app.register_blueprint(info)

--- a/api/blueprints/drbSearch.py
+++ b/api/blueprints/drbSearch.py
@@ -10,7 +10,7 @@ search = Blueprint('search', __name__, url_prefix='/search')
 
 @search.route('/', methods=['GET'])
 def standardQuery():
-    esClient = ElasticClient(current_app.config['ES_CLIENT'])
+    esClient = ElasticClient()
     dbClient = DBClient(current_app.config['DB_CLIENT'])
     dbClient.createSession()
 

--- a/api/elastic.py
+++ b/api/elastic.py
@@ -17,9 +17,7 @@ class ElasticClient():
         'writer of supplementary textual content'
     ]
 
-    def __init__(self, esClient):
-        self.client = esClient
-        
+    def __init__(self):
         self.query = None
 
         self.dateSort = None
@@ -30,7 +28,7 @@ class ElasticClient():
         self.appliedAggregations = []
     
     def createSearch(self):
-        return Search(using=self.client, index=os.environ['ELASTICSEARCH_INDEX'])
+        return Search(index=os.environ['ELASTICSEARCH_INDEX'])
 
     def searchQuery(self, params, page=0, perPage=10):
         startPos, endPos = ElasticClient.getFromSize(page, perPage)

--- a/managers/elasticsearch.py
+++ b/managers/elasticsearch.py
@@ -7,7 +7,7 @@ from elasticsearch.exceptions import (
     ConflictError
 )
 from elasticsearch.helpers import bulk
-from elasticsearch_dsl import connections, Search
+from elasticsearch_dsl import connections, Search, Index
 
 from model import ESWork
 
@@ -15,33 +15,26 @@ from model import ESWork
 class ElasticsearchManager:
     def __init__(self):
         self.index = os.environ.get('ELASTICSEARCH_INDEX', None)
-        self.client = None
 
     def createElasticConnection(self):
         host = os.environ.get('ELASTICSEARCH_HOST', None)
         port = os.environ.get('ELASTICSEARCH_PORT', None)
         timeout = int(os.environ.get('ELASTICSEARCH_TIMEOUT', 5))
-        try:
-            self.client = Elasticsearch(
-               hosts=['{}:{}'.format(host, port)],
-               timeout = timeout,
-               retry_on_timeout=True,
-               max_retries=3
-            )
-        except ConnectionError as err:
-            raise err
 
-        connections.connections._conns['default'] = self.client
+        connections.create_connection(
+            hosts=['{}:{}'.format(host, port)],
+            timeout=timeout,
+            retry_on_timeout=True,
+            max_retries=3
+        )
 
     def createElasticSearchIndex(self):
-        if self.client.indices.exists(index=self.index) is False:
+        esIndex = Index(self.index)
+        if esIndex.exists() is False:
             ESWork.init()
         else:
-            print('ElasticSearch index {} already exists'.format(self.index))
+            logger.info('ElasticSearch index {} already exists'.format(self.index))
     
-    def bulkSaveElasticSearchRecords(self, records):
-        bulk(client=self.client, index=self.index, actions=records)
-
     def deleteWorkRecords(self, uuids):
         for uuid in uuids:
             workSearch = Search(index=self.index).query('match', uuid=uuid)

--- a/processes/api.py
+++ b/processes/api.py
@@ -11,7 +11,7 @@ class APIProcess(CoreProcess):
 
         self.createElasticConnection()
         self.generateEngine()
-        self.api = FlaskAPI(self.client, self.engine)
+        self.api = FlaskAPI(self.engine)
 
     def runProcess(self):
         logger.info('Starting API...')

--- a/tests/unit/test_api_es.py
+++ b/tests/unit/test_api_es.py
@@ -14,10 +14,10 @@ class TestElasticClient:
         TestHelpers.clearEnvVars()
 
     @pytest.fixture
-    def testInstance(self, mocker):
+    def testInstance(self):
         class MockElasticClient(ElasticClient):
             def __init__(self):
-                self.client = mocker.MagicMock()
+                pass
 
         return MockElasticClient()
 
@@ -53,7 +53,7 @@ class TestElasticClient:
         searchClient = testInstance.createSearch()
 
         assert searchClient == 'searchClient'
-        mockSearch.assert_called_once_with(using=testInstance.client, index='test_es_index')
+        mockSearch.assert_called_once_with(index='test_es_index')
 
     def test_searchQuery_keyword_search(self, testInstance, mockSearch, searchMocks, mocker):
         searchMocks['createSearch'].return_value = mockSearch

--- a/tests/unit/test_api_search_blueprint.py
+++ b/tests/unit/test_api_search_blueprint.py
@@ -53,7 +53,6 @@ class TestSearchBlueprint:
     
     def test_standardQuery(self, mockUtils, mockHits, mocker):
         flaskApp = Flask('test')
-        flaskApp.config['ES_CLIENT'] = 'testESClient'
         flaskApp.config['DB_CLIENT'] = 'testDBClient'
 
         mockES = mocker.MagicMock()
@@ -90,7 +89,7 @@ class TestSearchBlueprint:
             testAPIResponse = standardQuery()
 
             assert testAPIResponse == 'mockAPIResponse'
-            mockESClient.assert_called_once_with('testESClient')
+            mockESClient.assert_called_once()
             mockDBClient.assert_called_once_with('testDBClient')
 
             mockUtils['normalizeQueryParams'].assert_called_once

--- a/tests/unit/test_es_manager.py
+++ b/tests/unit/test_es_manager.py
@@ -19,64 +19,43 @@ class TestElasticsearchManager:
 
     def test_initializer(self, testInstance):
         assert testInstance.index == 'testES'
-        assert testInstance.client == None
 
     def test_createElasticConnection_success(self, testInstance, mocker):
-        mockES = mocker.patch('managers.elasticsearch.Elasticsearch')
-        mockClient = mocker.MagicMock()
-        mockES.return_value = mockClient
-
         mockConnection = mocker.patch('managers.elasticsearch.connections')
-        mockConnection.connections._conns = {}
 
         testInstance.createElasticConnection()
 
-        assert testInstance.client == mockClient
-        assert mockConnection.connections._conns['default'] == mockClient
-
-        mockES.assert_called_once_with(
+        mockConnection.create_connection.assert_called_once_with(
             hosts=['host:port'], timeout=1000, retry_on_timeout=True, max_retries=3
         )
 
-    def test_createElasticConnection_error(self, testInstance, mocker):
-        mockES = mocker.patch('managers.elasticsearch.Elasticsearch')
-        mockClient = mocker.MagicMock()
-        mockES.side_effect = ConnectionError
-
-        mockConnection = mocker.patch('managers.elasticsearch.connections')
-        mockConnection.connections._conns = {}
-
-        with pytest.raises(ConnectionError):
-            testInstance.createElasticConnection()
-
     def test_createELasticSearchIndex_execute(self, testInstance, mocker):
-        testInstance.client = mocker.MagicMock()
-        testInstance.client.indices.exists.return_value = False
+        testIndexCon = mocker.patch('managers.elasticsearch.Index')
+        testIndex = mocker.MagicMock()
+        testIndexCon.return_value = testIndex
+        testIndex.exists.return_value = False
         
         mockInit = mocker.patch.object(ESWork, 'init')
 
         testInstance.createElasticSearchIndex()
 
-        testInstance.client.indices.exists.assert_called_once_with(index='testES')
-        mockInit.assert_called_once
+        testIndexCon.assert_called_once_with('testES')
+        testIndex.exists.assert_called_once()
+        mockInit.assert_called_once()
 
     def test_createELasticSearchIndex_skip(self, testInstance, mocker):
-        testInstance.client = mocker.MagicMock()
-        testInstance.client.indices.exists.return_value = True
+        testIndexCon = mocker.patch('managers.elasticsearch.Index')
+        testIndex = mocker.MagicMock()
+        testIndexCon.return_value = testIndex
+        testIndex.exists.return_value = True
         
         mockInit = mocker.patch.object(ESWork, 'init')
 
         testInstance.createElasticSearchIndex()
 
-        testInstance.client.indices.exists.assert_called_once_with(index='testES')
-        mockInit.assert_not_called
-
-    def test_bulkSaveElasticSearchRecords(self, testInstance, mocker):
-        mockBulk = mocker.patch('managers.elasticsearch.bulk')
-
-        testInstance.bulkSaveElasticSearchRecords([1, 2, 3])
-
-        mockBulk.assert_called_once_with(client=None, index='testES', actions=[1, 2, 3])
+        testIndexCon.assert_called_once_with('testES')
+        testIndex.exists.assert_called_once()
+        mockInit.assert_not_called()
 
     def test_deleteWorkRecords(self, testInstance, mocker):
         mockResp = mocker.MagicMock(name='testQuery')

--- a/tests/unit/test_es_manager.py
+++ b/tests/unit/test_es_manager.py
@@ -1,4 +1,4 @@
-from elasticsearch.exceptions import ConnectionError
+from elasticsearch.exceptions import ConflictError
 import pytest
 
 from managers import ElasticsearchManager
@@ -74,3 +74,15 @@ class TestElasticsearchManager:
         ])
 
         assert mockResp.delete.call_count == 3
+
+    def test_deleteWorkRecords_error(self, testInstance, mocker):
+        mockResp = mocker.MagicMock(name='testQuery')
+        mockSearchObj = mocker.MagicMock(name='searchObject')
+        mockSearch = mocker.patch('managers.elasticsearch.Search')
+        mockSearch.return_value = mockSearchObj
+        mockSearchObj.query.return_value = mockResp
+
+        mockResp.delete.side_effect = [ConflictError] * 3
+
+        with pytest.raises(ConflictError):
+            testInstance.deleteWorkRecords(['uuid1'])


### PR DESCRIPTION
This improves the ElasticSearch client by implementing the default connection style as specified by the high-level `elasticsearch-dsl` package. This should give us more confidence that connections to the ES cluster are being managed in a logical way and will not cause any unanticipated errors.