### PR TITLE
Added two filters for govDoc and noGovDoc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Exposed entire authors object to the edition details page
 - Two new scripts to update NYPL catalogs links in Record and Link table
 - Updated NYPL mapping and formats in APIUtils with new catalog link
+- Gov document filter for advanced search page
 ### Fixed
 - Added improved error handling around unexpected `media_type` values
 - Improve handling of NYPL Catalog records without EDD links

--- a/api/elastic.py
+++ b/api/elastic.py
@@ -343,13 +343,23 @@ class ElasticClient():
         languageFilters = list(filter(
             lambda x: x[0] == 'language', filterParams)
         )
-        formatFilters = list(filter(lambda x: x[0] == 'format', filterParams))
+        formatFilters = list(filter(
+            lambda x: x[0] == 'format', filterParams)
+        )
         displayFilters = list(filter(
             lambda x: x[0] == 'showAll', filterParams)
+        )
+        govDocFilters = list(filter(
+            lambda x: x[0] == 'govDoc', filterParams)
+        )
+        noGovDocFilters = list(filter(
+            lambda x: x[0] == 'noGovDoc', filterParams)
         )
 
         dateFilter, dateAggregation = (None, None)
         formatFilter, formatAggregation = (None, None)
+        govDocFilter, govDocAggregation = (None, None)
+        noGovDocFilter, noGovDocAggregation = (None, None)
         displayFilter, displayAggregation = (
             Q('exists', field='editions.formats'),
             A('filter', **{'exists': {'field': 'editions.formats'}})
@@ -386,6 +396,10 @@ class ElasticClient():
             formatAggregation = A(
                 'filter', **{'terms': {'editions.formats': formats}}
             )
+        
+        #if len(govDocFilters) > 0:
+
+        #if len(noGovDocFilters) > 0:
 
         if len(displayFilters) > 0 and displayFilters[0][1] == 'true':
             displayFilter = None

--- a/api/utils.py
+++ b/api/utils.py
@@ -9,7 +9,7 @@ import re
 class APIUtils():
     QUERY_TERMS = [
         'keyword', 'title', 'author', 'subject', 'viaf', 'lcnaf',
-        'date', 'startYear', 'endYear', 'language', 'format', 'showAll'
+        'date', 'startYear', 'endYear', 'language', 'format', 'govDoc', 'noGovDoc', 'showAll'
     ]
 
     FORMAT_CROSSWALK = {


### PR DESCRIPTION
To add the government document filters to the backend, I decided to first add two new QUERY_TERMS to represent the "onlyGovDoc" and "noGovDoc" filters. Then, I'm currently attempting to update the "createFilterClausesAndAggregations()" method in the Elastic API to add these two filters, but I'm struggling to understand how to format my queries for these filters especially since the measurements field of edition is a jsonb object. This object has two terms I need to search for which are the type and value that should be "government_document" as the type and "0" or "1" as the value. The two conditionals I made in this method are commented out for right now since I'm still thinking how the queries should look for both filters.