### PR TITLE
NOREF Fix media_type handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - New script to update past IntechOpen records with new HTML links
 - Exposed entire authors object to the edition details page
 ### Fixed
-- 
+- Added improved error handling around unexpected `media_type` values
 
 ## 2022-06-09 -- v0.10.4
 ### Added

--- a/api/utils.py
+++ b/api/utils.py
@@ -303,10 +303,13 @@ class APIUtils():
             'text/html': 2,
             'application/pdf': 3,
             'application/html+edd': 4,
-            'application/epub+xml': 5, 'application/epub+zip': 5,
+            'application/x.html+edd': 4,
+            'application/epub+xml': 5,
+            'application/epub+zip': 5,
+            'application/html+catalog': 6
         }
 
-        return scores[link['mediaType']]
+        return scores.get(link['mediaType'], 7)
 
     @classmethod
     def formatRecord(cls, record, itemsByLink):


### PR DESCRIPTION
In previous versions of the API, unexpected `media_type`s caused a `500` error. This allows for handling of these values, and extends the current lookup dictionary to anticipate some upcoming improvements