### PR TITLE
NOREF Make Proxy CORS configuration configurable

### DIFF
--- a/api/blueprints/drbUtils.py
+++ b/api/blueprints/drbUtils.py
@@ -1,5 +1,6 @@
 from flask import Blueprint, current_app, request, Response
 from flask_cors import cross_origin
+import os
 import requests
 from urllib.parse import unquote_plus
 
@@ -42,7 +43,7 @@ def totalCounts():
     return APIUtils.formatResponseObject(200, 'totalCounts', totalsSummary)
 
 @utils.route('/proxy', methods=['GET', 'POST', 'PUT', 'HEAD'])
-@cross_origin(origins='http[s]?://.*nypl.org')
+@cross_origin(origins=os.environ.get('API_PROXY_CORS_ALLOWED', []))
 def getProxyResponse():
     proxyUrl = request.args.get('proxy_url')
     cleanUrl = unquote_plus(proxyUrl)

--- a/api/blueprints/drbUtils.py
+++ b/api/blueprints/drbUtils.py
@@ -14,6 +14,7 @@ logger = createLog(__name__)
 
 utils = Blueprint('utils', __name__, url_prefix='/utils')
 
+
 @utils.route('/languages', methods=['GET'])
 def languageCounts():
     esClient = ElasticClient(current_app.config['REDIS_CLIENT'])
@@ -23,11 +24,14 @@ def languageCounts():
 
     langResult = esClient.languageQuery(workCounts)
 
-    languageList = APIUtils.formatLanguages(langResult.aggregations, workCounts)
+    languageList = APIUtils.formatLanguages(
+        langResult.aggregations, workCounts
+    )
 
     logger.debug('Language list 200 OK on /utils/languages')
 
     return APIUtils.formatResponseObject(200, 'languageCounts', languageList)
+
 
 @utils.route('/counts', methods=['GET'])
 def totalCounts():
@@ -42,14 +46,17 @@ def totalCounts():
 
     return APIUtils.formatResponseObject(200, 'totalCounts', totalsSummary)
 
+
 @utils.route('/proxy', methods=['GET', 'POST', 'PUT', 'HEAD'])
-@cross_origin(origins=os.environ.get('API_PROXY_CORS_ALLOWED', []))
+@cross_origin(origins=os.environ.get('API_PROXY_CORS_ALLOWED', '*'))
 def getProxyResponse():
     proxyUrl = request.args.get('proxy_url')
     cleanUrl = unquote_plus(proxyUrl)
 
     while True:
-        headResp = requests.head(cleanUrl, headers={'User-agent': 'Mozilla/5.0'})
+        headResp = requests.head(
+            cleanUrl, headers={'User-agent': 'Mozilla/5.0'}
+        )
 
         statusCode = headResp.status_code
         if statusCode in [200, 204]:
@@ -73,7 +80,10 @@ def getProxyResponse():
         'upgrade'
     ]
 
-    headers = [(k, v) for (k, v) in resp.headers.items() if k.lower() not in excludedHeaders]
+    headers = [
+        (k, v) for (k, v) in resp.headers.items()
+        if k.lower() not in excludedHeaders
+    ]
 
     proxyResp = Response(resp.content, resp.status_code, headers)
     return proxyResp

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -58,3 +58,6 @@ DOAB_OAI_URL: http://www.doabooks.org/oai?
 
 # ePub-to-Webpub Conversion Service
 WEBPUB_CONVERSION_URL: https://epub-to-webpub.vercel.app
+
+# Allowed sources of CORS requests to proxy endpoint
+API_PROXY_CORS_ALLOWED: '*'

--- a/config/example.yaml
+++ b/config/example.yaml
@@ -65,3 +65,6 @@ DOAB_OAI_URL: xxx
 
 # ePub-to-Webpub Conversion Service
 WEBPUB_CONVERSION_URL: xxx
+
+# Allowed sources of CORS requests to proxy endpoint
+API_PROXY_CORS_ALLOWED: (?:Source1:Source2)

--- a/config/production.yaml
+++ b/config/production.yaml
@@ -83,3 +83,6 @@ DEFAULT_COVER_URL: https://drb-files-qa.s3.amazonaws.com/covers/default/defaultC
 
 # ePub-to-Webpub Conversion Service
 WEBPUB_CONVERSION_URL: https://epub-to-webpub.vercel.app
+
+# Allowed sources of CORS requests to proxy endpoint
+API_PROXY_CORS_ALLOWED: http[s]?://.*nypl.org

--- a/config/qa.yaml
+++ b/config/qa.yaml
@@ -85,4 +85,4 @@ DEFAULT_COVER_URL: https://drb-files-qa.s3.amazonaws.com/covers/default/defaultC
 WEBPUB_CONVERSION_URL: https://epub-to-webpub.vercel.app
 
 # Allowed sources of CORS requests to proxy endpoint
-API_PROXY_CORS_ALLOWED: (?:http[s]?://.*nypl.org|https://nypl-web-reader.vercel.app)
+API_PROXY_CORS_ALLOWED: (?:http[s]?://.*nypl.org|https://nypl-web-reader.vercel.app|http[s]?://.*-nypl.vercel.app)

--- a/config/qa.yaml
+++ b/config/qa.yaml
@@ -83,3 +83,6 @@ DEFAULT_COVER_URL: https://drb-files-qa.s3.amazonaws.com/covers/default/defaultC
 
 # ePub-to-Webpub Conversion Service
 WEBPUB_CONVERSION_URL: https://epub-to-webpub.vercel.app
+
+# Allowed sources of CORS requests to proxy endpoint
+API_PROXY_CORS_ALLOWED: (?:http[s]?://.*nypl.org|https://nypl-web-reader.vercel.app)

--- a/task-definition.json
+++ b/task-definition.json
@@ -31,6 +31,10 @@
                 {
                     "name": "ELASTICSEARCH_INDEX",
                     "value": "drb_dcdw_qa"
+                },
+                {
+                    "name": "API_PROXY_CORS_ALLOWED",
+                    "value": "*"
                 }
 
             ],


### PR DESCRIPTION
To increase the testability of the proxy endpoint (especially when testing other components of the DRB application) this makes the source of CORS requests to the proxy endpoint configurable via environment variable. This should make interacting with the proxy to test the development of othe components much easier