### PR TITLE
HOTFIX Update Vercel CORS string

### DIFF
--- a/config/qa.yaml
+++ b/config/qa.yaml
@@ -89,7 +89,7 @@ WEBPUB_CONVERSION_URL: https://epub-to-webpub.vercel.app
 WEBPUB_PDF_PROFILE: http://librarysimplified.org/terms/profiles/pdf
 
 # Allowed sources of CORS requests to proxy endpoint
-API_PROXY_CORS_ALLOWED: (?:http[s]?:\/\/.*nypl.org|https:\/\/.*nypl.*vercel.app|http[s]?:\/\/.*tugboat.qa)
+API_PROXY_CORS_ALLOWED: (?:http[s]?:\/\/.*nypl.org|https:\/\/.*(?:nypl|sfr).*vercel.app|http[s]?:\/\/.*tugboat.qa)
 
 # Current NYPL Webreader version
 READER_VERSION: v2


### PR DESCRIPTION
This updates our CORS configuration to accept requests from a new format of URLs from the now Vercel-hosted QA environment