### PR TITLE
NOREF Put Webpub links at top of link arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unreleased -- v0.9.4
+### Fixed
+- Updated order of links for new reader
+
 ## 2021-10-04 -- v0.9.3
 ### Added
 - ElasticSearch query highlighting

--- a/api/utils.py
+++ b/api/utils.py
@@ -273,11 +273,11 @@ class APIUtils():
     @staticmethod
     def sortByMediaType(link):
         scores = {
-            'application/epub+xml': 1, 'application/epub+zip': 1,
+            'application/webpub+json': 1,
             'text/html': 2,
             'application/pdf': 3,
             'application/html+edd': 4,
-            'application/webpub+json': 5
+            'application/epub+xml': 5, 'application/epub+zip': 5,
         }
 
         return scores[link['mediaType']]

--- a/tests/unit/test_api_utils.py
+++ b/tests/unit/test_api_utils.py
@@ -581,8 +581,8 @@ class TestAPIUtils:
 
         shuffle(testList)
         testList.sort(key=APIUtils.sortByMediaType)
-        assert [i['id'] for i in testList] == [1, 1, 2, 3, 4, 5]
+        assert [i['id'] for i in testList] == [5, 2, 3, 4, 1, 1]
 
         shuffle(testList)
         testList.sort(key=APIUtils.sortByMediaType)
-        assert [i['id'] for i in testList] == [1, 1, 2, 3, 4, 5]
+        assert [i['id'] for i in testList] == [5, 2, 3, 4, 1, 1]


### PR DESCRIPTION
Webpub manifests should be given priority in all cases because they provide the best reading experience.