### PR TITLE
SFR-1156 Remove ES_CLIENT for utils and OPDS2

### DIFF
--- a/api/blueprints/drbOPDS2.py
+++ b/api/blueprints/drbOPDS2.py
@@ -62,7 +62,7 @@ def opdsSearch():
     if params.get('showAll', None):
         searchTerms['filter'].append(('showAll', params['showAll'][0]))
 
-    esClient = ElasticClient(current_app.config['ES_CLIENT'])
+    esClient = ElasticClient()
     dbClient = DBClient(current_app.config['DB_CLIENT'])
     dbClient.createSession()
 

--- a/api/blueprints/drbUtils.py
+++ b/api/blueprints/drbUtils.py
@@ -12,7 +12,7 @@ utils = Blueprint('utils', __name__, url_prefix='/utils')
 
 @utils.route('/languages', methods=['GET'])
 def languageCounts():
-    esClient = ElasticClient(current_app.config['ES_CLIENT'])
+    esClient = ElasticClient()
 
     reqParams = APIUtils.normalizeQueryParams(request.args)
     workCounts = reqParams.get('totals', ['true'])[0].lower() != 'false'

--- a/tests/unit/test_api_opds_blueprint.py
+++ b/tests/unit/test_api_opds_blueprint.py
@@ -112,7 +112,6 @@ class TestOPDSBlueprint:
 
     def test_opdsSearch(self, mockUtils, opdsMocks, mockHits, mocker):
         flaskApp = Flask('test')
-        flaskApp.config['ES_CLIENT'] = 'testESClient'
         flaskApp.config['DB_CLIENT'] = 'testDBClient'
 
         mockES = mocker.MagicMock()
@@ -143,7 +142,7 @@ class TestOPDSBlueprint:
         with flaskApp.test_request_context('/search'):
             assert opdsSearch() == 'mockOPDSResponse'
 
-            mockESClient.assert_called_once_with('testESClient')
+            mockESClient.assert_called_once()
             mockDBClient.assert_called_once_with('testDBClient')
 
             mockUtils['normalizeQueryParams'].assert_called_once()

--- a/tests/unit/test_api_search_blueprint.py
+++ b/tests/unit/test_api_search_blueprint.py
@@ -123,7 +123,6 @@ class TestSearchBlueprint:
 
     def test_standardQuery_elastic_error(self, mockUtils, mocker):
         flaskApp = Flask('test')
-        flaskApp.config['ES_CLIENT'] = 'testESClient'
         flaskApp.config['DB_CLIENT'] = 'testDBClient'
 
         mockES = mocker.MagicMock()

--- a/tests/unit/test_api_utils_blueprint.py
+++ b/tests/unit/test_api_utils_blueprint.py
@@ -19,7 +19,6 @@ class TestEditionBlueprint:
     def testApp(self):
         flaskApp = Flask('test')
         flaskApp.config['DB_CLIENT'] = 'testDBClient'
-        flaskApp.config['ES_CLIENT'] = 'testESClient'
 
         return flaskApp
 
@@ -39,7 +38,7 @@ class TestEditionBlueprint:
             testAPIResponse = languageCounts()
 
             assert testAPIResponse == 'languageListResponse'
-            mockESClient.assert_called_once_with('testESClient')
+            mockESClient.assert_called_once()
 
             mockUtils['normalizeQueryParams'].assert_called_once()
             mockES.languageQuery.assert_called_once_with(True)


### PR DESCRIPTION
Two flask blueprints still contain references to a configuration variable that is no longer present with the new ElasticSearch client connection. This simply removes those references.