### PR TITLE
NOREF Fix Advanced Search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased -- v0.6.6
 ### Fixed
 - Default sorting options
+- Added Redis client to `utils/languages` endpoint to resolve error
 
 ## 2021-06-24 -- v0.6.5
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unreleased -- v0.6.6
+### Fixed
+- Default sorting options
+
 ## 2021-06-24 -- v0.6.5
 ### Fixed
 - Handling of empty result sets from ElasticSearch

--- a/api/blueprints/drbUtils.py
+++ b/api/blueprints/drbUtils.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, jsonify, current_app, request
+from flask import Blueprint, current_app, request
 
 from ..db import DBClient
 from ..elastic import ElasticClient
@@ -12,7 +12,7 @@ utils = Blueprint('utils', __name__, url_prefix='/utils')
 
 @utils.route('/languages', methods=['GET'])
 def languageCounts():
-    esClient = ElasticClient()
+    esClient = ElasticClient(current_app.config['REDIS_CLIENT'])
 
     reqParams = APIUtils.normalizeQueryParams(request.args)
     workCounts = reqParams.get('totals', ['true'])[0].lower() != 'false'

--- a/api/elastic.py
+++ b/api/elastic.py
@@ -99,9 +99,6 @@ class ElasticClient():
         else:
             res = self.query[startPos:endPos].execute()
         
-        for r in res.hits:
-            print(r.meta.score, r.title)
-
         if not searchFromStr:
             try:
                 lastSort = list(res.hits[-1].meta.sort)
@@ -141,7 +138,6 @@ class ElasticClient():
             iteration += 1 
 
     def setPageResultCache(self, cacheKey, sort):
-        print(sort)
         self.redis.set(
             '{}/queryPaging/{}'.format(self.environment, cacheKey),
             '|'.join([str(s) for s in sort]),

--- a/api/elastic.py
+++ b/api/elastic.py
@@ -170,7 +170,7 @@ class ElasticClient():
 
     @staticmethod
     def escapeSearchQuery(query):
-        return re.sub(r'[\+\-\&\|\!\(\)\[\]\{\}\^\~\?\:\\]{1}', '\\\\\g<0>', query)
+        return re.sub(r'[\+\-\&\|\!\(\)\[\]\{\}\^\~\?\:\\\/]{1}', '\\\\\g<0>', query)
 
     def languageQuery(self, workTotals):
         search = self.createSearch()

--- a/task-definition.json
+++ b/task-definition.json
@@ -26,7 +26,7 @@
                 },
                 {
                     "name": "ELASTICSEARCH_HOST",
-                    "value": "https://vpc-sfr-search-api-production-tom4zg45o45pfomgtasgskvx4e.us-east-1.es.amazonaws.com"
+                    "value": "https://vpc-drb-search-production-5ptfzwisshcadbbaph35dqilva.us-east-1.es.amazonaws.com"
                 },
                 {
                     "name": "ELASTICSEARCH_INDEX",

--- a/tests/unit/test_api_es.py
+++ b/tests/unit/test_api_es.py
@@ -439,7 +439,7 @@ class TestElasticClient:
         testQuery = testQueryES.to_dict()
 
         assert testQuery['bool']['should'][0]['query_string']['query'] == 'testTitle'
-        assert testQuery['bool']['should'][0]['query_string']['fields'] == ['title', 'alt_titles']
+        assert testQuery['bool']['should'][0]['query_string']['fields'] == ['title^3', 'alt_titles']
         assert testQuery['bool']['should'][1]['nested']['path'] == 'editions'
         assert testQuery['bool']['should'][1]['nested']['query']['query_string']['query'] == 'testTitle'
         assert testQuery['bool']['should'][1]['nested']['query']['query_string']['fields'] == ['editions.title']
@@ -451,7 +451,7 @@ class TestElasticClient:
 
         assert testQuery['bool']['should'][0]['nested']['path'] == 'agents'
         assert testQuery['bool']['should'][0]['nested']['query']['bool']['must'][0]['query_string']['query'] == 'testAuthor'
-        assert testQuery['bool']['should'][0]['nested']['query']['bool']['must'][0]['query_string']['fields'] == ['agents.name']
+        assert testQuery['bool']['should'][0]['nested']['query']['bool']['must'][0]['query_string']['fields'] == ['agents.name^2']
         assert testQuery['bool']['should'][0]['nested']['query']['bool']['must'][1]['terms']['agents.roles'] == ElasticClient.ROLE_ALLOWLIST
         assert testQuery['bool']['should'][1]['nested']['path'] == 'editions.agents'
         assert testQuery['bool']['should'][1]['nested']['query']['bool']['must'][0]['query_string']['query'] == 'testAuthor'
@@ -586,7 +586,7 @@ class TestElasticClient:
         testInstance.addSortClause([])
 
         assert testInstance.query == 'sortQuery'
-        mockQuery.sort.assert_called_once_with({'uuid': 'asc'})
+        mockQuery.sort.assert_called_once_with({'_score': 'desc'}, {'uuid': 'asc'})
 
     def test_addSortClause_reverse_true(self, testInstance, mocker):
         mockQuery = mocker.MagicMock()

--- a/tests/unit/test_api_es.py
+++ b/tests/unit/test_api_es.py
@@ -429,7 +429,7 @@ class TestElasticClient:
         )
 
     def test_escapeSearchQuery_changed(self):
-        assert ElasticClient.escapeSearchQuery('[test]+a:thing!') == '\[test\]\+a\:thing\!'
+        assert ElasticClient.escapeSearchQuery('/[test]+a:thing!') == '\/\[test\]\+a\:thing\!'
 
     def test_escapeSearchQuery_unchanged(self):
         assert ElasticClient.escapeSearchQuery('a simple query') == 'a simple query'

--- a/tests/unit/test_api_utils_blueprint.py
+++ b/tests/unit/test_api_utils_blueprint.py
@@ -19,6 +19,7 @@ class TestEditionBlueprint:
     def testApp(self):
         flaskApp = Flask('test')
         flaskApp.config['DB_CLIENT'] = 'testDBClient'
+        flaskApp.config['REDIS_CLIENT'] = 'testRedisClient'
 
         return flaskApp
 
@@ -38,7 +39,7 @@ class TestEditionBlueprint:
             testAPIResponse = languageCounts()
 
             assert testAPIResponse == 'languageListResponse'
-            mockESClient.assert_called_once()
+            mockESClient.assert_called_once_with('testRedisClient')
 
             mockUtils['normalizeQueryParams'].assert_called_once()
             mockES.languageQuery.assert_called_once_with(True)


### PR DESCRIPTION
This implements a simple fix for a regression that is currently blocking the use of Advanced Search in DRB. The root cause is a missing redis client in a Flask endpoint.

In a related update this also changes how results are sorted to realize more pertinent results for users (and corrects an issue that was causing some errors to show up).