### PR TITLE
SFR-1221 Add proxy endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unreleased -- v0.8.0
+### Added
+- New endpoint `utils/proxy` to allow for proxying of resources to webreader
+
 ## 2021-07-21 -- v0.7.1
 ### Fixed
 - Extended wait time during OCLC Catalog process

--- a/api/blueprints/drbUtils.py
+++ b/api/blueprints/drbUtils.py
@@ -42,7 +42,7 @@ def totalCounts():
     return APIUtils.formatResponseObject(200, 'totalCounts', totalsSummary)
 
 @utils.route('/proxy', methods=['GET', 'POST', 'PUT', 'HEAD'])
-# @cross_origin(origins='http[s]?://.*nypl.org')
+@cross_origin(origins='http[s]?://.*nypl.org')
 def getProxyResponse():
     proxyUrl = request.args.get('proxy_url')
     cleanUrl = unquote_plus(proxyUrl)
@@ -67,7 +67,9 @@ def getProxyResponse():
 
     excludedHeaders = [
         'content-encoding', 'content-length', 'transfer-encoding',
-        'x-frame-options', 'referrer-policy', 'access-control-allow-origin'
+        'x-frame-options', 'referrer-policy', 'access-control-allow-origin',
+        'connection', 'keep-alive', 'public', 'proxy-authenticate',
+        'upgrade'
     ]
 
     headers = [(k, v) for (k, v) in resp.headers.items() if k.lower() not in excludedHeaders]

--- a/api/blueprints/drbUtils.py
+++ b/api/blueprints/drbUtils.py
@@ -42,7 +42,7 @@ def totalCounts():
     return APIUtils.formatResponseObject(200, 'totalCounts', totalsSummary)
 
 @utils.route('/proxy', methods=['GET', 'POST', 'PUT', 'HEAD'])
-@cross_origin(origins='http[s]?://.*nypl.org')
+# @cross_origin(origins='http[s]?://.*nypl.org')
 def getProxyResponse():
     proxyUrl = request.args.get('proxy_url')
     cleanUrl = unquote_plus(proxyUrl)

--- a/swagger.v4.json
+++ b/swagger.v4.json
@@ -282,6 +282,40 @@
                 }
             }
         },
+        "/utils/proxy": {
+            "get": {
+                "tags": ["digital-research-books"],
+                "summary": "v4 Proxy Resource",
+                "description": "Provides a proxy service for use with the NYPL Web reader",
+                "parameters": [
+                    {
+                        "name": "proxy_url",
+                        "in": "query",
+                        "description": "Provide a URL-encoded resource to proxy",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The proxied resource",
+                        "type": "string"
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "default": {
+                        "description": "Unexpected Error",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/utils/counts": {
             "get": {
                 "tags": ["digital-research-books"],


### PR DESCRIPTION
This adds a new endpoint that proxies requests for resources. It is intended for use with the webreader when that application has difficulty loading resources. At present it has a CORS header setting to only accept requests from `.nypl.org` addresses. This is a (probably over-cautious) security setting but shouldn't prove too difficult to work with in testing scenarios