### PR TITLE
SFR-1065 Update default DOAB parser

### DIFF
--- a/managers/parsers/defaultParser.py
+++ b/managers/parsers/defaultParser.py
@@ -34,7 +34,11 @@ class DefaultParser(AbstractParser):
             ePubReadPath = 'epubs/{}/{}/META-INF/container.xml'.format(self.source, self.identifier)
             ePubReadURI = '{}{}'.format(s3Root, ePubReadPath)
 
+            webpubReadPath = 'epubs/{}/{}/manifest.json'.format(self.source, self.identifier)
+            webpubReadURI = '{}{}'.format(s3Root, webpubReadPath)
+
             return [
+                (webpubReadURI, {'reader': True}, 'application/webpub+json', None, None),
                 (ePubReadURI, {'reader': True}, 'application/epub+xml', None, None),
                 (ePubDownloadURI, {'download': True}, self.mediaType, None, (ePubDownloadPath, self.uri))
             ]

--- a/tests/unit/test_parser_default.py
+++ b/tests/unit/test_parser_default.py
@@ -53,6 +53,7 @@ class TestDefaultParser:
         testLinks = testParser.createLinks()
 
         assert testLinks == [
+            ('testRoot/epubs/testSource/1/manifest.json', {'reader': True}, 'application/webpub+json', None, None),
             ('testRoot/epubs/testSource/1/META-INF/container.xml', {'reader': True}, 'application/epub+xml', None, None),
             ('testRoot/epubs/testSource/1.epub', {'download': True}, 'application/epub+zip', None, ('epubs/testSource/1.epub', 'http://testURI'))
         ]


### PR DESCRIPTION
In the previous merge from this working branch the default DOAB parser was not updated to generate new webpub URLs. This adds this URL to that method.