### PR TITLE
NOREF Improve Cluster and Cover stability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 ### Fixed
 - Extended wait time during OCLC Catalog process
 - Handled timeout error in ElasticSearch save operation during clustering
+- Restricted record types read by the clustering process
+- Set max run time for cover process to 12 hours (for API limit purposes)
 
 ## 2021-07-12 -- v0.7.0
 ### Added

--- a/processes/covers.py
+++ b/processes/covers.py
@@ -24,6 +24,7 @@ class CoverProcess(CoreProcess):
         self.fileBucket = os.environ['FILE_BUCKET']
 
         self.ingestLimit = None
+        self.runTime = datetime.utcnow()
 
     def runProcess(self):
         coverQuery = self.generateQuery()
@@ -47,7 +48,7 @@ class CoverProcess(CoreProcess):
             if self.ingestPeriod:
                 startDate = datetime.strptime(self.ingestPeriod, '%Y-%m-%d')
             else:
-                startDate = datetime.utcnow() - timedelta(hours=24)
+                startDate = self.runTime - timedelta(hours=24)
 
             filters.append(Edition.date_modified >= startDate)
 
@@ -58,6 +59,8 @@ class CoverProcess(CoreProcess):
             coverManager = self.searchForCover(edition)
 
             if coverManager: self.storeFoundCover(coverManager, edition)
+
+            if (self.runTime + timedelta(hours=12)) < datetime.utcnow(): break
 
     def searchForCover(self, edition):
         identifiers = [i for i in self.getEditionIdentifiers(edition)]

--- a/processes/sfrCluster.py
+++ b/processes/sfrCluster.py
@@ -37,7 +37,9 @@ class ClusterProcess(CoreProcess):
     def clusterRecords(self, full=False, startDateTime=None):
         baseQuery = self.session.query(Record)\
             .filter(Record.frbr_status == 'complete')\
-            .filter(Record.cluster_status == False)
+            .filter(Record.cluster_status == False)\
+            .filter(Record.source != 'oclcClassify')\
+            .filter(Record.source != 'oclcCatalog')
 
         if full is False:
             if not startDateTime:

--- a/tests/unit/test_sfrCluster_process.py
+++ b/tests/unit/test_sfrCluster_process.py
@@ -119,7 +119,7 @@ class TestSFRClusterProcess:
         testInstance.session = mockSession
         mockDatetime = mocker.spy(datetime, 'datetime')
 
-        mockSession.query().filter().filter.return_value = mockQuery
+        mockSession.query().filter().filter().filter().filter.return_value = mockQuery
         mockQueryResponses = [mocker.MagicMock(id=1), mocker.MagicMock(id=2), None]
         mockQuery.first.side_effect = mockQueryResponses
 
@@ -127,7 +127,7 @@ class TestSFRClusterProcess:
 
         testInstance.clusterRecords(full=True)
 
-        mockSession.query().filter().filter.assert_called_once()
+        mockSession.query().filter().filter().filter().filter.assert_called_once()
         mockDatetime.utcnow.assert_not_called()
         mockDatetime.timedelta.assert_not_called()
         mockQuery.filter.assert_not_called()


### PR DESCRIPTION
This makes two improvements to the ingest process:

- The Cluster process is restricted to reading non-OCLC records which should improve overall execution time as those records should always be associated with a different source
- The max execution time of the cover process is set to 12 hours so that API rate limits have time to reset between executions