### PR TITLE
SFR-1387 Improve proxy redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unreleased -- v0.9.5
+### Fixed
+- Improved redirect handling in proxy endpoint
+
 ## 2021-10-28 -- v0.9.4
 ### Fixed
 - Updated order of links for new reader

--- a/api/blueprints/drbUtils.py
+++ b/api/blueprints/drbUtils.py
@@ -62,15 +62,22 @@ def getProxyResponse():
         )
 
         statusCode = headResp.status_code
+        print(statusCode, cleanUrl)
         if statusCode in [200, 204]:
             break
         elif statusCode in [301, 302, 303, 307, 308]:
+            print(headResp.headers)
             cleanUrl = headResp.headers['Location']
 
             if cleanUrl[0] == '/':
                 cleanUrl = '{}://{}{}'.format(
                     urlParts.scheme, urlParts.netloc, cleanUrl
                 )
+        else:
+            logger.warn('Unable to proxy URL {}'.format(cleanUrl))
+            cleanUrl = proxyUrl
+            break
+
 
     resp = requests.request(
         method=request.method,


### PR DESCRIPTION
In rare cases (from a subset of publishers) `302` redirects may exhibit odd behavior that prevents them from being handled in a standard way. This inserts a fallback that relies on the `requests` module parsing of the redirect. While generally this can have issues, these edge case redirects are accurately handled by the module (as it more closely represents a browser environment).