### PR TITLE
NOREF Fix DOAB single record import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Work title and authors info only show up in edition endpoint now
 - Editions and utils tests updated and fixed
 - All toc object url links in ProjectMuse manifests have a query parameter now
+- Update DOAB single record import to reflect new OAI-PMH structure
 
 ## 2022-05-19 -- v0.10.3
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,8 @@
 - Work title and authors info only show up in edition endpoint now
 - Editions and utils tests updated and fixed
 - All toc object url links in ProjectMuse manifests have a query parameter now
-<<<<<<< HEAD
 - Update DOAB single record import to reflect new OAI-PMH structure
-=======
 - Deleted extra urls in toc object of Muse manifests 
->>>>>>> main
 
 ## 2022-05-19 -- v0.10.3
 ### Added

--- a/processes/doab.py
+++ b/processes/doab.py
@@ -84,7 +84,8 @@ class DOABProcess(CoreProcess):
 
         if doabResponse.status_code == 200:
             content = BytesIO(doabResponse.content)
-            oaidcRecord = etree.parse(content)
+            oaidcXML = etree.parse(content)
+            oaidcRecord = oaidcXML.xpath('//oai_dc:dc', namespaces=self.OAI_NAMESPACES)[0]
 
             try:
                 self.parseDOABRecord(oaidcRecord)

--- a/tests/unit/test_doab_process.py
+++ b/tests/unit/test_doab_process.py
@@ -110,8 +110,10 @@ class TestDOABProcess:
         mockGet = mocker.patch.object(requests, 'get')
         mockGet.return_value = mockResponse
 
+        mockXML = mocker.MagicMock()
+        mockXML.xpath.return_value = ['mockOAIRecord']
         mockEtree = mocker.patch('processes.doab.etree')
-        mockEtree.parse.return_value = 'mockOAIRecord'
+        mockEtree.parse.return_value = mockXML
 
         mockParseRecord = mocker.patch.object(DOABProcess, 'parseDOABRecord')
 
@@ -130,8 +132,10 @@ class TestDOABProcess:
         mockGet = mocker.patch.object(requests, 'get')
         mockGet.return_value = mockResponse
 
+        mockXML = mocker.MagicMock()
+        mockXML.xpath.return_value = ['mockOAIRecord']
         mockEtree = mocker.patch('processes.doab.etree')
-        mockEtree.parse.return_value = 'mockOAIRecord'
+        mockEtree.parse.return_value = mockXML
 
         mockParseRecord = mocker.patch.object(DOABProcess, 'parseDOABRecord')
         mockParseRecord.side_effect = DOABError('test')


### PR DESCRIPTION
The method to import individual DOAB records (used for testing and dev purposes) had broken due to a change in DOAB's OAI-PMH feed. This updates the method to accurately extract the correct XML object that can be understood by the DOAB mapping.