### PR TITLE
NOREF Add readerVersion parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unreleased -- v0.9.2
+### Added
+- `readerVersion` parameter for `/search`, `/work` and `/edition` endpoints to control media types returned
+
 ## 2021-09-09 -- v0.9.1
 ### Fixed
 - Improved InternetArchive link parsing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,10 @@
 # CHANGELOG
 
 ## unreleased -- v0.9.2
-<<<<<<< HEAD
 ### Added
 - `readerVersion` parameter for `/search`, `/work` and `/edition` endpoints to control media types returned
-=======
 ### Fixed
 - Improve clustering stability by improving individual error handling
->>>>>>> main
 
 ## 2021-09-09 -- v0.9.1
 ### Fixed

--- a/api/app.py
+++ b/api/app.py
@@ -25,6 +25,8 @@ class FlaskAPI:
         self.app.config['DB_CLIENT'] = dbEngine
         self.app.config['REDIS_CLIENT'] = redisClient
 
+        self.app.config['READER_VERSION'] = os.environ['READER_VERSION']
+
         self.app.register_blueprint(info)
         self.app.register_blueprint(search)
         self.app.register_blueprint(work)

--- a/api/blueprints/drbEdition.py
+++ b/api/blueprints/drbEdition.py
@@ -7,6 +7,7 @@ logger = createLog(__name__)
 
 edition = Blueprint('edition', __name__, url_prefix='/edition')
 
+
 @edition.route('/<editionID>', methods=['GET'])
 def editionFetch(editionID):
     logger.info('Fetching Edition #{}'.format(editionID))
@@ -16,19 +17,30 @@ def editionFetch(editionID):
 
     searchParams = APIUtils.normalizeQueryParams(request.args)
     showAll = searchParams.get('showAll', ['true'])[0].lower() != 'false'
+    readerVersion = searchParams.get(
+        'readerVersion', current_app.config['READER_VERSION']
+    )
 
     edition = dbClient.fetchSingleEdition(editionID)
 
     if edition:
         statusCode = 200
         records = dbClient.fetchRecordsByUUID(edition.dcdw_uuids)
-        responseBody = APIUtils.formatEditionOutput(edition, records=records, showAll=showAll) 
+        responseBody = APIUtils.formatEditionOutput(
+            edition, records=records, showAll=showAll, reader=readerVersion
+        )
     else:
         statusCode = 404
-        responseBody = {'message': 'Unable to locate edition with id {}'.format(editionID)}
+        responseBody = {
+            'message': 'Unable to locate edition with id {}'.format(editionID)
+        }
 
-    logger.debug('Edition Fetch {} on /edition/{}'.format(statusCode, editionID))
+    logger.debug(
+        'Edition Fetch {} on /edition/{}'.format(statusCode, editionID)
+    )
 
     dbClient.closeSession()
 
-    return APIUtils.formatResponseObject(statusCode, 'singleEdition', responseBody)
+    return APIUtils.formatResponseObject(
+        statusCode, 'singleEdition', responseBody
+    )

--- a/api/blueprints/drbEdition.py
+++ b/api/blueprints/drbEdition.py
@@ -17,9 +17,8 @@ def editionFetch(editionID):
 
     searchParams = APIUtils.normalizeQueryParams(request.args)
     showAll = searchParams.get('showAll', ['true'])[0].lower() != 'false'
-    readerVersion = searchParams.get(
-        'readerVersion', current_app.config['READER_VERSION']
-    )
+    readerVersion = searchParams.get('readerVersion', [None])[0]\
+        or current_app.config['READER_VERSION']
 
     edition = dbClient.fetchSingleEdition(editionID)
 

--- a/api/blueprints/drbSearch.py
+++ b/api/blueprints/drbSearch.py
@@ -27,6 +27,10 @@ def standardQuery():
     searchPage = int(searchParams.get('page', [1])[0]) - 1
     searchSize = int(searchParams.get('size', [10])[0])
 
+    readerVersion = searchParams.get(
+        'readerVersion', current_app.config['READER_VERSION']
+    )
+
     logger.info('Executing ES Query {} with filters {}'.format(searchParams, terms['filter']))
 
     try:
@@ -57,7 +61,7 @@ def standardQuery():
 
     dataBlock = {
         'totalWorks': searchResult.hits.total,
-        'works': APIUtils.formatWorkOutput(works, resultIds, formats=filteredFormats),
+        'works': APIUtils.formatWorkOutput(works, resultIds, formats=filteredFormats, reader=readerVersion),
         'paging': paging,
         'facets': facets
     }

--- a/api/blueprints/drbSearch.py
+++ b/api/blueprints/drbSearch.py
@@ -27,9 +27,8 @@ def standardQuery():
     searchPage = int(searchParams.get('page', [1])[0]) - 1
     searchSize = int(searchParams.get('size', [10])[0])
 
-    readerVersion = searchParams.get(
-        'readerVersion', current_app.config['READER_VERSION']
-    )
+    readerVersion = searchParams.get('readerVersion', [None])[0]\
+        or current_app.config['READER_VERSION']
 
     logger.info('Executing ES Query {} with filters {}'.format(searchParams, terms['filter']))
 

--- a/api/blueprints/drbWork.py
+++ b/api/blueprints/drbWork.py
@@ -7,6 +7,7 @@ logger = createLog(__name__)
 
 work = Blueprint('work', __name__, url_prefix='/work')
 
+
 @work.route('/<uuid>', methods=['GET'])
 def workFetch(uuid):
     logger.info('Fetching Work {}'.format(uuid))
@@ -16,18 +17,27 @@ def workFetch(uuid):
 
     searchParams = APIUtils.normalizeQueryParams(request.args)
     showAll = searchParams.get('showAll', ['true'])[0].lower() != 'false'
+    readerVersion = searchParams.get(
+        'readerVersion', current_app.config['READER_VERSION']
+    )
 
     work = dbClient.fetchSingleWork(uuid)
 
     if work:
         statusCode = 200
-        responseBody = APIUtils.formatWorkOutput(work, None, showAll=showAll) 
+        responseBody = APIUtils.formatWorkOutput(
+            work, None, showAll=showAll, reader=readerVersion
+        )
     else:
         statusCode = 404
-        responseBody = {'message': 'Unable to locate work with UUID {}'.format(uuid)} 
+        responseBody = {
+            'message': 'Unable to locate work with UUID {}'.format(uuid)
+        }
 
     logger.warning('Work Fetch {} on /work/{}'.format(statusCode, uuid))
 
     dbClient.closeSession()
 
-    return APIUtils.formatResponseObject(statusCode, 'singleWork', responseBody)
+    return APIUtils.formatResponseObject(
+        statusCode, 'singleWork', responseBody
+    )

--- a/api/blueprints/drbWork.py
+++ b/api/blueprints/drbWork.py
@@ -17,9 +17,8 @@ def workFetch(uuid):
 
     searchParams = APIUtils.normalizeQueryParams(request.args)
     showAll = searchParams.get('showAll', ['true'])[0].lower() != 'false'
-    readerVersion = searchParams.get(
-        'readerVersion', current_app.config['READER_VERSION']
-    )
+    readerVersion = searchParams.get('readerVersion', [None])[0]\
+        or current_app.config['READER_VERSION']
 
     work = dbClient.fetchSingleWork(uuid)
 

--- a/api/utils.py
+++ b/api/utils.py
@@ -13,11 +13,11 @@ class APIUtils():
     ]
 
     FORMAT_CROSSWALK = {
-        'epub_zip': ['application/epub+zip', 'application/epub+xml'],
-        'epub_xml': ['application/epub+zip', 'application/epub+xml'],
+        'epub_zip': ['application/epub+zip', 'application/epub+xml', 'application/webpub+json'],
+        'epub_xml': ['application/epub+zip', 'application/epub+xml', 'application/webpub+json'],
         'html': ['text/html'],
         'html_edd': ['application/html+edd', 'application/x.html+edd'],
-        'pdf': ['application/pdf'],
+        'pdf': ['application/pdf', 'application/webpub+json'],
         'webpub_json': ['application/webpub+json']
     }
 
@@ -199,10 +199,20 @@ class APIUtils():
 
             itemDict['links'] = []
 
-            for link in item.links:
-                if formats and link.media_type not in formats:
-                    continue
+            validLinks = list(filter(lambda x: x.media_type in formats, item.links))\
+                if formats else item.links
 
+            if (
+                len(validLinks) < 1
+                or (
+                    formats
+                    and len(validLinks) == 1
+                    and validLinks[0].media_type == 'application/webpub+json'
+                )
+            ):
+                continue
+
+            for link in validLinks:
                 flags = link.flags
 
                 if (
@@ -233,9 +243,6 @@ class APIUtils():
                 }
                 for rights in item.rights
             ]
-
-            if len(itemDict['links']) < 1:
-                continue
 
             editionDict['items'].append(itemDict)
 

--- a/api/utils.py
+++ b/api/utils.py
@@ -197,23 +197,33 @@ class APIUtils():
             itemDict['location'] = item.physical_location['name']\
                 if item.physical_location else None
 
-            itemDict['links'] = list(filter(None, [
-                {
+            itemDict['links'] = []
+
+            for link in item.links:
+                if formats and link.media_type not in formats:
+                    continue
+
+                flags = link.flags
+
+                if (
+                    (
+                        reader == 'v2'
+                        and link.media_type == 'application/epub+xml'
+                    )
+                    or
+                    (
+                        reader != 'v2'
+                        and link.media_type == 'application/webpub+json'
+                    )
+                ):
+                    flags['reader'] = False
+
+                itemDict['links'].append({
                     'link_id': link.id,
                     'mediaType': link.media_type,
-                    'url': link.url
-                }
-                if not formats or link.media_type in formats else None
-                for link in item.links
-            ]))
-
-            if reader != 'v2':
-                itemDict['links'] = list(filter(
-                    lambda x: x['mediaType'] != 'application/webpub+json',
-                    itemDict['links']
-                ))
-                if len(itemDict['links']) < 1:
-                    continue
+                    'url': link.url,
+                    'flags': flags
+                })
 
             itemDict['rights'] = [
                 {

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -64,3 +64,6 @@ WEBPUB_PDF_PROFILE: http://librarysimplified.org/terms/profiles/pdf
 
 # Allowed sources of CORS requests to proxy endpoint
 API_PROXY_CORS_ALLOWED: '*'
+
+# Current NYPL Webreader version
+READER_VERSION: v1

--- a/config/example.yaml
+++ b/config/example.yaml
@@ -71,3 +71,6 @@ WEBPUB_PDF_PROFILE: http://librarysimplified.org/terms/profiles/pdf
 
 # Allowed sources of CORS requests to proxy endpoint
 API_PROXY_CORS_ALLOWED: (?:Source1:Source2)
+
+# Current NYPL Webreader version
+READER_VERSION: xxx

--- a/config/production.yaml
+++ b/config/production.yaml
@@ -89,3 +89,6 @@ WEBPUB_PDF_PROFILE: http://librarysimplified.org/terms/profiles/pdf
 
 # Allowed sources of CORS requests to proxy endpoint
 API_PROXY_CORS_ALLOWED: http[s]?://.*nypl.org
+
+# Current NYPL Webreader version
+READER_VERSION: v1

--- a/config/qa.yaml
+++ b/config/qa.yaml
@@ -89,3 +89,6 @@ WEBPUB_PDF_PROFILE: http://librarysimplified.org/terms/profiles/pdf
 
 # Allowed sources of CORS requests to proxy endpoint
 API_PROXY_CORS_ALLOWED: (?:http[s]?://.*nypl.org|https://nypl-web-reader.vercel.app|http[s]?://.*-nypl.vercel.app)
+
+# Current NYPL Webreader version
+READER_VERSION: v1

--- a/mappings/nypl.py
+++ b/mappings/nypl.py
@@ -68,7 +68,7 @@ class NYPLMapping(SQLMapping):
                 ('656', '{a}|{2}|'),
                 ('690', '{a} -- {b} -- {v} -- {x} -- {z}|lcsh|{0}'),
             ],
-            'has_part': [('856', '1|{u}|nypl|text/html|{z}')],
+            'has_part': [('856', '1|{u}|nypl|text/html|{{"catalog": false, "download": false, "reader": false}}')],
         }
 
     def applyMapping(self):
@@ -126,7 +126,7 @@ class NYPLMapping(SQLMapping):
 
         # Add catalog link derived from nypl identifier if 856 field is not present
         if len(self.record.has_part) < 1:
-            self.record.has_part.append('1|{}|nypl|text/html|{{}}'.format(
+            self.record.has_part.append('1|{}|nypl|text/html|{{"catalog": true, "download": false, "reader": false}}'.format(
                 'https://www.nypl.org/research/collections/shared-collection-catalog/bib/b{}'.format(self.source['id'])
             ))
 
@@ -144,7 +144,7 @@ class NYPLMapping(SQLMapping):
                     item['location']['code'], item['location']['name'], pos
                 ))
 
-                self.record.has_part.append('{}|{}|nypl|application/x.html+edd|{{}}'.format(
+                self.record.has_part.append('{}|{}|nypl|application/x.html+edd|{{"edd": true, "catalog": false, "download": false, "reader": false}}'.format(
                     pos,
                     'http://www.nypl.org/research/collections/shared-collection-catalog/hold/request/b{}-i{}'.format(self.source['id'], item['id'])
                 ))

--- a/mappings/oclcCatalog.py
+++ b/mappings/oclcCatalog.py
@@ -152,7 +152,7 @@ class CatalogMapping(XMLMapping):
                     '//oclc:datafield[@tag=\'856\']/oclc:subfield[@code=\'u\']/text()',
                     '//oclc:datafield[@tag=\'856\']/@ind1'
                 ],
-                '1|{0}|oclc|text/html|{{"ebook": true, "download": false, "reader": false, "catalog": true, "marcInd1": "{1}"}}'
+                '1|{0}|oclc|text/html|{{"download": false, "reader": false, "catalog": false, "marcInd1": "{1}"}}'
             )]
         }
 

--- a/swagger.v4.json
+++ b/swagger.v4.json
@@ -74,6 +74,14 @@
                         "description": "Sets the number of results to return per page",
                         "required": false,
                         "type": "integer"
+                    },
+                    {
+                        "name": "readerVersion",
+                        "in": "query",
+                        "description": "Informs the API of the reader to be used, which determines which Read Online links can be served",
+                        "required": false,
+                        "type": "string",
+                        "enum": ["v1", "v2"]
                     }
                 ],
                 "responses": {
@@ -123,6 +131,14 @@
                         "description": "If True all editions are returned, if False only editions with readable links are returned",
                         "type": "boolean",
                         "required": false
+                    },
+                    {
+                        "name": "readerVersion",
+                        "in": "query",
+                        "description": "Informs the API of the reader to be used, which determines which Read Online links can be served",
+                        "required": false,
+                        "type": "string",
+                        "enum": ["v1", "v2"]
                     }
                 ],
                 "responses": {
@@ -172,6 +188,14 @@
                         "description": "If True all editions are returned, if False only editions with readable links are returned",
                         "type": "boolean",
                         "required": false
+                    },
+                    {
+                        "name": "readerVersion",
+                        "in": "query",
+                        "description": "Informs the API of the reader to be used, which determines which Read Online links can be served",
+                        "required": false,
+                        "type": "string",
+                        "enum": ["v1", "v2"]
                     }
                 ],
                 "responses": {

--- a/swagger.v4.json
+++ b/swagger.v4.json
@@ -1264,6 +1264,9 @@
                 "url": {
                     "type": "string",
                     "format": "uri"
+                },
+                "flags": {
+                   "type": "object" 
                 }
             }
         },

--- a/tests/unit/test_api_edition_blueprint.py
+++ b/tests/unit/test_api_edition_blueprint.py
@@ -4,6 +4,7 @@ import pytest
 from api.blueprints.drbEdition import editionFetch
 from api.utils import APIUtils
 
+
 class TestEditionBlueprint:
     @pytest.fixture
     def mockUtils(self, mocker):
@@ -18,6 +19,7 @@ class TestEditionBlueprint:
     def testApp(self):
         flaskApp = Flask('test')
         flaskApp.config['DB_CLIENT'] = 'testDBClient'
+        flaskApp.config['READER_VERSION'] = 'test'
 
         return flaskApp
 
@@ -34,7 +36,8 @@ class TestEditionBlueprint:
         mockDB.fetchRecordsByUUID.return_value = 'testRecords'
 
         mockUtils['formatEditionOutput'].return_value = 'testEdition'
-        mockUtils['formatResponseObject'].return_value = 'singleEditionResponse'
+        mockUtils['formatResponseObject'].return_value\
+            = 'singleEditionResponse'
 
         with testApp.test_request_context('/'):
             testAPIResponse = editionFetch(1)
@@ -44,7 +47,7 @@ class TestEditionBlueprint:
 
             mockUtils['normalizeQueryParams'].assert_called_once()
             mockUtils['formatEditionOutput'].assert_called_once_with(
-                mockEdition, records='testRecords', showAll=True
+                mockEdition, records='testRecords', showAll=True, reader='test'
             )
             mockUtils['formatResponseObject'].assert_called_once_with(
                 200, 'singleEdition', 'testEdition'
@@ -70,5 +73,7 @@ class TestEditionBlueprint:
             mockUtils['normalizeQueryParams'].assert_called_once()
             mockUtils['formatEditionOutput'].assert_not_called()
             mockUtils['formatResponseObject'].assert_called_once_with(
-                404, 'singleEdition', {'message': 'Unable to locate edition with id 1'}
+                404,
+                'singleEdition',
+                {'message': 'Unable to locate edition with id 1'}
             )

--- a/tests/unit/test_api_es.py
+++ b/tests/unit/test_api_es.py
@@ -649,14 +649,14 @@ class TestElasticClient:
             mocker.call('exists', field='editions.formats'),
             mocker.call(
                 'terms',
-                editions__formats=['application/pdf', 'application/html+edd', 'application/x.html+edd']
+                editions__formats=['application/pdf', 'application/webpub+json', 'application/html+edd', 'application/x.html+edd']
             )
         ])
         mockAgg.assert_has_calls([
             mocker.call('filter', exists={'field': 'editions.formats'}),
             mocker.call(
                 'filter',
-                terms={'editions.formats': ['application/pdf', 'application/html+edd', 'application/x.html+edd']}
+                terms={'editions.formats': ['application/pdf', 'application/webpub+json', 'application/html+edd', 'application/x.html+edd']}
             )
         ])
 

--- a/tests/unit/test_api_utils.py
+++ b/tests/unit/test_api_utils.py
@@ -3,6 +3,7 @@ import pytest
 
 from api.utils import APIUtils
 
+
 class TestAPIUtils:
     @pytest.fixture
     def testAggregationResp(self):
@@ -17,7 +18,10 @@ class TestAPIUtils:
                     },
                     'formats': {
                         'buckets': [
-                            {'key': 'Format1', 'editions_per': {'doc_count': 5}}
+                            {
+                                'key': 'Format1',
+                                'editions_per': {'doc_count': 5}
+                            }
                         ]
                     }
                 }
@@ -74,25 +78,39 @@ class TestAPIUtils:
 
     @pytest.fixture
     def testLink(self, MockDBObject):
-        return MockDBObject(id='li1', media_type='application/test', url='testURI')
+        return MockDBObject(
+            id='li1', media_type='application/test', url='testURI'
+        )
 
     @pytest.fixture
     def testWebpubLink(self, MockDBObject):
-        return MockDBObject(id='li2', media_type='application/webpub+json', url='testURI')
+        return MockDBObject(
+            id='li2', media_type='application/webpub+json', url='testURI'
+        )
 
     @pytest.fixture
     def testRights(self, MockDBObject):
-        return MockDBObject(id='ri1', source='test', license='testLicense', rights_statement='testStatement')
+        return MockDBObject(
+            id='ri1',
+            source='test',
+            license='testLicense',
+            rights_statement='testStatement'
+        )
 
     @pytest.fixture
     def testItem(self, MockDBObject, testLink, testRights):
         return MockDBObject(
-            id='it1', links=[testLink], rights=[testRights], physical_location={'name': 'test'}
+            id='it1',
+            links=[testLink],
+            rights=[testRights],
+            physical_location={'name': 'test'}
         )
 
     @pytest.fixture
     def testWebpubItem(self, MockDBObject, testWebpubLink):
-        return MockDBObject(id='it2', links=[testWebpubLink], rights=[], physical_location={})
+        return MockDBObject(
+            id='it2', links=[testWebpubLink], rights=[], physical_location={}
+        )
 
     @pytest.fixture
     def testEdition(self, MockDBObject, testItem, mocker):
@@ -101,12 +119,16 @@ class TestAPIUtils:
             work=mocker.MagicMock(uuid='uuid1'),
             publication_date=mocker.MagicMock(year=2000),
             items=[testItem],
-            links=[mocker.MagicMock(id='co1', media_type='image/png', url='testCover')]
+            links=[mocker.MagicMock(
+                id='co1', media_type='image/png', url='testCover'
+            )]
         )
 
     @pytest.fixture
     def testWork(self, MockDBObject, testEdition):
-        return MockDBObject(uuid='testUUID', title='Test Title', editions=[testEdition])
+        return MockDBObject(
+            uuid='testUUID', title='Test Title', editions=[testEdition]
+        )
 
     def test_normalizeQueryParams(self, mocker):
         mockParams = mocker.MagicMock()
@@ -117,50 +139,69 @@ class TestAPIUtils:
         assert testParams == {'test1': 1, 'test2': 2}
 
     def test_extractParamPairs(self):
-        testPairs = APIUtils.extractParamPairs('test', {'test': ['title:value', 'bareValue']})
+        testPairs = APIUtils.extractParamPairs(
+            'test', {'test': ['title:value', 'bareValue']}
+        )
 
         assert testPairs[0] == ('title', 'value')
         assert testPairs[1] == ('test', 'bareValue')
 
     def test_extractParamPairs_comma_delimited(self):
-        testPairs = APIUtils.extractParamPairs('test', {'test': ['title:value,subject:value']})
+        testPairs = APIUtils.extractParamPairs(
+            'test', {'test': ['title:value,subject:value']}
+        )
 
         assert testPairs[0] == ('title', 'value')
         assert testPairs[1] == ('subject', 'value')
 
     def test_extractParamPairs_comma_delimited_quotes(self):
-        testPairs = APIUtils.extractParamPairs('test', {'test': ['title:value,author:"Test, Author",other']})
+        testPairs = APIUtils.extractParamPairs(
+            'test', {'test': ['title:value,author:"Test, Author",other']}
+        )
 
         assert testPairs[0] == ('title', 'value')
         assert testPairs[1] == ('author', '"Test, Author",other')
 
     def test_extractParamPairs_semantic_semicolon(self):
-        testPairs = APIUtils.extractParamPairs('test', {'test': ['title:A Book: A Title']})
+        testPairs = APIUtils.extractParamPairs(
+            'test', {'test': ['title:A Book: A Title']}
+        )
 
         assert testPairs[0] == ('title', 'A Book: A Title')
 
     def test_extractParamPairs_semicolon_no_field(self):
-        testPairs = APIUtils.extractParamPairs('test', {'test': ['A Book: A Title']})
+        testPairs = APIUtils.extractParamPairs(
+            'test', {'test': ['A Book: A Title']}
+        )
 
         assert testPairs[0] == ('test', 'A Book: A Title')
 
     def test_extractParamPairs_dangling_quotation(self):
-        testPairs = APIUtils.extractParamPairs('test', {'test': ['"A Title']})
+        testPairs = APIUtils.extractParamPairs(
+            'test', {'test': ['"A Title']}
+        )
 
         assert testPairs[0] == ('test', 'A Title')
 
     def test_extractParamPairs_dangling_quotation_multiple(self):
-        testPairs = APIUtils.extractParamPairs('test', {'test': ['"A Title",keyword:"other']})
+        testPairs = APIUtils.extractParamPairs(
+            'test', {'test': ['"A Title",keyword:"other']}
+        )
 
         assert testPairs[0] == ('test', '"A Title"')
         assert testPairs[1] == ('keyword', 'other')
 
     def test_formatAggregationResult(self, testAggregationResp):
-        testAggregations = APIUtils.formatAggregationResult(testAggregationResp)
+        testAggregations = APIUtils.formatAggregationResult(
+            testAggregationResp
+        )
 
-        assert testAggregations['languages'][0] == {'value': 'Lang1', 'count': 1}
-        assert testAggregations['languages'][1] == {'value': 'Lang2', 'count': 3}
-        assert testAggregations['formats'][0] == {'value': 'Format1', 'count': 5}
+        assert testAggregations['languages'][0] ==\
+            {'value': 'Lang1', 'count': 1}
+        assert testAggregations['languages'][1] ==\
+            {'value': 'Lang2', 'count': 3}
+        assert testAggregations['formats'][0] ==\
+            {'value': 'Format1', 'count': 5}
 
     def test_formatPagingOptions_previous_null(self):
         testPagingOptions = APIUtils.formatPagingOptions(1, 10, 50)
@@ -202,25 +243,31 @@ class TestAPIUtils:
         assert outWork['uuid'] == 1
         assert outWork['editions'][0]['id'] == 'ed3'
         assert outWork['editions'][2]['id'] == 'ed1'
-        mockFormat.assert_called_once_with('testWork', None, True)
+        mockFormat.assert_called_once_with('testWork', None, True, reader=None)
 
     def test_formatWorkOutput_multiple_works(self, mocker):
         mockFormat = mocker.patch.object(APIUtils, 'formatWork')
         mockFormat.side_effect = ['formattedWork1', 'formattedWork2']
 
-        testWorks = [mocker.MagicMock(uuid='uuid1'), mocker.MagicMock(uuid='uuid2')]
+        testWorks = [
+            mocker.MagicMock(uuid='uuid1'), mocker.MagicMock(uuid='uuid2')
+        ]
 
-        outWorks = APIUtils.formatWorkOutput(testWorks, [('uuid1', 1), ('uuid2', 2), ('uuid3', 3)])
+        outWorks = APIUtils.formatWorkOutput(
+            testWorks, [('uuid1', 1), ('uuid2', 2), ('uuid3', 3)]
+        )
 
         assert outWorks == ['formattedWork1', 'formattedWork2']
         mockFormat.assert_has_calls([
-            mocker.call(testWorks[0], 1, True, formats=None),
-            mocker.call(testWorks[1], 2, True, formats=None)
+            mocker.call(testWorks[0], 1, True, formats=None, reader=None),
+            mocker.call(testWorks[1], 2, True, formats=None, reader=None)
         ])
 
     def test_formatWork_showAll(self, testWork, mocker):
         mockFormatEdition = mocker.patch.object(APIUtils, 'formatEdition')
-        mockFormatEdition.return_value = {'edition_id': 'ed1', 'items': ['it1']}
+        mockFormatEdition.return_value = {
+            'edition_id': 'ed1', 'items': ['it1']
+        }
 
         testWorkDict = APIUtils.formatWork(testWork, ['ed1'], True)
 
@@ -233,7 +280,9 @@ class TestAPIUtils:
 
     def test_formatWork_showAll_false(self, testWork, mocker):
         mockFormatEdition = mocker.patch.object(APIUtils, 'formatEdition')
-        mockFormatEdition.return_value = {'edition_id': 'ed1', 'items': ['it1']}
+        mockFormatEdition.return_value = {
+            'edition_id': 'ed1', 'items': ['it1']
+        }
         testWorkDict = APIUtils.formatWork(testWork, ['ed1'], False)
 
         assert testWorkDict['uuid'] == 'testUUID'
@@ -268,9 +317,13 @@ class TestAPIUtils:
         mockFormatEdition = mocker.patch.object(APIUtils, 'formatEdition')
         mockFormatEdition.return_value = 'testEdition'
 
-        assert APIUtils.formatEditionOutput(1, records='testRecords', showAll=True) == 'testEdition'
+        assert APIUtils.formatEditionOutput(
+            1, records='testRecords', showAll=True
+        ) == 'testEdition'
 
-        mockFormatEdition.assert_called_once_with(1, 'testRecords', showAll=True)
+        mockFormatEdition.assert_called_once_with(
+            1, 'testRecords', showAll=True, reader=None
+        )
 
     def test_formatEdition_no_records(self, testEdition):
         formattedEdition = APIUtils.formatEdition(testEdition)
@@ -284,27 +337,42 @@ class TestAPIUtils:
         assert formattedEdition['items'][0]['item_id'] == 'it1'
         assert formattedEdition['items'][0]['location'] == 'test'
         assert formattedEdition['items'][0]['links'][0]['link_id'] == 'li1'
-        assert formattedEdition['items'][0]['links'][0]['mediaType'] == 'application/test'
+        assert formattedEdition['items'][0]['links'][0]['mediaType'] ==\
+            'application/test'
         assert formattedEdition['items'][0]['links'][0]['url'] == 'testURI'
         assert formattedEdition['items'][0]['rights'][0]['source'] == 'test'
-        assert formattedEdition['items'][0]['rights'][0]['license'] == 'testLicense'
-        assert formattedEdition['items'][0]['rights'][0]['rightsStatement'] == 'testStatement'
-        assert formattedEdition.get('instances', None) == None
+        assert formattedEdition['items'][0]['rights'][0]['license'] ==\
+            'testLicense'
+        assert formattedEdition['items'][0]['rights'][0]['rightsStatement'] ==\
+            'testStatement'
+        assert formattedEdition.get('instances', None) is None
 
     def test_formatEdition_w_records(self, testEdition, mocker):
         mockRecFormat = mocker.patch.object(APIUtils, 'formatRecord')
-        mockRecFormat.side_effect = [{'id': 1, 'items': []}, {'id': 2, 'items': ['it1']}]
+        mockRecFormat.side_effect = [
+            {'id': 1, 'items': []}, {'id': 2, 'items': ['it1']}
+        ]
 
-        formattedEdition = APIUtils.formatEdition(testEdition, ['rec1', 'rec2'], showAll=False)
+        formattedEdition = APIUtils.formatEdition(
+            testEdition, ['rec1', 'rec2'], showAll=False
+        )
 
         assert len(formattedEdition['instances']) == 1
         assert formattedEdition['instances'][0]['id'] == 2
-        assert formattedEdition.get('items', None) == None
+        assert formattedEdition.get('items', None) is None
 
         testItemDict = {
             'id': 'it1',
-            'links': [{'link_id': 'li1', 'mediaType': 'application/test', 'url': 'testURI'}],
-            'rights': [{'source': 'test', 'license': 'testLicense', 'rightsStatement': 'testStatement'}],
+            'links': [{
+                'link_id': 'li1',
+                'mediaType': 'application/test',
+                'url': 'testURI'
+            }],
+            'rights': [{
+                'source': 'test',
+                'license': 'testLicense',
+                'rightsStatement': 'testStatement'
+            }],
             'physical_location': {'name': 'test'},
             'item_id': 'it1',
             'location': 'test'
@@ -315,14 +383,25 @@ class TestAPIUtils:
             mocker.call('rec2', {'testURI': testItemDict})
         ])
 
-    def test_formatEdition_filter_webpubs_temp(self, testEdition, testWebpubItem):
+    def test_formatEdition_filter_reader_v1(self, testEdition, testWebpubItem):
         testEdition.items.append(testWebpubItem)
 
-        formattedEdition = APIUtils.formatEdition(testEdition)
+        formattedEdition = APIUtils.formatEdition(testEdition, reader='v1')
 
         assert len(formattedEdition['items']) == 1
         assert formattedEdition['items'][0]['item_id'] == 'it1'
-        assert formattedEdition['items'][0]['links'][0]['mediaType'] == 'application/test'
+        assert formattedEdition['items'][0]['links'][0]['mediaType'] ==\
+            'application/test'
+
+    def test_formatEdition_filter_reader_v2(self, testEdition, testWebpubItem):
+        testEdition.items.append(testWebpubItem)
+
+        formattedEdition = APIUtils.formatEdition(testEdition, reader='v2')
+
+        assert len(formattedEdition['items']) == 2
+        assert formattedEdition['items'][1]['item_id'] == 'it2'
+        assert formattedEdition['items'][1]['links'][0]['mediaType'] ==\
+            'application/webpub+json'
 
     def test_formatRecord(self, testRecord, mocker):
         testLinkItems = {
@@ -330,9 +409,12 @@ class TestAPIUtils:
             'url2': {'item_id': 2, 'url': 'url2'}
         }
 
-        mockFormatPipe = mocker.patch.object(APIUtils, 'formatPipeDelimitedData')
+        mockFormatPipe = mocker.patch.object(
+            APIUtils, 'formatPipeDelimitedData'
+        )
         mockFormatPipe.side_effect = [
-            'testAuthors', 'testContribs', 'testPublishers', 'testDates', 'testLangs', 'testIDs'
+            'testAuthors', 'testContribs', 'testPublishers',
+            'testDates', 'testLangs', 'testIDs'
         ]
 
         testFormatted = APIUtils.formatRecord(testRecord, testLinkItems)
@@ -367,16 +449,25 @@ class TestAPIUtils:
 
     def test_formatLanguages_no_counts(self, mocker):
         mockAggs = mocker.MagicMock()
-        mockAggs.languages.languages.buckets = [mocker.MagicMock(key='bLang'), mocker.MagicMock(key='aLang')]
+        mockAggs.languages.languages.buckets = [
+            mocker.MagicMock(key='bLang'), mocker.MagicMock(key='aLang')
+        ]
 
-        assert APIUtils.formatLanguages(mockAggs) == [{'language': 'aLang'}, {'language': 'bLang'}]
+        assert APIUtils.formatLanguages(mockAggs) ==\
+            [{'language': 'aLang'}, {'language': 'bLang'}]
 
     def test_formatLanguages_counts(self, mocker):
         mockAggs = mocker.MagicMock()
         mockAggs.languages.languages.buckets = [
-            mocker.MagicMock(key='bLang', work_totals=mocker.MagicMock(doc_count=10)),
-            mocker.MagicMock(key='cLang', work_totals=mocker.MagicMock(doc_count=30)),
-            mocker.MagicMock(key='aLang', work_totals=mocker.MagicMock(doc_count=20))
+            mocker.MagicMock(
+                key='bLang', work_totals=mocker.MagicMock(doc_count=10)
+            ),
+            mocker.MagicMock(
+                key='cLang', work_totals=mocker.MagicMock(doc_count=30)
+            ),
+            mocker.MagicMock(
+                key='aLang', work_totals=mocker.MagicMock(doc_count=20)
+            )
         ]
 
         assert APIUtils.formatLanguages(mockAggs, True) == [
@@ -386,7 +477,8 @@ class TestAPIUtils:
         ]
 
     def test_formatTotals(self):
-        assert APIUtils.formatTotals([('test', 3), ('other', 6)]) == {'test': 3, 'other': 6}
+        assert APIUtils.formatTotals([('test', 3), ('other', 6)]) ==\
+            {'test': 3, 'other': 6}
 
     def test_flatten_already_flat(self):
         flatArray = [i for i in APIUtils.flatten([1, 2, 3, 4, 5])]
@@ -410,7 +502,10 @@ class TestAPIUtils:
         assert testResponse[1] == 200
         mockDatetime.utcnow.assert_called_once
         mockJsonify.assert_called_once_with({
-            'status': 200, 'timestamp': 'presentTimestamp', 'responseType': 'test', 'data': 'testData'
+            'status': 200,
+            'timestamp': 'presentTimestamp',
+            'responseType': 'test',
+            'data': 'testData'
         })
 
     def test_formatPipeDelimitedData_string(self):
@@ -418,11 +513,15 @@ class TestAPIUtils:
             == {'one': 'test', 'two': 'object'}
 
     def test_formatPipeDelimitedData_list(self):
-        assert APIUtils.formatPipeDelimitedData(['test|object', None, 'another|thing'], ['one', 'two'])\
-            == [{'one': 'test', 'two': 'object'}, {'one': 'another', 'two': 'thing'}]
+        assert APIUtils.formatPipeDelimitedData(
+            ['test|object', None, 'another|thing'], ['one', 'two']
+        ) == [
+            {'one': 'test', 'two': 'object'},
+            {'one': 'another', 'two': 'thing'}
+        ]
 
     def test_formatPipeDelimitedData_none(self):
-        assert APIUtils.formatPipeDelimitedData(None, ['one', 'two']) == None
+        assert APIUtils.formatPipeDelimitedData(None, ['one', 'two']) is None
 
     def test_validatePassword_success(self):
         testHash = scrypt(b'testPswd', salt=b'testSalt', n=2**14, r=8, p=1)

--- a/tests/unit/test_api_utils.py
+++ b/tests/unit/test_api_utils.py
@@ -79,13 +79,19 @@ class TestAPIUtils:
     @pytest.fixture
     def testLink(self, MockDBObject):
         return MockDBObject(
-            id='li1', media_type='application/test', url='testURI'
+            id='li1',
+            media_type='application/epub+xml',
+            url='testURI',
+            flags={'test': True}
         )
 
     @pytest.fixture
     def testWebpubLink(self, MockDBObject):
         return MockDBObject(
-            id='li2', media_type='application/webpub+json', url='testURI'
+            id='li2',
+            media_type='application/webpub+json',
+            url='testURI',
+            flags={'test': True}
         )
 
     @pytest.fixture
@@ -338,8 +344,10 @@ class TestAPIUtils:
         assert formattedEdition['items'][0]['location'] == 'test'
         assert formattedEdition['items'][0]['links'][0]['link_id'] == 'li1'
         assert formattedEdition['items'][0]['links'][0]['mediaType'] ==\
-            'application/test'
+            'application/epub+xml'
         assert formattedEdition['items'][0]['links'][0]['url'] == 'testURI'
+        assert formattedEdition['items'][0]['links'][0]['flags']['test'] is\
+            True
         assert formattedEdition['items'][0]['rights'][0]['source'] == 'test'
         assert formattedEdition['items'][0]['rights'][0]['license'] ==\
             'testLicense'
@@ -365,8 +373,9 @@ class TestAPIUtils:
             'id': 'it1',
             'links': [{
                 'link_id': 'li1',
-                'mediaType': 'application/test',
-                'url': 'testURI'
+                'mediaType': 'application/epub+xml',
+                'url': 'testURI',
+                'flags': {'test': True}
             }],
             'rights': [{
                 'source': 'test',
@@ -383,17 +392,19 @@ class TestAPIUtils:
             mocker.call('rec2', {'testURI': testItemDict})
         ])
 
-    def test_formatEdition_filter_reader_v1(self, testEdition, testWebpubItem):
+    def test_formatEdition_v1_reader_flag(self, testEdition, testWebpubItem):
         testEdition.items.append(testWebpubItem)
 
         formattedEdition = APIUtils.formatEdition(testEdition, reader='v1')
 
-        assert len(formattedEdition['items']) == 1
+        assert len(formattedEdition['items']) == 2
         assert formattedEdition['items'][0]['item_id'] == 'it1'
         assert formattedEdition['items'][0]['links'][0]['mediaType'] ==\
-            'application/test'
+            'application/epub+xml'
+        assert formattedEdition['items'][1]['links'][0]['flags']['reader'] is\
+            False
 
-    def test_formatEdition_filter_reader_v2(self, testEdition, testWebpubItem):
+    def test_formatEdition_v2_reader_flag(self, testEdition, testWebpubItem):
         testEdition.items.append(testWebpubItem)
 
         formattedEdition = APIUtils.formatEdition(testEdition, reader='v2')
@@ -402,6 +413,8 @@ class TestAPIUtils:
         assert formattedEdition['items'][1]['item_id'] == 'it2'
         assert formattedEdition['items'][1]['links'][0]['mediaType'] ==\
             'application/webpub+json'
+        assert formattedEdition['items'][0]['links'][0]['flags']['reader'] is\
+            False
 
     def test_formatRecord(self, testRecord, mocker):
         testLinkItems = {

--- a/tests/unit/test_api_work_blueprint.py
+++ b/tests/unit/test_api_work_blueprint.py
@@ -4,6 +4,7 @@ import pytest
 from api.blueprints.drbWork import workFetch
 from api.utils import APIUtils
 
+
 class TestSearchBlueprint:
     @pytest.fixture
     def mockUtils(self, mocker):
@@ -18,6 +19,7 @@ class TestSearchBlueprint:
     def testApp(self):
         flaskApp = Flask('test')
         flaskApp.config['DB_CLIENT'] = 'testDBClient'
+        flaskApp.config['READER_VERSION'] = 'test'
 
         return flaskApp
 
@@ -27,7 +29,7 @@ class TestSearchBlueprint:
         mockDBClient.return_value = mockDB
 
         mockUtils['normalizeQueryParams'].return_value = {'showAll': ['true']}
-        
+
         mockDB.fetchSingleWork.return_value = 'dbWorkRecord'
 
         mockUtils['formatWorkOutput'].return_value = 'testWork'
@@ -41,7 +43,7 @@ class TestSearchBlueprint:
 
             mockUtils['normalizeQueryParams'].assert_called_once
             mockUtils['formatWorkOutput'].assert_called_once_with(
-                'dbWorkRecord', None, showAll=True
+                'dbWorkRecord', None, showAll=True, reader='test'
             )
             mockUtils['formatResponseObject'].assert_called_once_with(
                 200, 'singleWork', 'testWork'
@@ -53,7 +55,7 @@ class TestSearchBlueprint:
         mockDBClient.return_value = mockDB
 
         mockUtils['normalizeQueryParams'].return_value = {'showAll': ['false']}
-        
+
         mockDB.fetchSingleWork.return_value = 'dbWorkRecord'
 
         mockUtils['formatWorkOutput'].return_value = 'testWork'
@@ -67,7 +69,7 @@ class TestSearchBlueprint:
 
             mockUtils['normalizeQueryParams'].assert_called_once
             mockUtils['formatWorkOutput'].assert_called_once_with(
-                'dbWorkRecord', None, showAll=False
+                'dbWorkRecord', None, showAll=False, reader='test'
             )
             mockUtils['formatResponseObject'].assert_called_once_with(
                 200, 'singleWork', 'testWork'
@@ -79,7 +81,7 @@ class TestSearchBlueprint:
         mockDBClient.return_value = mockDB
 
         mockUtils['normalizeQueryParams'].return_value = {}
-        
+
         mockDB.fetchSingleWork.return_value = None
 
         mockUtils['formatResponseObject'].return_value = 'errorResponse'
@@ -93,5 +95,7 @@ class TestSearchBlueprint:
             mockUtils['normalizeQueryParams'].assert_called_once()
             mockUtils['formatWorkOutput'].assert_not_called()
             mockUtils['formatResponseObject'].assert_called_once_with(
-                404, 'singleWork', {'message': 'Unable to locate work with UUID testUUID'}
+                404,
+                'singleWork',
+                {'message': 'Unable to locate work with UUID testUUID'}
             )

--- a/tests/unit/test_nypl_mapping.py
+++ b/tests/unit/test_nypl_mapping.py
@@ -103,6 +103,6 @@ class TestNYPLMapping:
         assert testMapping.record.contributors == ['Contributor|1234|n9876|Tester']
         assert testMapping.record.coverage == ['tst|Test|2']
         assert testMapping.record.has_part == [
-            '1|https://www.nypl.org/research/collections/shared-collection-catalog/bib/b1|nypl|text/html|{}',
-            '2|http://www.nypl.org/research/collections/shared-collection-catalog/hold/request/b1-i1|nypl|application/x.html+edd|{}'
+            '1|https://www.nypl.org/research/collections/shared-collection-catalog/bib/b1|nypl|text/html|{"catalog": true, "download": false, "reader": false}',
+            '2|http://www.nypl.org/research/collections/shared-collection-catalog/hold/request/b1-i1|nypl|application/x.html+edd|{"edd": true, "catalog": false, "download": false, "reader": false}'
         ]


### PR DESCRIPTION
This adds a new parameter to the search, work and edition endpoints that controls what `media_types` are returned for links. This allows the API to return results that are compatible with multiple readers, and importantly allows DRB to deploy new readors on the front-end with zero downtime