### PR TITLE
SFR-1068 Collections db model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unreleased --v0.9.0
+### Added
+- Collections model for storing arbitrary collections of editions/works
+
 ## 2021-08-03 -- v0.8.0
 ### Added
 - New endpoint `utils/proxy` to allow for proxying of resources to webreader

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,95 @@
+# A generic, single database configuration.
+
+[alembic]
+# path to migration scripts
+script_location = migrations
+
+# template used to generate migration files
+# file_template = %%(rev)s_%%(slug)s
+
+# sys.path path, will be prepended to sys.path if present.
+# defaults to the current working directory.
+prepend_sys_path = .
+
+# timezone to use when rendering the date
+# within the migration file as well as the filename.
+# string value is passed to dateutil.tz.gettz()
+# leave blank for localtime
+# timezone =
+
+# max length of characters to apply to the
+# "slug" field
+# truncate_slug_length = 40
+
+# set to 'true' to run the environment during
+# the 'revision' command, regardless of autogenerate
+# revision_environment = false
+
+# set to 'true' to allow .pyc and .pyo files without
+# a source .py file to be detected as revisions in the
+# versions/ directory
+# sourceless = false
+
+# version location specification; this defaults
+# to migrations/versions.  When using multiple version
+# directories, initial revisions must be specified with --version-path
+# version_locations = %(here)s/bar %(here)s/bat migrations/versions
+
+# the output encoding used when revision files
+# are written from script.py.mako
+# output_encoding = utf-8
+
+user = %(POSTGRES_USER)s
+pswd = %(POSTGRES_PSWD)s
+host = %(POSTGRES_HOST)s
+port = %(POSTGRES_PORT)s
+name = %(POSTGRES_NAME)s
+
+sqlalchemy.url = postgresql://%(user)s:%(pswd)s@%(host)s:%(port)s/%(name)s
+
+
+[post_write_hooks]
+# post_write_hooks defines scripts or Python functions that are run
+# on newly generated revision scripts.  See the documentation for further
+# detail and examples
+
+# format using "black" - use the console_scripts runner, against the "black" entrypoint
+# hooks = black
+# black.type = console_scripts
+# black.entrypoint = black
+# black.options = -l 79 REVISION_SCRIPT_FILENAME
+
+# Logging configuration
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/main.py
+++ b/main.py
@@ -17,6 +17,7 @@ def main(args):
     singleRecord = args.singleRecord
     limit = args.limit
     offset = args.offset
+    options = args.options
 
     logger.info('Staring Process {} in {}'.format(process, environment))
     logger.debug('Process Args Type: {}, Limit: {}, Offset: {}, Date: {}, File: {}, Record: {}'.format(
@@ -26,7 +27,9 @@ def main(args):
     availableProcesses = registerProcesses()
 
     procClass = availableProcesses[process]
-    processInstance = procClass(procType, customFile, startDate, singleRecord, limit, offset)
+    processInstance = procClass(
+        procType, customFile, startDate, singleRecord, limit, offset, options
+    )
     processInstance.runProcess()
 
 
@@ -54,6 +57,7 @@ def createArgParser():
                         help='Set start offset for current processed (for batched import process)')
     parser.add_argument('-r', '--singleRecord',
                         help='Single record ID for ingesting an individual record (only applicable for DOAB)')
+    parser.add_argument('options', nargs='*', help='Additional arguments')
     
     return parser
 

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,0 +1,98 @@
+import os
+
+from logging.config import fileConfig
+
+from sqlalchemy import engine_from_config
+from sqlalchemy import pool
+
+from alembic import context
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Set postgresql host for current environment
+section = config.config_ini_section
+config.set_section_option(
+    section, "POSTGRES_USER", os.environ.get("POSTGRES_USER", None)
+)
+config.set_section_option(
+    section, "POSTGRES_PSWD", os.environ.get("POSTGRES_PSWD", None)
+)
+config.set_section_option(
+    section, "POSTGRES_HOST", os.environ.get("POSTGRES_HOST", None)
+)
+config.set_section_option(
+    section, "POSTGRES_PORT", os.environ.get("POSTGRES_PORT", None)
+)
+config.set_section_option(
+    section, "POSTGRES_NAME", os.environ.get("POSTGRES_NAME", None)
+)
+
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+fileConfig(config.config_file_name)
+
+# add your model's MetaData object here
+# for 'autogenerate' support
+# from myapp import mymodel
+# target_metadata = mymodel.Base.metadata
+target_metadata = None
+
+# other values from the config, defined by the needs of env.py,
+# can be acquired:
+# my_important_option = config.get_main_option("my_important_option")
+# ... etc.
+
+
+def run_migrations_offline():
+    """Run migrations in 'offline' mode.
+
+    This configures the context with just a URL
+    and not an Engine, though an Engine is acceptable
+    here as well.  By skipping the Engine creation
+    we don't even need a DBAPI to be available.
+
+    Calls to context.execute() here emit the given string to the
+    script output.
+
+    """
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online():
+    """Run migrations in 'online' mode.
+
+    In this scenario we need to create an Engine
+    and associate a connection with the context.
+
+    """
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection, target_metadata=target_metadata
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/migrations/script.py.mako
+++ b/migrations/script.py.mako
@@ -1,0 +1,24 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade():
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade():
+    ${downgrades if downgrades else "pass"}

--- a/migrations/versions/fabf5e5c3109_add_collections_table.py
+++ b/migrations/versions/fabf5e5c3109_add_collections_table.py
@@ -1,0 +1,55 @@
+"""add collections table
+
+Revision ID: fabf5e5c3109
+Revises: 
+Create Date: 2021-08-04 18:05:01.567042
+
+"""
+from alembic import op
+from datetime import datetime
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+
+# revision identifiers, used by Alembic.
+revision = 'fabf5e5c3109'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'collections',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('date_created', sa.TIMESTAMP, default=datetime.utcnow()),
+        sa.Column(
+            'date_modified', sa.TIMESTAMP,
+            default=datetime.utcnow(), onupdate=datetime.utcnow()
+        ),
+        sa.Column('uuid', UUID, index=True),
+        sa.Column('title', sa.String, index=True),
+        sa.Column('creator', sa.String, index=True)
+    )
+
+    op.create_table(
+        'collection_editions',
+        sa.Column('date_created', sa.TIMESTAMP, default=datetime.utcnow()),
+        sa.Column(
+            'date_modified', sa.TIMESTAMP,
+            default=datetime.utcnow(), onupdate=datetime.utcnow()
+        ),
+        sa.Column(
+            'collection_id', sa.Integer, sa.ForeignKey('collections.id'),
+            index=True
+        ),
+        sa.Column(
+            'edition_id', sa.Integer, sa.ForeignKey('editions.id'), index=True
+        )
+    )
+
+
+def downgrade():
+    op.drop_table('collection_editions')
+
+    op.drop_table('collections')

--- a/model/postgres/collection.py
+++ b/model/postgres/collection.py
@@ -1,0 +1,43 @@
+from sqlalchemy import Unicode, Integer, Column, Table, ForeignKey
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
+
+from .base import Base, Core
+
+COLLECTION_EDITIONS = Table(
+    'collection_editions', Base.metadata,
+    Column(
+        'collection_id',
+        Integer,
+        ForeignKey('collections.id', ondelete='CASCADE')
+    ),
+    Column(
+        'edition_id',
+        Integer,
+        ForeignKey('editions.id', ondelete='CASCADE')
+    )
+)
+
+
+class Collection(Base, Core):
+    __tablename__ = 'collections'
+
+    id = Column(Integer, primary_key=True)
+    uuid = Column(UUID, index=True)
+    title = Column(Unicode, index=True)
+    creator = Column(Unicode, index=True)
+
+    editions = relationship(
+        'Edition',
+        secondary=COLLECTION_EDITIONS,
+        backref='collections',
+        cascade='all, delete'
+    )
+
+    def __repr__(self):
+        return '<Collection(uuid={}, title={}, creator={}, items={})>'.format(
+            self.uuid, self.title, self.creator, len(self.editions)
+        )
+
+    def __dir__(self):
+        return ['uuid', 'title', 'creator']

--- a/processes/__init__.py
+++ b/processes/__init__.py
@@ -12,3 +12,4 @@ from .api import APIProcess
 from .muse import MUSEProcess
 from .ingestReport import IngestReportProcess
 from .met import METProcess
+from .migration import MigrationProcess

--- a/processes/migration.py
+++ b/processes/migration.py
@@ -1,0 +1,20 @@
+from alembic import config
+
+from .core import CoreProcess
+from logger import createLog
+
+logger = createLog(__name__)
+
+
+class MigrationProcess(CoreProcess):
+    def __init__(self, *args):
+        super(MigrationProcess, self).__init__(*args[:4])
+
+        self.options = args[6]
+
+    def runProcess(self):
+        logger.info('Running database migration')
+
+        alembicArgs = ['--raiseerr'] + self.options
+
+        config.main(argv=alembicArgs)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+alembic
 beautifulsoup4
 boto3
 elasticsearch-dsl>=6.0.0,<7.0.0

--- a/tests/unit/test_main_process.py
+++ b/tests/unit/test_main_process.py
@@ -1,5 +1,4 @@
 import inspect
-import os
 import pytest
 import sys
 import yaml
@@ -20,6 +19,7 @@ class TestMainProcess:
         mockArgs.singleRecord = 'testRecord'
         mockArgs.limit = 'testLimit'
         mockArgs.offset = 'testOffset'
+        mockArgs.options = ['opt1', 'opt2']
 
         return mockArgs
 
@@ -39,7 +39,10 @@ class TestMainProcess:
 
         main(processArgs)
 
-        mockProcess.assert_called_with('test', 'testFile', 'testDate', 'testRecord', 'testLimit', 'testOffset')
+        mockProcess.assert_called_with(
+            'test', 'testFile', 'testDate', 'testRecord', 'testLimit',
+            'testOffset', ['opt1', 'opt2']
+        )
         mockInstance.runProcess.assert_called_once
 
     def test_registerProcesses(self, mocker):

--- a/tests/unit/test_migration_process.py
+++ b/tests/unit/test_migration_process.py
@@ -1,0 +1,18 @@
+from alembic import config
+
+from processes import MigrationProcess
+
+
+class TestMigrationProcess:
+    def test_api_runProcess(self, mocker):
+        mockAlembic = mocker.patch.object(config, 'main')
+
+        testProc = MigrationProcess(
+            'TestProcess', 'testFile', 'testDate', 'testRecord', 'testLimit',
+            'testOffset', ['testOpt1', 'testOpt2']
+        )
+        testProc.runProcess()
+
+        mockAlembic.assert_called_once_with(
+            argv=['--raiseerr', 'testOpt1', 'testOpt2']
+        )


### PR DESCRIPTION
This adds a new table to the postgres model to hold collections (and associated editions). This migration is necessary to support the collections feature to be shown as a POC for further development.

To imploment this work we have added the alembic module for managing migrations. This module can be invoked via the normal process via the CLI or a container. Arbitrary arguments can be passed to upgrade/downgrade the database model as needed and as a result all future database updates will be versioned.