### PR TITLE
HOTFIX Add has_version None handler

### DIFF
--- a/model/postgres/record.py
+++ b/model/postgres/record.py
@@ -66,7 +66,9 @@ class Record(Base, Core):
 
     @has_version.setter
     def has_version(self, versionNum):
-        if self.languages != [] and self.languages != None:
+        if versionNum is None:
+            self._has_version = versionNum
+        elif self.languages != [] and self.languages != None:
             editionNo = extract(versionNum, self.languages[0].split('|')[0])
             self._has_version = f'{versionNum}|{editionNo}'
         else:

--- a/tests/unit/test_model_record.py
+++ b/tests/unit/test_model_record.py
@@ -17,6 +17,11 @@ class TestModelRecord:
         testRecord.has_version = 'first edition'
         assert testRecord.has_version == 'first edition|1'
 
+    # Test to assert that the setter properly handles null values
+    def test_no_edition(self, testRecord):
+        testRecord.has_version = None
+        assert testRecord.has_version is None
+
     # Failed Test for setter method
     def test_has_version_failure(self, testRecord):
         testRecord.has_version = 'other edition'


### PR DESCRIPTION
This is a minor fix to an edge case where no edition statement (`has_version`) in the `Record` table model is present