### PR TITLE
SFR-1065 Implement Webpub Conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unreleased -- v0.7.0
+### Added
+- Creation of Webpub Manifests for all ingested ePub files
+
 ## 2021-07-01 -- v0.6.6
 ### Fixed
 - Default sorting options

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -55,3 +55,6 @@ MUSE_MARC_URL: https://about.muse.jhu.edu/lib/metadata?format=marc&content=book&
 
 # DOAB OAI-PMH endpoint
 DOAB_OAI_URL: http://www.doabooks.org/oai?
+
+# ePub-to-Webpub Conversion Service
+WEBPUB_CONVERSION_URL: https://epub-to-webpub.vercel.app

--- a/config/example.yaml
+++ b/config/example.yaml
@@ -62,3 +62,6 @@ MUSE_MARC_URL: xxx
 
 # DOAB OAI-PMH endpoint
 DOAB_OAI_URL: xxx
+
+# ePub-to-Webpub Conversion Service
+WEBPUB_CONVERSION_URL: xxx

--- a/config/production.yaml
+++ b/config/production.yaml
@@ -80,3 +80,6 @@ SMARTSHEET_SHEET_ID: '3683038090553220'
 
 # Default Cover Image for OPDS2 Feed
 DEFAULT_COVER_URL: https://drb-files-qa.s3.amazonaws.com/covers/default/defaultCover.png
+
+# ePub-to-Webpub Conversion Service
+WEBPUB_CONVERSION_URL: https://epub-to-webpub.vercel.app

--- a/config/qa.yaml
+++ b/config/qa.yaml
@@ -80,3 +80,6 @@ SMARTSHEET_SHEET_ID: '3683038090553220'
 
 # Default Cover Image for OPDS2 Feed
 DEFAULT_COVER_URL: https://drb-files-qa.s3.amazonaws.com/covers/default/defaultCover.png
+
+# ePub-to-Webpub Conversion Service
+WEBPUB_CONVERSION_URL: https://epub-to-webpub.vercel.app

--- a/managers/parsers/degruyterParser.py
+++ b/managers/parsers/degruyterParser.py
@@ -52,7 +52,11 @@ class DeGruyterParser(AbstractParser):
         ePubReadPath = 'epubs/degruyter/{}/META-INF/container.xml'.format(self.uriIdentifier)
         ePubReadURI = '{}{}'.format(s3Root, ePubReadPath)
 
+        webpubReadPath = 'epubs/degruyter/{}/manifest.json'.format(self.uriIdentifier)
+        webpubReadURI = '{}{}'.format(s3Root, webpubReadPath)
+
         return [
+            (webpubReadURI, {'reader': True}, 'application/webpub+json', None, None),
             (ePubReadURI, {'reader': True}, 'application/epub+xml', None, None),
             (ePubDownloadURI, {'download': True}, 'application/epub+zip', None, (ePubDownloadPath, ePubSourceURI)),
         ]

--- a/managers/parsers/frontierParser.py
+++ b/managers/parsers/frontierParser.py
@@ -51,7 +51,11 @@ class FrontierParser(AbstractParser):
         ePubReadPath = 'epubs/frontier/{}_{}/META-INF/container.xml'.format(self.uriIdentifier, filename)
         ePubReadURI = '{}{}'.format(s3Root, ePubReadPath)
 
+        webpubReadPath = 'epubs/frontier/{}_{}/manifest.json'.format(self.uriIdentifier, filename)
+        webpubReadURI = '{}{}'.format(s3Root, webpubReadPath)
+
         return [
+            (webpubReadURI, {'reader': True}, 'application/webpub+json', None, None),
             (ePubReadURI, {'reader': True}, 'application/epub+xml', None, None),
             (ePubDownloadURI, {'download': True}, 'application/epub+zip', None, (ePubDownloadPath, ePubSourceURI))
         ]

--- a/managers/parsers/openEditionParser.py
+++ b/managers/parsers/openEditionParser.py
@@ -71,7 +71,11 @@ class OpenEditionParser(AbstractParser):
         ePubReadPath = 'epubs/doab/{}_{}/META-INF/container.xml'.format(self.publisher, self.uriIdentifier)
         ePubReadURI = '{}{}'.format(s3Root, ePubReadPath)
 
+        webpubReadPath = 'epubs/doab/{}_{}/manifest.json'.format(self.publisher, self.uriIdentifier)
+        webpubReadURI = '{}{}'.format(s3Root, webpubReadPath)
+
         return [
+            (webpubReadURI, bookFlags, 'application/webpub+json', None, None),
             (ePubReadURI, bookFlags, bookType, None, None),
             (ePubDownloadURI, {'download': True}, 'application/epub+zip', None, (ePubDownloadPath, bookURI))
         ]

--- a/managers/parsers/springerParser.py
+++ b/managers/parsers/springerParser.py
@@ -94,16 +94,24 @@ class SpringerParser(AbstractParser):
 
         if SpringerParser.checkAvailability(ePubSourceURI) is False: return []
 
+        uriCode = self.code.replace('.', '-')
+
         ePubDownloadPath = 'epubs/springer/{}_{}.epub'.format(
-            self.code.replace('.', '-'), self.uriIdentifier
+            uriCode, self.uriIdentifier
         )
         ePubDownloadURI = '{}{}'.format(s3Root, ePubDownloadPath)
         ePubReadPath = 'epubs/springer/{}_{}/META-INF/container.xml'.format(
-            self.code.replace('.', '-'), self.uriIdentifier
+            uriCode, self.uriIdentifier
         )
         ePubReadURI = '{}{}'.format(s3Root, ePubReadPath)
 
+        webpubReadPath = 'epubs/springer/{}_{}/manifest.json'.format(
+            uriCode, self.uriIdentifier
+        )
+        webpubReadURI = '{}{}'.format(s3Root, webpubReadPath)
+
         return [
+            (webpubReadURI, {'reader': True}, 'application/webpub+json', None, None),
             (ePubReadURI, {'reader': True}, 'application/epub+zip', None, None),
             (ePubDownloadURI, {'download': True}, 'application/epub+xml', None, (ePubDownloadPath, ePubSourceURI))
         ]

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -48,7 +48,8 @@ class TestHelpers:
         'MUSE_CSV_URL': 'test_muse_csv',
         'DOAB_OAI_URL': 'test_doab_url',
         'SMARTSHEET_API_TOKEN': 'test_smartsheet_token',
-        'SMARTSHEET_SHEET_ID': '1000'
+        'SMARTSHEET_SHEET_ID': '1000',
+        'WEBPUB_CONVERSION_URL': 'test_conversion_url'
     }
 
     @classmethod

--- a/tests/unit/test_parser_degruyter.py
+++ b/tests/unit/test_parser_degruyter.py
@@ -93,6 +93,7 @@ class TestDeGruyterParser:
         testLinks = testParser.generateEpubLinks('testRoot/', 'epubSourceURI')
 
         assert testLinks == [
+            ('testRoot/epubs/degruyter/1/manifest.json', {'reader': True}, 'application/webpub+json', None, None),
             ('testRoot/epubs/degruyter/1/META-INF/container.xml', {'reader': True}, 'application/epub+xml', None, None),
             ('testRoot/epubs/degruyter/1.epub', {'download': True}, 'application/epub+zip', None, ('epubs/degruyter/1.epub', 'epubSourceURI'))
         ]

--- a/tests/unit/test_parser_frontier.py
+++ b/tests/unit/test_parser_frontier.py
@@ -52,6 +52,7 @@ class TestFrontierParser:
         testLinks = testParser.generateEpubLinks('testRoot/')
 
         assert testLinks == [
+            ('testRoot/epubs/frontier/1_title/manifest.json', {'reader': True}, 'application/webpub+json', None, None),
             ('testRoot/epubs/frontier/1_title/META-INF/container.xml', {'reader': True}, 'application/epub+xml', None, None),
             ('testRoot/epubs/frontier/1_title.epub', {'download': True}, 'application/epub+zip', None, ('epubs/frontier/1_title.epub', 'https://www.frontiersin.org/research-topics/1/epub'))
         ]

--- a/tests/unit/test_parser_openedition.py
+++ b/tests/unit/test_parser_openedition.py
@@ -85,6 +85,7 @@ class TestOpenEditionParser:
         testLinks = testParser.createEpubLink('sourceURI', 'application/epub+xml', {'reader': True})
 
         assert testLinks == [
+            ('testRoot/epubs/doab/pub_1/manifest.json', {'reader': True}, 'application/webpub+json', None, None),
             ('testRoot/epubs/doab/pub_1/META-INF/container.xml', {'reader': True}, 'application/epub+xml', None, None),
             ('testRoot/epubs/doab/pub_1.epub', {'download': True}, 'application/epub+zip', None, ('epubs/doab/pub_1.epub', 'sourceURI'))
         ]

--- a/tests/unit/test_parser_springer.py
+++ b/tests/unit/test_parser_springer.py
@@ -150,6 +150,7 @@ class TestSpringerParser:
         testLinks = testParser.createEPubLinks('testRoot/')
 
         assert testLinks == [
+            ('testRoot/epubs/springer/10-007_1/manifest.json', {'reader': True}, 'application/webpub+json', None, None),
             ('testRoot/epubs/springer/10-007_1/META-INF/container.xml', {'reader': True}, 'application/epub+zip', None, None),
             ('testRoot/epubs/springer/10-007_1.epub', {'download': True}, 'application/epub+xml', None, ('epubs/springer/10-007_1.epub', 'https://link.springer.com/download/epub/10.007/1.epub')),
         ]


### PR DESCRIPTION
This adds a step to the ingest process for ePub files (from DOAB and Project Gutenberg at present). In order to be compatible with the new reader ePub files will have to be made available through a Readium Webpub manifest. These manifests can be generated from an ePub's `container.xml` file using the epub-to-webpub tool that Kristo has created.

This tool is loaded as a 3rd-party service, which returns a JSON blob as a response and which can be stored in s3, alongside the content of the ePub file.

This generates an additional way of accessing these files and creates a new link in the DCDW database with a media type of `application/webpub+json` which can be read by client applications. At present the other means of accessing the ePub files are still present so it is up to client applications to select what version to display and how to do so. (The sole download option will remain a zipped ePub file.)