### PR TITLE
NOREF Add explicit embed flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixed
 - Improve clustering stability by improving individual error handling
 - Handle relative links from redirects in proxy endpoint
+- Add `embed` flag for HTML links
 
 ## 2021-09-09 -- v0.9.1
 ### Fixed

--- a/mappings/doab.py
+++ b/mappings/doab.py
@@ -48,7 +48,7 @@ class DOABMapping(XMLMapping):
             'subjects': [('./datacite:subject/text()', '{0}||')],
             'has_part': [(
                 './dc:identifier/text()',
-                '1|{0}|doab|text/html|{{"reader": false, "download": false, "catalog": false}}'
+                '1|{0}|doab|text/html|{{"reader": false, "download": false, "catalog": false, "embed": true}}'
             )],
             'rights': [
                 (

--- a/mappings/hathitrust.py
+++ b/mappings/hathitrust.py
@@ -86,7 +86,7 @@ class HathiMapping(CSVMapping):
             'https://babel.hathitrust.org/cgi/pt?id={}'.format(self.source[0]),
             'hathitrust',
             'text/html',
-            json.dumps({'reader': False, 'download': False, 'catalog': False})
+            json.dumps({'reader': False, 'download': False, 'catalog': False, 'embed': True})
         )
 
         self.record.has_part = [readOnlineLink]

--- a/mappings/met.py
+++ b/mappings/met.py
@@ -34,7 +34,7 @@ class METMapping(JSONMapping):
             ],
             'subjects': [('subjec', '{0}||')],
             'rights': (['rights', 'copyra', 'copyri'], 'met|{0}|{1}|{2}|'),
-            'has_part': [('link', '1|{0}|met|text/html|{{}}')]
+            'has_part': [('link', '1|{0}|met|text/html|{{"catalog": false, "download": false, "reader": false, "embed": true}}')]
         }
 
     def applyFormatting(self):

--- a/mappings/muse.py
+++ b/mappings/muse.py
@@ -57,7 +57,7 @@ class MUSEMapping(MARCMapping):
             ],
             'is_part_of': ('490', '{a}|{v}|volume'),
             'has_part': [
-                ('856', '1|{u}|muse|text/html|{{"reader": false, "download": false, "catalog": false}}')
+                ('856', '1|{u}|muse|text/html|{{"reader": false, "download": false, "catalog": false, "embed": true}}')
             ]
         }
 

--- a/mappings/nypl.py
+++ b/mappings/nypl.py
@@ -68,7 +68,7 @@ class NYPLMapping(SQLMapping):
                 ('656', '{a}|{2}|'),
                 ('690', '{a} -- {b} -- {v} -- {x} -- {z}|lcsh|{0}'),
             ],
-            'has_part': [('856', '1|{u}|nypl|text/html|{{"catalog": false, "download": false, "reader": false}}')],
+            'has_part': [('856', '1|{u}|nypl|text/html|{{"catalog": false, "download": false, "reader": false, "embed": true}}')],
         }
 
     def applyMapping(self):

--- a/mappings/oclcCatalog.py
+++ b/mappings/oclcCatalog.py
@@ -152,7 +152,7 @@ class CatalogMapping(XMLMapping):
                     '//oclc:datafield[@tag=\'856\']/oclc:subfield[@code=\'u\']/text()',
                     '//oclc:datafield[@tag=\'856\']/@ind1'
                 ],
-                '1|{0}|oclc|text/html|{{"download": false, "reader": false, "catalog": false, "marcInd1": "{1}"}}'
+                '1|{0}|oclc|text/html|{{"download": false, "reader": false, "catalog": false, "embed": true, "marcInd1": "{1}"}}'
             )]
         }
 

--- a/tests/unit/test_hathitrust_mapping.py
+++ b/tests/unit/test_hathitrust_mapping.py
@@ -65,7 +65,7 @@ class TestHathingMapping:
         assert testMapping.record.contributors == ['Contributor|test']
         assert testMapping.record.rights == 'hathitrust|test|Test Reason|Test License|'
         assert testMapping.record.has_part == [
-            '1|https://babel.hathitrust.org/cgi/pt?id=recordID|hathitrust|text/html|{"reader": false, "download": false, "catalog": false}',
+            '1|https://babel.hathitrust.org/cgi/pt?id=recordID|hathitrust|text/html|{"reader": false, "download": false, "catalog": false, "embed": true}',
             '1|https://babel.hathitrust.org/cgi/imgsrv/download/pdf?id=recordID|hathitrust|application/pdf|{"reader": false, "download": true, "catalog": false}',
         ]
         assert testMapping.record.spatial == 'Test Country'
@@ -90,5 +90,5 @@ class TestHathingMapping:
 
         assert len(testMapping.record.has_part) == 1
         assert testMapping.record.has_part == [
-            '1|https://babel.hathitrust.org/cgi/pt?id=recordID|hathitrust|text/html|{"reader": false, "download": false, "catalog": false}'
+            '1|https://babel.hathitrust.org/cgi/pt?id=recordID|hathitrust|text/html|{"reader": false, "download": false, "catalog": false, "embed": true}'
         ]


### PR DESCRIPTION
To make it easier for the DRB front end (and other applications) to identify "embedable" HTML book links this adds an explicit `embed: true` flag on these link objects. Previously it was assumed that this could be infered but it is more reliable and transparent to provide a positive flag for this functionality