### PR TITLE
HOTFIX Empty result set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unreleased -- v0.6.5
+### Fixed
+- Handling of empty result sets from ElasticSearch
+
 ## 2021-06-23 -- v0.6.4
 ### Added
 - Added deep paging options for result sets larger than 10,000 records

--- a/api/elastic.py
+++ b/api/elastic.py
@@ -99,10 +99,13 @@ class ElasticClient():
         else:
             res = self.query[startPos:endPos].execute()
         
-        lastSort = list(res.hits[-1].meta.sort)
 
         if not searchFromStr:
-            self.setPageResultCache(queryHash, lastSort)
+            try:
+                lastSort = list(res.hits[-1].meta.sort)
+                self.setPageResultCache(queryHash, lastSort)
+            except IndexError:
+                logger.debug('Empty result set, skipping paging cache')
 
         return res
 

--- a/tests/unit/test_api_es.py
+++ b/tests/unit/test_api_es.py
@@ -291,6 +291,25 @@ class TestElasticClient:
         searchMocks['getPageResultCache'].assert_not_called()
         searchMocks['setPageResultCache'].assert_called_once_with('testHash', ['testSort'])
 
+    def test_executeSearchQuery_no_results(self, testInstance, mockSearch, searchMocks, mocker):
+        searchMocks['getFromSize'].return_value = (0, 10)
+        searchMocks['generateQueryHash'].return_value = 'testHash'
+        searchMocks['getPageResultCache'].return_value = None
+
+        mockEmptyRes = mocker.MagicMock(name='mockRes', hits=[])
+        mockSearch.execute.return_value = mockEmptyRes
+
+        testInstance.query = mockSearch
+
+        testResult = testInstance.executeSearchQuery({}, 0, 10)
+
+        assert testResult._extract_mock_name() == 'mockRes'
+
+        searchMocks['getFromSize'].assert_called_once_with(0, 10)
+        searchMocks['generateQueryHash'].assert_called_once_with({}, 0)
+        searchMocks['getPageResultCache'].assert_not_called()
+        searchMocks['setPageResultCache'].assert_not_called()
+
     def test_executeSearchQuery_cached(self, testInstance, mockSearch, searchMocks):
         searchMocks['getFromSize'].return_value = (10, 20)
         searchMocks['generateQueryHash'].return_value = 'testHash'


### PR DESCRIPTION
This corrects a bug that results in a `500` error when no documents are matched in ElasticSearch