### PR TITLE
SFR-1245 Add Conforms to for PDFs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased -- v0.8.0
 ### Added
 - New endpoint `utils/proxy` to allow for proxying of resources to webreader
+- `conformsTo` parameter for Webpub Manifests for identifying PDF resources
 
 ## 2021-07-21 -- v0.7.1
 ### Fixed

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -58,3 +58,6 @@ DOAB_OAI_URL: http://www.doabooks.org/oai?
 
 # ePub-to-Webpub Conversion Service
 WEBPUB_CONVERSION_URL: https://epub-to-webpub.vercel.app
+
+# Webpub PDF Profile
+WEBPUB_PDF_PROFILE: http://librarysimplified.org/terms/profiles/pdf

--- a/config/example.yaml
+++ b/config/example.yaml
@@ -65,3 +65,6 @@ DOAB_OAI_URL: xxx
 
 # ePub-to-Webpub Conversion Service
 WEBPUB_CONVERSION_URL: xxx
+
+# Webpub PDF Profile
+WEBPUB_PDF_PROFILE: http://librarysimplified.org/terms/profiles/pdf

--- a/config/production.yaml
+++ b/config/production.yaml
@@ -83,3 +83,6 @@ DEFAULT_COVER_URL: https://drb-files-qa.s3.amazonaws.com/covers/default/defaultC
 
 # ePub-to-Webpub Conversion Service
 WEBPUB_CONVERSION_URL: https://epub-to-webpub.vercel.app
+
+# Webpub PDF Profile
+WEBPUB_PDF_PROFILE: http://librarysimplified.org/terms/profiles/pdf

--- a/config/qa.yaml
+++ b/config/qa.yaml
@@ -83,3 +83,6 @@ DEFAULT_COVER_URL: https://drb-files-qa.s3.amazonaws.com/covers/default/defaultC
 
 # ePub-to-Webpub Conversion Service
 WEBPUB_CONVERSION_URL: https://epub-to-webpub.vercel.app
+
+# Webpub PDF Profile
+WEBPUB_PDF_PROFILE: http://librarysimplified.org/terms/profiles/pdf

--- a/managers/parsers/abstractParser.py
+++ b/managers/parsers/abstractParser.py
@@ -4,6 +4,7 @@ import re
 
 from managers.webpubManifest import WebpubManifest
 
+
 class AbstractParser(ABC):
     TIMEOUT = 15
 
@@ -36,13 +37,17 @@ class AbstractParser(ABC):
     def generateManifest(self, sourceURI, manifestURI):
         manifest = WebpubManifest(sourceURI, 'application/pdf')
 
-        manifest.addMetadata(self.record)
+        manifest.addMetadata(
+            self.record, conformsTo=os.environ['WEBPUB_PDF_PROFILE']
+        )
 
         manifest.addChapter(sourceURI, self.record.title)
 
-        manifest.links.append(
-            {'rel': 'self', 'href': manifestURI, 'type': 'application/webpub+json'}
-        )
+        manifest.links.append({
+            'rel': 'self',
+            'href': manifestURI,
+            'type': 'application/webpub+json'
+        })
 
         return manifest.toJson()
 

--- a/managers/webpubManifest.py
+++ b/managers/webpubManifest.py
@@ -13,15 +13,21 @@ class WebpubManifest:
         self.openSection = None
 
     # TODO validate kwargs against schema.org/Book
-    def addMetadata(self, dcdwRecord):
+    def addMetadata(self, dcdwRecord, conformsTo=None):
         self.metadata['title'] = dcdwRecord.title
 
         if len(dcdwRecord.authors) > 0:
             self.metadata['author'] = list(dcdwRecord.authors[0].split('|'))[0]
 
-        isbns = list(filter(lambda x: x[-4:] == 'isbn', dcdwRecord.identifiers))
+        isbns = list(filter(
+            lambda x: x[-4:] == 'isbn', dcdwRecord.identifiers
+        ))
+
         if len(isbns) > 0:
             self.metadata['identifier'] = 'urn:isbn:{}'.format(isbns[0][:-5])
+
+        if conformsTo:
+            self.metadata['conformsTo'] = conformsTo
 
     def addSection(self, sectionTitle, sectionURL):
         if self.openSection:
@@ -36,7 +42,7 @@ class WebpubManifest:
     def closeSection(self):
         if self.openSection:
             self.tableOfContents.append(self.openSection)
-        
+
         self.openSection = None
 
     # TODO Make it possible to add subsections iteratively
@@ -71,7 +77,10 @@ class WebpubManifest:
             'metadata': self.metadata,
             'links': self.links,
             'readingOrder': self.readingOrder,
-            'resources': [{'href': res, 'type': 'application/pdf'} for res in self.resources],
+            'resources': [
+                {'href': res, 'type': 'application/pdf'}
+                for res in self.resources
+            ],
             'toc': self.tableOfContents
         }
 

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -49,7 +49,8 @@ class TestHelpers:
         'DOAB_OAI_URL': 'test_doab_url',
         'SMARTSHEET_API_TOKEN': 'test_smartsheet_token',
         'SMARTSHEET_SHEET_ID': '1000',
-        'WEBPUB_CONVERSION_URL': 'test_conversion_url'
+        'WEBPUB_CONVERSION_URL': 'test_conversion_url',
+        'WEBPUB_PDF_PROFILE': 'test_profile_uri'
     }
 
     @classmethod

--- a/tests/unit/test_met_process.py
+++ b/tests/unit/test_met_process.py
@@ -218,7 +218,7 @@ class TestMUSEProcess:
         assert testManifest == 'testJSON'
         assert mockManifest.links[0] == {'rel': 'self', 'href': 'manifestURI', 'type': 'application/webpub+json'}
 
-        mockManifest.addMetadata.assert_called_once_with(mockRecord)
+        mockManifest.addMetadata.assert_called_once_with(mockRecord, conformsTo='test_profile_uri')
         mockManifest.addChapter.assert_called_once_with('sourceURI', 'Test')
 
     def test_queryMetAPI_success_non_head(self, mocker):

--- a/tests/unit/test_muse_process.py
+++ b/tests/unit/test_muse_process.py
@@ -269,7 +269,7 @@ class TestMUSEProcess:
 
         mockLoad.assert_called_once_with('testLink')
         mockManifestConstructor.assert_called_once_with('testLink', 'testType')
-        mockManifest.addMetadata.assert_called_once_with('testRecord')
+        mockManifest.addMetadata.assert_called_once_with('testRecord', conformsTo='test_profile_uri')
 
         mockManifest.addSection.assert_has_calls([
             mocker.call('Part One. Reading Reading Historically', ''),

--- a/tests/unit/test_parser_abstract.py
+++ b/tests/unit/test_parser_abstract.py
@@ -58,7 +58,7 @@ class TestAbstractParser:
         assert testManifest == 'jsonManifest'
         assert mockManifest.links == [{'rel': 'self', 'href': 'manifestURI', 'type': 'application/webpub+json'}]
         mockManifestManager.assert_called_once_with('sourceURI', 'application/pdf')
-        mockManifest.addMetadata.assert_called_once_with(testParser.record)
+        mockManifest.addMetadata.assert_called_once_with(testParser.record, conformsTo='test_profile_uri')
         mockManifest.addChapter.assert_called_once_with('sourceURI', 'testRecord')
         mockManifest.toJson.assert_called_once()
 

--- a/tests/unit/test_webpub_manifest.py
+++ b/tests/unit/test_webpub_manifest.py
@@ -33,11 +33,12 @@ class TestPDFManifest:
         mockRecord.authors = ['Author 1|||true', 'Author 2|||false']
         mockRecord.identifiers = ['id1|test', 'id2|isbn']
 
-        testManifest.addMetadata(mockRecord)
+        testManifest.addMetadata(mockRecord, conformsTo='test_profile_uri')
 
         assert testManifest.metadata == {
             '@type': 'https://schema.org/Book', 'title': 'Test Record',
-            'author': 'Author 1', 'identifier': 'urn:isbn:id2'
+            'author': 'Author 1', 'identifier': 'urn:isbn:id2',
+            'conformsTo': 'test_profile_uri'
         }
 
     def test_addSection_no_existing(self, testManifest):


### PR DESCRIPTION
In order to facilitate the use of PDF files in Webpub Manifests, web reader clients need a method of determining the contents of a manifest. The established way of doing so is to use the `conformsTo` option in the metadata block. This implements this for PDF manifests only (as ePub manifests are assumed to be the default in the current web reader)

A PDF profile has been defined so the only udpate here is to include the relevant URI for PDF manifests as they are generated. This is configurable via an environment variable.