### PR TITLE
HOTFIX Improve Record Handling for new reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - `readerVersion` parameter for `/search`, `/work` and `/edition` endpoints to control media types returned
 ### Fixed
 - Improve clustering stability by improving individual error handling
+- Handle relative links from redirects in proxy endpoint
 
 ## 2021-09-09 -- v0.9.1
 ### Fixed

--- a/processes/sfrCluster.py
+++ b/processes/sfrCluster.py
@@ -150,7 +150,7 @@ class ClusterProcess(CoreProcess):
             for match in matches:
                 recTitle, recID, recIdentifiers = match
 
-                if iterations > 1 and self.compareTitleTokens(recTitle):
+                if iterations > 0 and self.compareTitleTokens(recTitle):
                     logger.debug('Matched Title Error: {}'.format(recTitle))
                     continue
 

--- a/tests/unit/test_api_utils_blueprint.py
+++ b/tests/unit/test_api_utils_blueprint.py
@@ -84,7 +84,7 @@ class TestEditionBlueprint:
             headers={'Content-Encoding': 'block', 'Media-Type': 'allow'},
             content='Test Content'
         )
-        with testApp.test_request_context('/?proxy_url=testURL'):
+        with testApp.test_request_context('/?proxy_url=https://www.testURL.com'):
             testAPIResponse = getProxyResponse()
 
             assert isinstance(testAPIResponse, Response)
@@ -92,13 +92,16 @@ class TestEditionBlueprint:
             assert testAPIResponse.response == [b'Test Content']
             assert testAPIResponse.headers['Media-Type'] == 'allow'
 
-            mockHead.assert_called_once_with('testURL', headers={'User-agent': 'Mozilla/5.0'})
+            mockHead.assert_called_once_with(
+                'https://www.testURL.com',
+                headers={'User-agent': 'Mozilla/5.0'}
+            )
             mockReq.assert_called_once()
 
     def test_getProxyResponse_redirect_success(self, testApp, mocker):
         mockHead = mocker.patch.object(requests, 'head')
         mockHead.side_effect = [
-            mocker.MagicMock(status_code=301, headers={'Location': 'redirectURL'}),
+            mocker.MagicMock(status_code=301, headers={'Location': '/redirectURL'}),
             mocker.MagicMock(status_code=200)
         ]
 
@@ -109,7 +112,7 @@ class TestEditionBlueprint:
             content='Test Content'
         )
 
-        with testApp.test_request_context('/?proxy_url=testURL'):
+        with testApp.test_request_context('/?proxy_url=https://www.testURL.com'):
             testAPIResponse = getProxyResponse()
 
             assert isinstance(testAPIResponse, Response)
@@ -118,7 +121,7 @@ class TestEditionBlueprint:
             assert testAPIResponse.headers['Media-Type'] == 'allow'
 
             mockHead.assert_has_calls([
-                mocker.call('testURL', headers={'User-agent': 'Mozilla/5.0'}),
-                mocker.call('redirectURL', headers={'User-agent': 'Mozilla/5.0'})]
+                mocker.call('https://www.testURL.com', headers={'User-agent': 'Mozilla/5.0'}),
+                mocker.call('https://www.testURL.com/redirectURL', headers={'User-agent': 'Mozilla/5.0'})]
             )
             mockReq.assert_called_once()

--- a/tests/unit/test_sfrCluster_process.py
+++ b/tests/unit/test_sfrCluster_process.py
@@ -274,9 +274,11 @@ class TestSFRClusterProcess:
 
         testIDs = testInstance.queryIdens(['1|test', '2|test', '3|test'])
 
-        assert testIDs == [1, 2, 3]
+        assert testIDs == [1, 2]
         assert mockGetBatches.call_count == 4
-        mockCompareTitles.assert_called_once_with('title4')
+        mockCompareTitles.assert_has_calls([
+            mocker.call('title3'), mocker.call('title4')
+        ])
 
     def test_queryIdens_exceed_cluster_threshold(self, testInstance, mocker):
         mockGetBatch = mocker.patch.object(ClusterProcess, 'getRecordBatches')


### PR DESCRIPTION
This implements a simple fix for the proxy endpoint that handles relative redirects from source files. It resolves these using the extracted scheme and netloc of the original url, which must contain these values.

In addition this tweaks the settings for the clustering process to produce more accurate work records.