### PR TITLE
Sfr 1498 update es catalog links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Exposed entire authors object to the edition details page
 ### Fixed
 - Added improved error handling around unexpected `media_type` values
+- Improve handling of NYPL Catalog records without EDD links
 
 ## 2022-06-09 -- v0.10.4
 ### Added

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,2 +1,3 @@
 from .extractAllEditions import main as editionExtraction
 from .updateOldInTechOpenLinks import main as updateInTechOpenLinks
+from .updateESEditionFormats import main as updateESEditionFormats

--- a/scripts/updateESEditionFormats.py
+++ b/scripts/updateESEditionFormats.py
@@ -1,0 +1,87 @@
+import os
+import re
+
+from model import Work, Item, Edition, ESWork
+from main import loadEnvFile
+from managers import DBManager, ElasticsearchManager
+
+
+def main():
+    '''
+    Updating NYPL catalog records with new link to replace text/html link
+    '''
+
+    loadEnvFile('local-qa', fileString='config/{}.yaml')
+
+    dbManager = DBManager(
+        user=os.environ.get('POSTGRES_USER', None),
+        pswd=os.environ.get('POSTGRES_PSWD', None),
+        host=os.environ.get('POSTGRES_HOST', None),
+        port=os.environ.get('POSTGRES_PORT', None),
+        db=os.environ.get('POSTGRES_NAME', None)
+    )
+
+    esManager = ElasticsearchManager()
+    esManager.createElasticConnection()
+
+    dbManager.generateEngine()
+
+    dbManager.createSession()
+
+    catalogLinkQuery = dbManager.session.query(Work) \
+        .join(Edition)\
+        .join(Item)\
+        .filter(Item.source == 'nypl')
+
+    for work in catalogLinkQuery.all():
+        workEdFormats = {}
+        print(work.uuid)
+        for edition in work.editions:
+            workEdFormats[edition.id] = getEditionFormats(edition.items)
+
+        workRec = ESWork.get(work.uuid, index=esManager.index)
+        saveWork = False
+
+        for edition in workRec.editions:
+            if edition.formats != workEdFormats[edition.edition_id]:
+                print('REPLACE')
+                edition.formats = workEdFormats[edition.edition_id]
+                saveWork = True
+            else:
+                print('SKIP')
+        
+        if saveWork:
+            workRec.save()
+
+    dbManager.closeConnection()
+
+
+def getEditionFormats(items):
+    formats = set()
+
+    for item in items:
+        links = [(l.media_type, l.flags) for l in item.links]
+        htmlReadable = linkCriteriaChecker(item.links, 'catalog', False)
+        htmlCatalog = linkCriteriaChecker(item.links, 'catalog', True)
+
+        if htmlReadable and htmlCatalog:
+            formats.add('text/html')
+            formats.add('application/html+catalog')
+        elif htmlReadable:
+            formats.add('text/html')
+        elif htmlCatalog:
+            formats.add('application/html+catalog')
+
+        for link in links:
+            if link[0] not in ['text/html', 'application/html+catalog']:
+                formats.add(link[0])
+
+    return list(formats) if len(formats) > 0 else None
+
+
+def linkCriteriaChecker(links, flag, value):
+    return len(list(filter(lambda x: x.flags[flag] == value and x.media_type == 'text/html', links))) > 0
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/updateESEditionFormats.py
+++ b/scripts/updateESEditionFormats.py
@@ -57,6 +57,21 @@ def main():
 
 
 def getEditionFormats(items):
+    '''Accepts an array that represent all the Items associated with an Edition
+    from the database. It builds a unique array of all the media_types of all
+    the links associated with all of the items.
+
+    In this process it replaces the media_type for any link that represents a 
+    catalog URL with the value of application/html+catalog. This more specific
+    media_type allows consuming application to distinguish catalog links from
+    other links that resolve to web pages.
+
+    Parametes:
+    items -- an array of Item ORM records, drawn from a single Edition record
+
+    Response:
+    Unique array of media_type strings or None
+    '''
     formats = set()
 
     for item in items:
@@ -80,6 +95,19 @@ def getEditionFormats(items):
 
 
 def linkCriteriaChecker(links, flag, value):
+    '''Takes the provided Link object and, if it has a media_type of text/html, 
+    evaluates it for the presence/value of a specified flag. This allows us to
+    evaluate links that have ambiguous media_types and assert whether or not it
+    meets certain criteria based on the more specific flag object.
+
+    Parameters:
+    link -- a ORM Link object
+    flag -- a key in the flag JSON object of the Link
+    value -- a boolean value that validates the expected value of the flag
+
+    Response:
+    Boolean
+    '''
     return len(list(filter(lambda x: x.flags[flag] == value and x.media_type == 'text/html', links))) > 0
 
 


### PR DESCRIPTION
This script finds all work/edition records that have a resolvable link pointing to an NYPL resource. If that resource is a link to a catalog record (not to an EDD option), the `mediaType` of that link is updated to `application/html+catalog` which prevents these links from being picked up as readable.