### PR TITLE
HOTFIX ElasticSearch 8 Fixes

### DIFF
--- a/.github/workflows/tests-unit.yaml
+++ b/.github/workflows/tests-unit.yaml
@@ -35,6 +35,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r dev-requirements.txt
           pip install -r requirements.txt
+          pip install elasticsearch>8.0.0
       - name: Run test suite
         run: |
           make test

--- a/.github/workflows/tests-unit.yaml
+++ b/.github/workflows/tests-unit.yaml
@@ -35,7 +35,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r dev-requirements.txt
           pip install -r requirements.txt
-          pip install elasticsearch>8.0.0
       - name: Run test suite
         run: |
           make test

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 manifests/secrets-*.yaml
 config/*
 /allure-results
+/scripts/*.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## unreleased -- v0.10.1
+### Added
+- Query parameter to manifest ProjectMuse url links
+### Fixed
+- JSON Decoder error for interstitial pages script
+- ES 8.x+ timeout configuration and OPDS2 integration
+
 ## 2022-04-04 -- v0.10.0
 ### Added
 - Method in sfrRecord manager to check for reasonable publication dates for editions
@@ -8,7 +15,6 @@
 - Blueprint for a citation generator 
 - MLA Citation rules to citation generator
 - ElasticSearch 7.10+ language per-field indexing & searching
-- Query parameter to manifest ProjectMuse url links
 ### Fixed
 - Classify Performance improvements
 - Improved stability during clustering processes
@@ -18,7 +24,6 @@
 - Modified MLA citation rules
 - Deduplicated MLA citation generator
 - Replaced polyglot with fasttext for language detection
-- JSON Decoder error for interstitial pages script
 
 ## 2022-01-25 -- v0.9.6
 ### Fixed

--- a/api/blueprints/drbOPDS2.py
+++ b/api/blueprints/drbOPDS2.py
@@ -86,7 +86,7 @@ def opdsSearch():
     for res in searchResult.hits:
         editionIds = [e.edition_id for e in res.meta.inner_hits.editions.hits]
 
-        if res.meta.highlight:
+        if getattr(res.meta, 'highlight', None):
             highlights[res.uuid] = {
                 key: list(set(res.meta.highlight[key]))
                 for key in res.meta.highlight
@@ -101,7 +101,7 @@ def opdsSearch():
     )
 
     OPDSUtils.addPagingOptions(
-        searchFeed, request.full_path, searchResult.hits.total,
+        searchFeed, request.full_path, searchResult.hits.total.value,
         page=page+1, perPage=pageSize
     )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 alembic
 beautifulsoup4
 boto3
+elastic-transport
 elasticsearch-dsl>7.0.0
 elasticsearch==7.16.3
 fasttext

--- a/tests/unit/test_api_opds_blueprint.py
+++ b/tests/unit/test_api_opds_blueprint.py
@@ -54,7 +54,7 @@ class TestOPDSBlueprint:
     def mockHits(self, FakeHit, mocker):
         class FakeHits:
             def __init__(self):
-                self.total = 5
+                self.total = mocker.MagicMock(value=5)
                 self.hits = [
                     FakeHit('uuid1', ['ed1', 'ed2']),
                     FakeHit('uuid2', ['ed3']),

--- a/tests/unit/test_es_manager.py
+++ b/tests/unit/test_es_manager.py
@@ -36,7 +36,10 @@ class TestElasticsearchManager:
         )
 
         mockClient.assert_called_once_with(
-            hosts=['http://testUser:testPswd@host:port']
+            hosts=['http://testUser:testPswd@host:port'],
+            timeout=1000,
+            retry_on_timeout=True,
+            max_retries=3
         )
 
     def test_createELasticSearchIndex_execute(self, testInstance, mocker):


### PR DESCRIPTION
DRB was recently updated to use the latest ElasticSearch 8.x release version, which necessitated several updates of internal logic. A few aspects were missed or not fully understood in this process:

- The OPDS2 client was not updated to take into account changes to the `meta` and `total` objects in the ES response
- Timeouts were not properly applied to the ElasticSearch client used for bulk indexing

In addition to this a few changes were made to clean up some dangling logs and update tests