### PR TITLE
NOREF Fix VIAF/LCNAF parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased -- v0.6.4
 ### Fixed
 - Improved ElasticSearch connection in local client
+- Fixed VIAF/LCNAF parsing in clustering step
 
 ## 2021-06-15 -- v0.6.3
 ### Fixed


### PR DESCRIPTION
In the current clustering step records with LCNAF/VIAF numbers are being omitted from the edition-level clustering step. This is because they contain no edition-level metadata. This adds an additional step to silo these records and pull out relevant work-level metadata, most importantly the VIAF and LCNAF numbers for authors.