### PR TITLE
NOREF Clustering Stability 2021-09-16

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+per-file-ignores = 
+  mappings/*.py: E501

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unreleased -- v0.9.2
+### Fixed
+- Improve clustering stability by improving individual error handling
+
 ## 2021-09-09 -- v0.9.1
 ### Fixed
 - Improved InternetArchive link parsing

--- a/managers/sfrRecord.py
+++ b/managers/sfrRecord.py
@@ -345,7 +345,11 @@ class SFRRecordManager:
         newEd = Edition(items=[], links=[])
 
         # Set Titles
-        newEd.title = edition['title'].most_common(1)[0][0].strip(' .:/')
+        try:
+            newEd.title = edition['title'].most_common(1)[0][0].strip(' .:/')
+        except AttributeError:
+            logger.warning('Unable to read title for edition')
+
         if len(edition['sub_title']):
             newEd.sub_title = edition['sub_title'].most_common(1)[0][0]
         newEd.alt_titles = [t[0] for t in edition['alt_titles'].most_common()]

--- a/processes/sfrCluster.py
+++ b/processes/sfrCluster.py
@@ -164,7 +164,7 @@ class ClusterProcess(CoreProcess):
 
         if len(matchedIDs) > 10000:
             logger.info(matchedIDs)
-            raise Exception('Clustering Error encountered, unreasonable number of records matched')
+            raise ClusterError('Clustering Error encountered, unreasonable number of records matched')
 
         return list(matchedIDs)
 


### PR DESCRIPTION
There are two errors that currently halt the clustering process that can be safely handled without interrupting the larger import process. In the future these kinds of errors should be reported to a service for review, but right now they will be recorded in the standard logs.

These fixes are:

- The error raised when the clustering process encounters a collection of records it considers unreasonable (>10,000) it should skip that record rather than exit.
- When an edition is missing a title that should be logged but not raise an unexpected error