### PR TITLE
NOREF Improve proxy endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Improve clustering stability by improving individual error handling
 - Handle relative links from redirects in proxy endpoint
 - Add `embed` flag for HTML links
+- Extended settings for `utils/proxy` epndoint to be more flexible
 
 ## 2021-09-09 -- v0.9.1
 ### Fixed

--- a/api/blueprints/drbUtils.py
+++ b/api/blueprints/drbUtils.py
@@ -93,10 +93,5 @@ def getProxyResponse():
         if k.lower() not in excludedHeaders
     ]
 
-    headers.append((
-        'Access-Control-Allow-Origin',
-        os.environ.get('API_PROXY_CORS_ALLOWED', '*')
-    ))
-
     proxyResp = Response(resp.content, resp.status_code, headers)
     return proxyResp

--- a/api/blueprints/drbUtils.py
+++ b/api/blueprints/drbUtils.py
@@ -47,7 +47,7 @@ def totalCounts():
     return APIUtils.formatResponseObject(200, 'totalCounts', totalsSummary)
 
 
-@utils.route('/proxy', methods=['GET', 'POST', 'PUT', 'HEAD'])
+@utils.route('/proxy', methods=['GET', 'POST', 'PUT', 'HEAD', 'OPTIONS'])
 @cross_origin(origins=os.environ.get('API_PROXY_CORS_ALLOWED', '*'))
 def getProxyResponse():
     proxyUrl = request.args.get('proxy_url')
@@ -92,6 +92,11 @@ def getProxyResponse():
         (k, v) for (k, v) in resp.headers.items()
         if k.lower() not in excludedHeaders
     ]
+
+    headers.append((
+        'Access-Control-Allow-Origin',
+        os.environ.get('API_PROXY_CORS_ALLOWED', '*')
+    ))
 
     proxyResp = Response(resp.content, resp.status_code, headers)
     return proxyResp

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -1,40 +1,51 @@
+# LOGGING
+LOG_LEVEL: info
+
 # POSTGRES CONNECTION DETAILS
 # POSTGRES_USER, POSTGRES_PSWD, POSTGRES_ADMIN_USER and POSTGRES_ADMIN_PSWD must be configured in secrets file 
-# POSTGRES_HOST: ''
-# POSTGRES_NAME: ''
-# POSTGRES_PORT: ''
+POSTGRES_HOST: sfr-new-metadata-production-cluster.cluster-cvy7z512hcjg.us-east-1.rds.amazonaws.com
+POSTGRES_NAME: dcdw_qa
+POSTGRES_PORT: '5432'
 
 # REDIS CONFIGURATION
-# REDIS_HOST: ''
-# REDIS_PORT: ''
+# REDIS_HOST configured as part of ECS deployment
+REDIS_PORT: '6379'
 
 # ELASTICSEARCH CONFIGURATION
 # ELASTICSEARCH_INDEX, ELASTICSEARCH_HOST must be configured in secrets file
-# ELASTICSEARCH_PORT: ''
-# ELASTICSEARCH_TIMEOUT: ''
+ELASTICSEARCH_PORT: '443'
+ELASTICSEARCH_TIMEOUT: '5'
 
 # RABBITMQ CONFIGURATION
-# RABBIT_HOST: ''
-# RABBIT_PORT: ''
-OCLC_QUEUE: oclc_catalog
-EPUB_QUEUE: epub_files
+# RABBIT_USER and RABBIT_PSWD must be configured in secrets file
+RABBIT_HOST: qa.rmq.aws.nypl.org
+RABBIT_PORT: '5672'
+RABBIT_VIRTUAL_HOST: /sfr
+RABBIT_EXCHANGE: sfrIngestExchange
+OCLC_QUEUE: sfrOCLCCatalog
+OCLC_ROUTING_KEY: sfrOCLCCatalog
+FILE_QUEUE: sfrS3Files
+FILE_ROUTING_KEY: sfrS3Files
 
 # HATHITRUST CONFIGURATION
+# HATHI_API_KEY and HATHI_API_SECRET must be configured as secrets
 HATHI_DATAFILES: https://www.hathitrust.org/filebrowser/download/244651
+HATHI_API_ROOT: https://babel.hathitrust.org/cgi/htd
 
 # OCLC CONFIGURATION
 # OCLC_API_KEY must be configured in secrets file
+OCLC_QUERY_LIMIT: '390000'
 
 # AWS CONFIGURATION
 # AWS_ACCESS and AWS_SECRET must be configured in secrets file
-AWS_REGION: 'us-east-1'
-EPUB_BUCKET: 'sfr_files'
+AWS_REGION: us-east-1
+FILE_BUCKET: drb-files-qa
 
 # NYPL BIB REPLICA DB CONNECTION
-# NYPL_BIB_USER, NYPL_BIB_PSWD must be configured in secrets file
-# NYPL_BIB_HOST: ''
-# NYPL_BIB_NAME: ''
-# NYPL_BIB_PORT: ''
+# NYPL_BIB_USER and NYPL_BIB_PSWD must be configured in secrets file
+NYPL_BIB_HOST: bib-service-production-rep.cvy7z512hcjg.us-east-1.rds.amazonaws.com
+NYPL_BIB_NAME: bib_service_production
+NYPL_BIB_PORT: '5432'
 
 # NYPL Location Code Lookup
 NYPL_LOCATIONS_BY_CODE: https://nypl-core-objects-mapping-qa.s3.amazonaws.com/by_sierra_location.json
@@ -52,9 +63,23 @@ BARDO_CCE_API: http://sfr-bardo-copyright-development.us-east-1.elasticbeanstalk
 
 # Project MUSE MARC endpoint
 MUSE_MARC_URL: https://about.muse.jhu.edu/lib/metadata?format=marc&content=book&include=oa&filename=open_access_books&no_auth=1
+MUSE_CSV_URL: https://about.muse.jhu.edu/static/org/local/holdings/muse_book_metadata.csv
 
 # DOAB OAI-PMH endpoint
-DOAB_OAI_URL: http://www.doabooks.org/oai?
+DOAB_OAI_URL: https://directory.doabooks.org/oai/request?
+
+# Google Books API
+# GOOGLE_BOOKS_KEY must be configured as a secret
+
+# ContentCafe2 API
+# CONTENT_CAFE_USER and CONTENT_CAFE_PSWD must be configured as secrets
+
+# SmartSheet API
+# SMARTSHEET_API_TOKEN must be configured as a secret
+SMARTSHEET_SHEET_ID: '3683038090553220'
+
+# Default Cover Image for OPDS2 Feed
+DEFAULT_COVER_URL: https://drb-files-qa.s3.amazonaws.com/covers/default/defaultCover.png
 
 # ePub-to-Webpub Conversion Service
 WEBPUB_CONVERSION_URL: https://epub-to-webpub.vercel.app

--- a/task-definition.json
+++ b/task-definition.json
@@ -17,12 +17,12 @@
             "essential": true,
             "command": [
                 "--process", "APIProcess",
-                "--environment", "qa"
+                "--environment", "development"
             ],
             "environment": [
                 {
                     "name": "ENVIRONMENT",
-                    "value": "qa"
+                    "value": "development"
                 },
                 {
                     "name": "ELASTICSEARCH_HOST",

--- a/tests/unit/test_api_utils_blueprint.py
+++ b/tests/unit/test_api_utils_blueprint.py
@@ -91,6 +91,8 @@ class TestEditionBlueprint:
             assert testAPIResponse.status_code == 200
             assert testAPIResponse.response == [b'Test Content']
             assert testAPIResponse.headers['Media-Type'] == 'allow'
+            assert testAPIResponse.headers['Access-Control-Allow-Origin'] ==\
+                '*'
 
             mockHead.assert_called_once_with(
                 'https://www.testURL.com',


### PR DESCRIPTION
This extends some settings for the proxy endpoint, allowing it to accept `OPTION` requests, which are necessary for the CORS preflight checks to pass