### PR TITLE
SFR-1221 Improve HEAD request method

### DIFF
--- a/api/blueprints/drbUtils.py
+++ b/api/blueprints/drbUtils.py
@@ -48,7 +48,7 @@ def getProxyResponse():
     cleanUrl = unquote_plus(proxyUrl)
 
     while True:
-        headResp = requests.head(cleanUrl)
+        headResp = requests.head(cleanUrl, headers={'User-agent': 'Mozilla/5.0'})
 
         statusCode = headResp.status_code
         if statusCode in [200, 204]:

--- a/tests/unit/test_api_utils_blueprint.py
+++ b/tests/unit/test_api_utils_blueprint.py
@@ -89,7 +89,7 @@ class TestEditionBlueprint:
             assert testAPIResponse.response == [b'Test Content']
             assert testAPIResponse.headers['Media-Type'] == 'allow'
 
-            mockHead.assert_called_once_with('testURL')
+            mockHead.assert_called_once_with('testURL', headers={'User-agent': 'Mozilla/5.0'})
             mockReq.assert_called_once()
 
     def test_getProxyResponse_redirect_success(self, testApp, mocker):
@@ -114,5 +114,8 @@ class TestEditionBlueprint:
             assert testAPIResponse.response == [b'Test Content']
             assert testAPIResponse.headers['Media-Type'] == 'allow'
 
-            mockHead.assert_has_calls([mocker.call('testURL'), mocker.call('redirectURL')])
+            mockHead.assert_has_calls([
+                mocker.call('testURL', headers={'User-agent': 'Mozilla/5.0'}),
+                mocker.call('redirectURL', headers={'User-agent': 'Mozilla/5.0'})]
+            )
             mockReq.assert_called_once()


### PR DESCRIPTION
To check for redirects in proxy requests HEAD requests are made. In some instances these requests can cause issues, so this updates the process to be slightly more robust