### PR TITLE
NOREF Fix QA CORS Vercel Integration

### DIFF
--- a/config/qa.yaml
+++ b/config/qa.yaml
@@ -88,7 +88,7 @@ WEBPUB_CONVERSION_URL: https://epub-to-webpub.vercel.app
 WEBPUB_PDF_PROFILE: http://librarysimplified.org/terms/profiles/pdf
 
 # Allowed sources of CORS requests to proxy endpoint
-API_PROXY_CORS_ALLOWED: (?:http[s]?:\/\/.*nypl.org|https:\/\/nypl-web-reader.vercel.app|http[s]?:\/\/.*tugboat.qa)
+API_PROXY_CORS_ALLOWED: (?:http[s]?:\/\/.*nypl.org|https:\/\/.*nypl.*vercel.app|http[s]?:\/\/.*tugboat.qa)
 
 # Current NYPL Webreader version
 READER_VERSION: v2


### PR DESCRIPTION
At present "test" deployments of the ePub-to-Webpub application on Vercel fail because they rely on the DRB API QA instance to proxy materials. This is because the CORS headers are set to be too restrictive. This should relax that requirement somewhat to enable these requests.