### PR TITLE
NOREF Update swagger to default theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - /collection endpoints for the creation, retrival and deletion of collection records
 - /collection/list epndoint to list all collections in database
 - Add Basic Authentication for managing collections
+- Update swagger documentation to use current http(s) scheme
 
 ## 2021-08-03 -- v0.8.0
 ### Added

--- a/swagger.v4.json
+++ b/swagger.v4.json
@@ -6,7 +6,6 @@
         "description": "RESTful API for the Digital Research Books Project"
     },
     "basePath": "/",
-    "schemes": ["http", "https"],
     "tags": [
         {
             "name": "digital-research-books",


### PR DESCRIPTION
Previously swagger was explicitly setting the scheme to be used by endpoints. Since this causes an error when loading in a different scheme (as would happen by default) this is removed in favor of using the currently deployed scheme. This works because the swagger documentation and API endpoints will always be deployed in the same manner.