### PR TITLE
SFR-1247 Add collection list endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Added
 - Collections model for storing arbitrary collections of editions/works
 - /collection endpoints for the creation, retrival and deletion of collection records
+- /collection/list epndoint to list all collections in database
 
 ## 2021-08-03 -- v0.8.0
 ### Added

--- a/api/db.py
+++ b/api/db.py
@@ -85,7 +85,18 @@ class DBClient():
     def fetchSingleCollection(self, uuid):
         return self.session.query(Collection)\
             .options(joinedload(Collection.editions))\
-            .filter(Collection.uuid == uuid).first()
+            .filter(Collection.uuid == uuid).one()
+
+    def fetchCollections(self, sort=None, page=1, perPage=10):
+        offset = (page - 1) * perPage
+
+        sort = sort.replace(':', ' ') if sort else 'title'
+
+        return self.session.query(Collection)\
+            .order_by(text(sort))\
+            .offset(offset)\
+            .limit(perPage)\
+            .all()
 
     def createCollection(
         self, title, creator, description, owner, workUUIDs=[], editionIDs=[]

--- a/swagger.v4.json
+++ b/swagger.v4.json
@@ -763,6 +763,56 @@
                     } 
                 }
             }
+        },
+        "/collection/list": {
+            "get": {
+                "tags": ["digital-research-books"],
+                "summary": "Return list of DRB Collections",
+                "description": "Returns list of collections in DRB",
+                "parameters": [
+                    {
+                        "name": "sort",
+                        "in": "query",
+                        "description": "Method of sorting collections. Either title or creator",
+                        "type": "string",
+                        "required": false
+                    },
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "description": "Page of collections to load",
+                        "type": "integer",
+                        "required": false
+                    },
+                    {
+                        "name": "perGage",
+                        "in": "query",
+                        "description": "Number of collections to load per page",
+                        "type": "integer",
+                        "required": false
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "A basic OPDS2 feed response",
+                        "schema": {
+                            "$ref": "#/definitions/OPDSFeedResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "default": {
+                        "description": "Unexpected Error",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    } 
+                }
+            }
         }
     },
     "definitions": {

--- a/tests/unit/test_api_db.py
+++ b/tests/unit/test_api_db.py
@@ -117,13 +117,19 @@ class TestDBClient:
             .assert_called_once()
 
     def test_fetchSingleCollection(self, testInstance):
-        testInstance.session.query().options().filter().first\
+        testInstance.session.query().options().filter().one\
             .return_value = 'testCollection'
 
         assert testInstance.fetchSingleCollection('uuid') == 'testCollection'
 
-        testInstance.session.query().options().filter().first\
+        testInstance.session.query().options().filter().one\
             .assert_called_once()
+
+    def test_fetchCollections(self, testInstance):
+        testInstance.session.query().order_by().offset().limit().all\
+            .return_value = 'testCollections'
+
+        assert testInstance.fetchCollections() == 'testCollections'
 
     def test_createCollection(self, testInstance, mocker):
         mockUUID = mocker.patch('api.db.uuid4')


### PR DESCRIPTION
This adds an endpoint that lists all collections in the database. It is paged and defaults to a page size of 10. Within the collection of collections, each collection displays the first 5 works within it.