### PR TITLE
Sfr 1469 date in api response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Getter and setter method for record model 
 - Script to extract edition number from edition statement for the edition field
 - Script to update future records with edition number in the has_version field
+- Date created and date modified values visible in API Response for work and search endpoint
 ### Fixed
 - ES8 API only counting up to 10,000 search results
 - Add bulk retry functionality for ES writes/deletes

--- a/api/blueprints/drbWork.py
+++ b/api/blueprints/drbWork.py
@@ -24,11 +24,7 @@ def workFetch(uuid):
 
     if work:
         statusCode = 200
-        responseBody = {'work': APIUtils.formatWorkOutput(
-                        work, None, showAll=showAll, reader=readerVersion),
-                        'date_created': work.date_created, 
-                        'date_modified': work.date_modified
-                        }
+        responseBody = APIUtils.formatWorkOutput(work, None, showAll=showAll, reader=readerVersion)
         
     else:
         statusCode = 404

--- a/api/blueprints/drbWork.py
+++ b/api/blueprints/drbWork.py
@@ -24,9 +24,12 @@ def workFetch(uuid):
 
     if work:
         statusCode = 200
-        responseBody = APIUtils.formatWorkOutput(
-            work, None, showAll=showAll, reader=readerVersion
-        )
+        responseBody = {'work': APIUtils.formatWorkOutput(
+                        work, None, showAll=showAll, reader=readerVersion),
+                        'date_created': work.date_created, 
+                        'date_modified': work.date_modified
+                        }
+        
     else:
         statusCode = 404
         responseBody = {

--- a/api/utils.py
+++ b/api/utils.py
@@ -155,6 +155,8 @@ class APIUtils():
     def formatWork(cls, work, editionIds, showAll, formats=None, reader=None):
         workDict = dict(work)
         workDict['edition_count'] = len(work.editions)
+        workDict['date_created'] = work.date_created
+        workDict['date_modified'] = work.date_modified
 
         orderedEds = OrderedDict.fromkeys(editionIds)\
             if editionIds else OrderedDict()

--- a/api/utils.py
+++ b/api/utils.py
@@ -155,8 +155,8 @@ class APIUtils():
     def formatWork(cls, work, editionIds, showAll, formats=None, reader=None):
         workDict = dict(work)
         workDict['edition_count'] = len(work.editions)
-        workDict['date_created'] = work.date_created
-        workDict['date_modified'] = work.date_modified
+        workDict['date_created'] = work.date_created.strftime('%Y-%m-%dT%H:%M:%S')
+        workDict['date_modified'] = work.date_modified.strftime('%Y-%m-%dT%H:%M:%S')
 
         orderedEds = OrderedDict.fromkeys(editionIds)\
             if editionIds else OrderedDict()

--- a/tests/unit/test_api_utils.py
+++ b/tests/unit/test_api_utils.py
@@ -3,7 +3,7 @@ import pytest
 from random import shuffle
 
 from api.utils import APIUtils
-
+from datetime import datetime
 
 class TestAPIUtils:
     @pytest.fixture
@@ -44,7 +44,7 @@ class TestAPIUtils:
                 self.attrs = []
                 for key, value in kwargs.items():
                     self.attrs.append(key)
-                    setattr(self, key, value)
+                    setattr(self, key, value)     
 
             def __iter__(self):
                 for attr in self.attrs:
@@ -72,6 +72,8 @@ class TestAPIUtils:
             contributors=['contrib1', 'contrib2'],
             publisher=['pub1'],
             dates=['date1', 'date2'],
+            date_created = 'Test Created Date',
+            date_modified = 'Test Modified Date',
             languages=['lang1'],
             identifiers=['id1', 'id2', 'id3'],
             has_part=['1|url1|', '2|url2|', '3|url3|']
@@ -142,6 +144,8 @@ class TestAPIUtils:
             uuid='testUUID',
             title='Test Title',
             editions=[testEdition],
+            date_created = datetime.strptime('2022-05-12T10:00:41', '%Y-%m-%dT%H:%M:%S'),
+            date_modified = datetime.strptime('2022-05-13T10:00:44', '%Y-%m-%dT%H:%M:%S'),
         )
 
     def test_normalizeQueryParams(self, mocker):
@@ -302,6 +306,8 @@ class TestAPIUtils:
         assert testWorkDict['editions'][0]['edition_id'] == 'ed1'
         assert testWorkDict['editions'][0]['items'][0] == 'it1'
         assert testWorkDict['edition_count'] == 1
+        assert testWorkDict['date_created'] == '2022-05-12T10:00:41'
+        assert testWorkDict['date_modified'] == '2022-05-13T10:00:44'
         mockFormatEdition.assert_called_once()
 
     def test_formatWork_showAll_false(self, testWork, mocker):
@@ -315,6 +321,8 @@ class TestAPIUtils:
         assert testWorkDict['title'] == 'Test Title'
         assert len(testWorkDict['editions']) == 1
         assert testWorkDict['edition_count'] == 1
+        assert testWorkDict['date_created'] == '2022-05-12T10:00:41'
+        assert testWorkDict['date_modified'] == '2022-05-13T10:00:44'
 
     def test_formatWork_blocked_edition(self, testWork):
         testWork.editions[0].items = []
@@ -324,6 +332,8 @@ class TestAPIUtils:
         assert testWorkDict['title'] == 'Test Title'
         assert len(testWorkDict['editions']) == 0
         assert testWorkDict['edition_count'] == 1
+        assert testWorkDict['date_created'] == '2022-05-12T10:00:41'
+        assert testWorkDict['date_modified'] == '2022-05-13T10:00:44'
 
     def test_formatWork_ordered_editions(self, testWork, mocker):
         testWork.editions = [mocker.MagicMock(id=1), mocker.MagicMock(id=2)]


### PR DESCRIPTION
I'm not sure if I should insert a space between the d and T, so it's clearer to see the date properly in the API Response or if it should stay this way since it needs to be there no space for the regression tests.