### PR TITLE
SFR-1068 Update auth method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Collections model for storing arbitrary collections of editions/works
 - /collection endpoints for the creation, retrival and deletion of collection records
 - /collection/list epndoint to list all collections in database
+- Add Basic Authentication for managing collections
 
 ## 2021-08-03 -- v0.8.0
 ### Added

--- a/api/blueprints/drbCollection.py
+++ b/api/blueprints/drbCollection.py
@@ -44,6 +44,8 @@ def validateToken(func):
 
         dbClient.closeSession()
 
+        kwargs['user'] = user.user
+
         return func(*args, **kwargs)
 
     return decorator
@@ -214,7 +216,7 @@ def constructOPDSFeed(
     })
 
     path = request.full_path\
-        if uuid in request.path\
+        if str(uuid) in request.path\
         else '/collection/{}'.format(uuid)
 
     opdsFeed.addLink({

--- a/api/blueprints/drbCollection.py
+++ b/api/blueprints/drbCollection.py
@@ -218,13 +218,7 @@ def constructOPDSFeed(
         else '/collection/{}'.format(uuid)
 
     opdsFeed.addLink({
-<<<<<<< HEAD
         'rel': 'self', 'href': path, 'type': 'application/opds+json'
-=======
-        'rel': 'self',
-        'href': path or request.path,
-        'type': 'application/opds+json'
->>>>>>> main
     })
 
     host = 'digital-research-books-beta'\

--- a/api/blueprints/drbCollection.py
+++ b/api/blueprints/drbCollection.py
@@ -155,10 +155,12 @@ def constructOPDSFeed(uuid, dbClient, sort=None, page=1, perPage=10):
         'description': collection.description
     })
 
+    path = request.full_path\
+        if uuid in request.path\
+        else '/collection/{}'.format(uuid)
+
     opdsFeed.addLink({
-        'rel': 'self',
-        'href': request.path,
-        'type': 'application/opds+json'
+        'rel': 'self', 'href': path, 'type': 'application/opds+json'
     })
 
     host = 'digital-research-books-beta'\
@@ -186,7 +188,7 @@ def constructOPDSFeed(uuid, dbClient, sort=None, page=1, perPage=10):
     opdsFeed.addPublications(opdsPubs[start:end])
 
     OPDSUtils.addPagingOptions(
-        opdsFeed, request.full_path, len(opdsPubs), page=page, perPage=perPage
+        opdsFeed, path, len(opdsPubs), page=page, perPage=perPage
     )
 
     return APIUtils.formatOPDS2Object(200, opdsFeed)

--- a/api/blueprints/drbUtils.py
+++ b/api/blueprints/drbUtils.py
@@ -1,5 +1,4 @@
 from flask import Blueprint, current_app, request, Response
-from flask.json import jsonify
 from flask_cors import cross_origin
 import os
 import requests
@@ -8,7 +7,6 @@ from urllib.parse import unquote_plus
 from ..db import DBClient
 from ..elastic import ElasticClient
 from ..utils import APIUtils
-from managers import NyplApiManager
 from logger import createLog
 
 logger = createLog(__name__)
@@ -89,19 +87,3 @@ def getProxyResponse():
 
     proxyResp = Response(resp.content, resp.status_code, headers)
     return proxyResp
-
-
-@utils.route('/auth', methods=['GET', 'POST'])
-def getAuthToken():
-    try:
-        clientID = request.args['client_id']
-        clientSecret = request.args['client_secret']
-    except KeyError:
-        errMsg = {'message': 'client_id and client_secret required'}
-        return APIUtils.formatResponseObject(400, 'authResponse', errMsg)
-
-    apiManager = NyplApiManager(clientID, clientSecret)
-
-    apiManager.generateAccessToken()
-
-    return (jsonify(apiManager.token), 200)

--- a/api/db.py
+++ b/api/db.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm import joinedload, sessionmaker
 from sqlalchemy.sql import text
 from uuid import uuid4
 
-from model import Work, Edition, Link, Item, Record, Collection
+from model import Work, Edition, Link, Item, Record, Collection, User
 from .utils import APIUtils
 
 
@@ -134,3 +134,8 @@ class DBClient():
         return self.session.query(Collection)\
             .filter(Collection.owner == owner)\
             .filter(Collection.uuid == uuid).delete()
+
+    def fetchUser(self, user):
+        return self.session.query(User)\
+            .filter(User.user == user)\
+            .one_or_none()

--- a/api/opdsUtils.py
+++ b/api/opdsUtils.py
@@ -18,6 +18,8 @@ class OPDSUtils:
         pagingRels[page + 1 if page < lastPage else lastPage].append('next')
         pagingRels[lastPage].append('last')
 
+        path = path[:-1] if path[-1] == '?' else path
+
         joinChar = '&' if '?' in path else '?'
 
         for pageNo, rels in pagingRels.items():

--- a/api/utils.py
+++ b/api/utils.py
@@ -1,5 +1,6 @@
 from collections import OrderedDict
 from datetime import datetime
+from hashlib import scrypt
 from flask import jsonify
 from math import ceil
 import re
@@ -288,3 +289,11 @@ class APIUtils():
             return [dict(zip(fields, d.split('|'))) for d in dataList]
         else:
             return dict(zip(fields, data.split('|')))
+
+    @staticmethod
+    def validatePassword(password, hash, salt):
+        password = password.encode('utf-8')
+
+        hashedPassword = scrypt(password, salt=salt, n=2**14, r=8, p=1)
+
+        return hashedPassword == hash

--- a/migrations/versions/975e451df332_add_user_table_for_basic_auth.py
+++ b/migrations/versions/975e451df332_add_user_table_for_basic_auth.py
@@ -1,0 +1,37 @@
+"""add user table for basic auth
+
+Revision ID: 975e451df332
+Revises: 2f6b783fc4aa
+Create Date: 2021-08-18 15:36:33.313176
+
+"""
+from alembic import op
+from datetime import datetime
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import BYTEA
+
+
+# revision identifiers, used by Alembic.
+revision = '975e451df332'
+down_revision = '2f6b783fc4aa'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'users',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('date_created', sa.TIMESTAMP, default=datetime.utcnow()),
+        sa.Column(
+            'date_modified', sa.TIMESTAMP,
+            default=datetime.utcnow(), onupdate=datetime.utcnow()
+        ),
+        sa.Column('user', sa.String, index=True, unique=True),
+        sa.Column('password', BYTEA),
+        sa.Column('salt', BYTEA)
+    )
+
+
+def downgrade():
+    op.drop_table('users')

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -8,6 +8,7 @@ from .postgres.link import Link
 from .postgres.olCover import OpenLibraryCover
 from .postgres.rights import Rights
 from .postgres.collection import Collection
+from .postgres.user import User
 
 from .elasticsearch.agent import Agent as ESAgent
 from .elasticsearch.edition import Edition as ESEdition

--- a/model/postgres/user.py
+++ b/model/postgres/user.py
@@ -1,0 +1,16 @@
+from sqlalchemy import Unicode, Integer, Column
+from sqlalchemy.dialects.postgresql import BYTEA
+
+from .base import Base, Core
+
+
+class User(Base, Core):
+    __tablename__ = 'users'
+
+    id = Column(Integer, primary_key=True)
+    user = Column(Unicode, index=True, unique=True)
+    password = Column(BYTEA)
+    salt = Column(BYTEA)
+
+    def __repr__(self):
+        return '<User(user={})>'.format(self.user)

--- a/swagger.v4.json
+++ b/swagger.v4.json
@@ -355,55 +355,6 @@
                 }
             }
         },
-        "/utils/auth": {
-            "get": {
-                "tags": ["digital-research-books"],
-                "summary": "Authenticate User",
-                "description": "Authenticates ISSO user, returning access token for use with collection endpoints",
-                "parameters": [
-                    {
-                        "name": "client_id",
-                        "in": "query",
-                        "description": "ISSO client_id value",
-                        "type": "string",
-                        "required": true
-                    },
-                    {
-                        "name": "client_secret",
-                        "in": "query",
-                        "description": "ISSO client_secret value",
-                        "type": "string",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "An object containing access token and supporting information",
-                        "schema": {
-                            "$ref": "#/definitions/TokenResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Invalid Parameters supplied",
-                        "schema": {
-                            "$ref": "#/definitions/ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/ErrorResponse"
-                        }
-                    },
-                    "default": {
-                        "description": "Unexpected Error",
-                        "schema": {
-                            "$ref": "#/definitions/ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
         "/opds": {
             "get": {
                 "tags": ["digital-research-books"],

--- a/swagger.v4.json
+++ b/swagger.v4.json
@@ -15,9 +15,7 @@
     ],
     "securityDefinitions": {
         "BasicAuth": {
-            "type": "apiKey",
-            "in": "header",
-            "name": "Authorization"
+            "type": "basic"
         }
     },
     "paths": {

--- a/tests/unit/test_api_db.py
+++ b/tests/unit/test_api_db.py
@@ -179,3 +179,11 @@ class TestDBClient:
 
         testInstance.session.query().filter().filter().delete\
             .assert_called_once()
+
+    def test_fetchUser(self, testInstance):
+        testInstance.session.query().filter().one_or_none\
+            .return_value = 'testUser'
+
+        assert testInstance.fetchUser('user') == 'testUser'
+
+        testInstance.session.query().filter().one_or_none.assert_called_once()

--- a/tests/unit/test_api_utils.py
+++ b/tests/unit/test_api_utils.py
@@ -1,3 +1,4 @@
+from hashlib import scrypt
 import pytest
 
 from api.utils import APIUtils
@@ -422,3 +423,15 @@ class TestAPIUtils:
 
     def test_formatPipeDelimitedData_none(self):
         assert APIUtils.formatPipeDelimitedData(None, ['one', 'two']) == None
+
+    def test_validatePassword_success(self):
+        testHash = scrypt(b'testPswd', salt=b'testSalt', n=2**14, r=8, p=1)
+
+        assert APIUtils.validatePassword('testPswd', testHash, b'testSalt')\
+            is True
+
+    def test_validatePassword_error(self):
+        testHash = scrypt(b'testPswd', salt=b'testSalt', n=2**14, r=8, p=1)
+
+        assert APIUtils.validatePassword('testError', testHash, b'testSalt')\
+            is False

--- a/tests/unit/test_api_utils_blueprint.py
+++ b/tests/unit/test_api_utils_blueprint.py
@@ -2,10 +2,11 @@ from flask import Flask, Response
 import pytest
 import requests
 
-from api.blueprints.drbUtils import(
-    languageCounts, totalCounts, getProxyResponse, getAuthToken
+from api.blueprints.drbUtils import (
+    languageCounts, totalCounts, getProxyResponse
 )
 from api.utils import APIUtils
+
 
 class TestEditionBlueprint:
     @pytest.fixture
@@ -121,31 +122,3 @@ class TestEditionBlueprint:
                 mocker.call('redirectURL', headers={'User-agent': 'Mozilla/5.0'})]
             )
             mockReq.assert_called_once()
-
-    def test_getAuthToken_success(self, testApp, mocker):
-        mockAPIInit = mocker.patch('api.blueprints.drbUtils.NyplApiManager')
-        mockAPI = mocker.MagicMock(token={'access_token': 'testToken'})
-        mockAPIInit.return_value = mockAPI
-
-        with testApp.test_request_context(
-            '/?client_id=testID&client_secret=testSecret'
-        ):
-            testAPIResponse = getAuthToken()
-
-            assert testAPIResponse[1] == 200
-            assert testAPIResponse[0].json['access_token'] == 'testToken'
-
-            mockAPIInit.assert_called_once_with('testID', 'testSecret')
-            mockAPI.generateAccessToken.assert_called_once()
-
-    def test_getAuthToken_missing_key(self, testApp, mockUtils, mocker):
-        mockUtils['formatResponseObject'].return_value = 'testErrorResponse'
-
-        with testApp.test_request_context('/'):
-            testAPIResponse = getAuthToken()
-            assert testAPIResponse == 'testErrorResponse'
-
-            mockUtils['formatResponseObject'].assert_called_once_with(
-                400, 'authResponse',
-                {'message': 'client_id and client_secret required'}
-            )


### PR DESCRIPTION
This implements a simpler, DRB-specific authentication system for interacting with collections. This enables DRB to distribute credentials on an as-needed basis and remove a dependency on the NYPL ISSO service. For the purposes of the simple collection POC this is more than sufficient and ensures that creation and protection are limited, and that users can only delete resources that they control