### PR TITLE
NOREF Add content_type detection to the s3 process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # CHANGELOG
 
 ## unreleased -- v0.9.2
+### Added
+- Detect file types in s3 process and specify during storage process
 ### Fixed
 - Improve clustering stability by improving individual error handling
 


### PR DESCRIPTION
When ingesting epub files and cover images to s3 the aws process assigns a default content type of `binary/octet-stream`. Previously this was not a problem but the new reader checks the types of files it loads. The fix for this is a simple implementation using pythons core `mimetypes` module that provides accurate string identifiers. It does not appear that a more advanced implementation of this is necessary.