### PR TITLE
NOREF improve format filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Handle relative links from redirects in proxy endpoint
 - Add `embed` flag for HTML links
 - Extended settings for `utils/proxy` epndoint to be more flexible
+- Resolve issue with display of links when filtering by format
 
 ## 2021-09-09 -- v0.9.1
 ### Fixed

--- a/api/utils.py
+++ b/api/utils.py
@@ -13,11 +13,11 @@ class APIUtils():
     ]
 
     FORMAT_CROSSWALK = {
-        'epub_zip': ['application/epub+zip', 'application/epub+xml', 'application/webpub+json'],
-        'epub_xml': ['application/epub+zip', 'application/epub+xml', 'application/webpub+json'],
+        'epub_zip': ['application/epub+zip', 'application/epub+xml'],
+        'epub_xml': ['application/epub+zip', 'application/epub+xml'],
         'html': ['text/html'],
         'html_edd': ['application/html+edd', 'application/x.html+edd'],
-        'pdf': ['application/pdf', 'application/webpub+json'],
+        'pdf': ['application/pdf'],
         'webpub_json': ['application/webpub+json']
     }
 
@@ -199,18 +199,13 @@ class APIUtils():
 
             itemDict['links'] = []
 
-            validLinks = list(filter(lambda x: x.media_type in formats, item.links))\
-                if formats else item.links
-
-            if (
-                len(validLinks) < 1
-                or (
-                    formats
-                    and len(validLinks) == 1
-                    and validLinks[0].media_type == 'application/webpub+json'
-                )
-            ):
-                continue
+            if formats:
+                formats.append('application/webpub+json')
+                validLinks = list(filter(
+                    lambda x: x.media_type in formats, item.links
+                ))
+            else:
+                validLinks = item.links
 
             for link in validLinks:
                 flags = link.flags

--- a/tests/unit/test_api_es.py
+++ b/tests/unit/test_api_es.py
@@ -665,14 +665,14 @@ class TestElasticClient:
             mocker.call('exists', field='editions.formats'),
             mocker.call(
                 'terms',
-                editions__formats=['application/pdf', 'application/webpub+json', 'application/html+edd', 'application/x.html+edd']
+                editions__formats=['application/pdf', 'application/html+edd', 'application/x.html+edd']
             )
         ])
         mockAgg.assert_has_calls([
             mocker.call('filter', exists={'field': 'editions.formats'}),
             mocker.call(
                 'filter',
-                terms={'editions.formats': ['application/pdf', 'application/webpub+json', 'application/html+edd', 'application/x.html+edd']}
+                terms={'editions.formats': ['application/pdf', 'application/html+edd', 'application/x.html+edd']}
             )
         ])
 


### PR DESCRIPTION
An issue when filtering with formats was due to a conflict with how webpub manifests must be handled. This removes that format from basic filtering and adds it back to criteria when necessary. This simplifies the process and ensures that the filters work conceptually as they would be expected to.