### PR TITLE
Noref stability improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## unreleased -- v0.7.1
+### Fixed
+- Extended wait time during OCLC Catalog process
+- Handled timeout error in ElasticSearch save operation during clustering
+
 ## 2021-07-12 -- v0.7.0
 ### Added
 - Creation of Webpub Manifests for all ingested ePub files

--- a/managers/elasticsearch.py
+++ b/managers/elasticsearch.py
@@ -34,21 +34,21 @@ class ElasticsearchManager:
             logger.info('ElasticSearch index {} already exists'.format(self.index))
     
     def deleteWorkRecords(self, uuids):
-        i = 0
-        retries = 0
-        while i < len(uuids):
-            try:
-                print(uuids[i], i, retries)
-                workSearch = Search(index=self.index).query('match', uuid=uuids[i])
-                workSearch.delete()
+        for uuid in uuids:
+            retries = 0
 
-                i += 1
-                retries = 0
-            except ConflictError as e:
-                if retries >= 2: 
-                    logger.error('Unable to delete work {}'.format(uuids[i]))
-                    raise e
+            while True:
+                try:
+                    logger.debug('Deleting work {}'.format(uuid))
+                    workSearch = Search(index=self.index).query('match', uuid=uuid)
+                    workSearch.delete()
 
-                logger.warning('Unable to delete work {}. Retrying'.format(uuids[i]))
-                retries += 1
+                    break
+                except ConflictError as e:
+                    if retries >= 2: 
+                        logger.error('Unable to delete work {}'.format(uuid))
+                        raise e
+
+                    logger.warning('Unable to delete work {}. Retrying'.format(uuid))
+                    retries += 1
     

--- a/managers/sfrElasticRecord.py
+++ b/managers/sfrElasticRecord.py
@@ -1,3 +1,5 @@
+from elasticsearch.exceptions import ConnectionTimeout
+
 from model import (
     ESWork,
     ESSubject,
@@ -28,8 +30,12 @@ class SFRElasticRecordManager:
 
         self.enhanceWork()
     
-    def saveWork(self):
-        self.work.save()
+    def saveWork(self, retries=0):
+        try:
+            self.work.save()
+        except ConnectionTimeout as e:
+            if retries >= 2: raise e
+            self.saveWork(retries=retries+1)
     
     def updateWork(self, data):
         for key, value in data.items():

--- a/managers/sfrRecord.py
+++ b/managers/sfrRecord.py
@@ -51,6 +51,7 @@ class SFRRecordManager:
 
         if len(matchedWorks) > 0:
             self.work.date_created = matchedWorks[0][1]
+            self.work.uuid = matchedWorks[0][0]
 
         self.work = self.session.merge(self.work)
 

--- a/processes/oclcCatalog.py
+++ b/processes/oclcCatalog.py
@@ -29,10 +29,10 @@ class CatalogProcess(CoreProcess):
     def receiveAndProcessMessages(self):
         attempts = 1
         while True:
-            msgProps, msgParams, msgBody = self.getMessageFromQueue(os.environ['OCLC_QUEUE'])
+            msgProps, _, msgBody = self.getMessageFromQueue(os.environ['OCLC_QUEUE'])
             if msgProps is None:
                 if attempts <= 3:
-                    sleep(30 * attempts)
+                    sleep(60 * attempts)
                     attempts += 1
                     continue
                 else:

--- a/tests/unit/test_oclcCatalog_process.py
+++ b/tests/unit/test_oclcCatalog_process.py
@@ -54,7 +54,7 @@ class TestOCLCCatalogProcess:
         mockQueueGet.assert_called_with('test_oclc_queue')
 
         mockSleep.assert_has_calls([
-            mocker.call(30), mocker.call(60), mocker.call(90)
+            mocker.call(60), mocker.call(120), mocker.call(180)
         ])
 
         mockProcess.assert_called_once_with('oclc_record')

--- a/tests/unit/test_sfrElastic_manager.py
+++ b/tests/unit/test_sfrElastic_manager.py
@@ -1,3 +1,4 @@
+from elasticsearch.exceptions import ConnectionTimeout
 import pytest
 
 from managers import SFRElasticRecordManager
@@ -85,7 +86,22 @@ class TestSFRElasticRecordManager:
 
         testInstance.saveWork()
 
-        testInstance.work.save.assert_called_once
+        testInstance.work.save.assert_called_once()
+
+    def test_saveWork_single_timeout(self, testInstance, mocker):
+        testInstance.work = mocker.MagicMock()
+        testInstance.work.save.side_effect = [ConnectionTimeout, None]
+
+        testInstance.saveWork()
+
+        assert testInstance.work.save.call_count == 2
+
+    def test_saveWork_multi_timeout_raise(self, testInstance, mocker):
+        testInstance.work = mocker.MagicMock()
+        testInstance.work.save.side_effect = ConnectionTimeout
+
+        with pytest.raises(ConnectionTimeout):
+            testInstance.saveWork()
 
     def test_updateWork(self, testInstance, mocker):
         testInstance.work = mocker.MagicMock()

--- a/tests/unit/test_sfrRecord_manager.py
+++ b/tests/unit/test_sfrRecord_manager.py
@@ -84,7 +84,7 @@ class TestSFRRecordManager:
         testUUIDsToDelete = testInstance.mergeRecords()
 
         assert testUUIDsToDelete == [4, 3, 2]
-        assert testInstance.work.uuid == 1
+        assert testInstance.work.uuid == 4
         assert testInstance.work.date_created == '2018-01-01'
 
         testInstance.session.query().join().filter().filter().all.assert_called_once()


### PR DESCRIPTION
This implements two minor but important stability improvements. First, it extends the wait period in the catalog process. Delays in the classification process are causing this process to exit early, extending the wait process should improve this, though it may need to be further extended. Second, timeout errors are handled in the cataloging process so that the saving of elastic records is retried. This should help the process run to completion in a consistent manner.