### PR TITLE
Sfr 1506 gov doc in es

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Two new scripts to update NYPL catalogs links in Record and Link table
 - Updated NYPL mapping and formats in APIUtils with new catalog link
 - Gov document filter for advanced search page
-- Script to update old works in ES with proper boolean value in their is_government_document field
+- Script to update past works in ES with the proper boolean value in their is_government_document field
 ### Fixed
 - Added improved error handling around unexpected `media_type` values
 - Improve handling of NYPL Catalog records without EDD links

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Exposed entire authors object to the edition details page
 - Two new scripts to update NYPL catalogs links in Record and Link table
 - Updated NYPL mapping and formats in APIUtils with new catalog link
+- Gov document filter for advanced search page
 ### Fixed
 - Added improved error handling around unexpected `media_type` values
 - Improve handling of NYPL Catalog records without EDD links

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Two new scripts to update NYPL catalogs links in Record and Link table
 - Updated NYPL mapping and formats in APIUtils with new catalog link
 - Gov document filter for advanced search page
-- New script to update old works in ES with proper boolean value in their is_government_document fields
+- New script to update old works in ES with proper boolean value in their is_government_document field
 ### Fixed
 - Added improved error handling around unexpected `media_type` values
 - Improve handling of NYPL Catalog records without EDD links

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### Fixed
 - Added improved error handling around unexpected `media_type` values
 - Improve handling of NYPL Catalog records without EDD links
-- Future government document works in ES now have 'True' boolean value in the is_government_document field
+- Future government document works in ES now have 'True' boolean value in their is_government_document field
 
 ## 2022-06-09 -- v0.10.4
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Exposed entire authors object to the edition details page
 - Two new scripts to update NYPL catalogs links in Record and Link table
 - Updated NYPL mapping and formats in APIUtils with new catalog link
-- Gov document filter for advanced search page
+- Government document filter for advanced search page
 - Script to update past works in ES with the proper boolean value in their is_government_document field
 ### Fixed
 - Added improved error handling around unexpected `media_type` values

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Two new scripts to update NYPL catalogs links in Record and Link table
 - Updated NYPL mapping and formats in APIUtils with new catalog link
 - Gov document filter for advanced search page
-- New script to update old works in ES with proper boolean value in their is_government_document field
+- Script to update old works in ES with proper boolean value in their is_government_document field
 ### Fixed
 - Added improved error handling around unexpected `media_type` values
 - Improve handling of NYPL Catalog records without EDD links

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@
 - Two new scripts to update NYPL catalogs links in Record and Link table
 - Updated NYPL mapping and formats in APIUtils with new catalog link
 - Gov document filter for advanced search page
+- New script to update old works in ES with proper boolean value in their is_government_document fields
 ### Fixed
 - Added improved error handling around unexpected `media_type` values
 - Improve handling of NYPL Catalog records without EDD links
+- Future government document works in ES now have 'True' boolean value in the is_government_document field
 
 ## 2022-06-09 -- v0.10.4
 ### Added

--- a/api/elastic.py
+++ b/api/elastic.py
@@ -349,17 +349,9 @@ class ElasticClient():
         displayFilters = list(filter(
             lambda x: x[0] == 'showAll', filterParams)
         )
-        govDocFilters = list(filter(
-            lambda x: x[0] == 'govDoc', filterParams)
-        )
-        noGovDocFilters = list(filter(
-            lambda x: x[0] == 'noGovDoc', filterParams)
-        )
 
         dateFilter, dateAggregation = (None, None)
         formatFilter, formatAggregation = (None, None)
-        govDocFilter, govDocAggregation = (None, None)
-        noGovDocFilter, noGovDocAggregation = (None, None)
         displayFilter, displayAggregation = (
             Q('exists', field='editions.formats'),
             A('filter', **{'exists': {'field': 'editions.formats'}})
@@ -396,10 +388,6 @@ class ElasticClient():
             formatAggregation = A(
                 'filter', **{'terms': {'editions.formats': formats}}
             )
-        
-        #if len(govDocFilters) > 0:
-
-        #if len(noGovDocFilters) > 0:
 
         if len(displayFilters) > 0 and displayFilters[0][1] == 'true':
             displayFilter = None

--- a/api/elastic.py
+++ b/api/elastic.py
@@ -343,13 +343,23 @@ class ElasticClient():
         languageFilters = list(filter(
             lambda x: x[0] == 'language', filterParams)
         )
-        formatFilters = list(filter(lambda x: x[0] == 'format', filterParams))
+        formatFilters = list(filter(
+            lambda x: x[0] == 'format', filterParams)
+        )
         displayFilters = list(filter(
             lambda x: x[0] == 'showAll', filterParams)
+        )
+        govDocFilters = list(filter(
+            lambda x: x[0] == 'govDoc', filterParams)
+        )
+        noGovDocFilters = list(filter(
+            lambda x: x[0] == 'noGovDoc', filterParams)
         )
 
         dateFilter, dateAggregation = (None, None)
         formatFilter, formatAggregation = (None, None)
+        govDocFilter, govDocAggregation = (None, None)
+        noGovDocFilter, noGovDocAggregation = (None, None)
         displayFilter, displayAggregation = (
             Q('exists', field='editions.formats'),
             A('filter', **{'exists': {'field': 'editions.formats'}})
@@ -386,6 +396,10 @@ class ElasticClient():
             formatAggregation = A(
                 'filter', **{'terms': {'editions.formats': formats}}
             )
+        
+        #if len(govDocFilters) > 0:
+
+        #if len(noGovDocFilters) > 0:
 
         if len(displayFilters) > 0 and displayFilters[0][1] == 'true':
             displayFilter = None

--- a/api/utils.py
+++ b/api/utils.py
@@ -9,7 +9,7 @@ import re
 class APIUtils():
     QUERY_TERMS = [
         'keyword', 'title', 'author', 'subject', 'viaf', 'lcnaf',
-        'date', 'startYear', 'endYear', 'language', 'format', 'showAll'
+        'date', 'startYear', 'endYear', 'language', 'format', 'govDoc', 'noGovDoc', 'showAll'
     ]
 
     FORMAT_CROSSWALK = {

--- a/api/utils.py
+++ b/api/utils.py
@@ -9,7 +9,7 @@ import re
 class APIUtils():
     QUERY_TERMS = [
         'keyword', 'title', 'author', 'subject', 'viaf', 'lcnaf',
-        'date', 'startYear', 'endYear', 'language', 'format', 'govDoc', 'noGovDoc', 'showAll'
+        'date', 'startYear', 'endYear', 'language', 'format', 'showAll'
     ]
 
     FORMAT_CROSSWALK = {

--- a/managers/sfrElasticRecord.py
+++ b/managers/sfrElasticRecord.py
@@ -89,13 +89,10 @@ class SFRElasticRecordManager:
     
     @staticmethod
     def addGovDocStatus(measurements):
-        govDocMeasurement = list(filter(
-            lambda x: x.quantity == 'government_document', measurements
-        ))
-        if len(govDocMeasurement) > 0:
-            if int(govDocMeasurement[0].value) == 1:
-                return True
-        
+        for dict in measurements:
+            if dict['type'] == "government_document":
+                if dict['value'] == "1":
+                    return True
         return False
 
     def createEdition(self, edition):

--- a/managers/sfrElasticRecord.py
+++ b/managers/sfrElasticRecord.py
@@ -76,7 +76,7 @@ class SFRElasticRecordManager:
         ]
         
         self.work.is_government_document = SFRElasticRecordManager.addGovDocStatus(
-            self.dbWork.measurements
+            self.work.editions.measurements
         )
 
         self.work.editions = [self.createEdition(e) for e in self.dbWork.editions]

--- a/managers/sfrElasticRecord.py
+++ b/managers/sfrElasticRecord.py
@@ -76,7 +76,7 @@ class SFRElasticRecordManager:
         ]
         
         self.work.is_government_document = SFRElasticRecordManager.addGovDocStatus(
-            self.work.editions.measurements
+            self.work.editions
         )
 
         self.work.editions = [self.createEdition(e) for e in self.dbWork.editions]
@@ -88,11 +88,13 @@ class SFRElasticRecordManager:
         return agent
     
     @staticmethod
-    def addGovDocStatus(measurements):
-        for dict in measurements:
-            if dict['type'] == "government_document":
-                if dict['value'] == "1":
-                    return True
+    def addGovDocStatus(editions):
+        '''Iterates through each editions' measurement array to return True if a gov doc type exists'''
+        for edit in editions:
+            for measurement in edit.measurements:
+                if measurement['type'] == "government_document":
+                    if measurement['value'] == "1":
+                        return True
         return False
 
     def createEdition(self, edition):

--- a/managers/sfrElasticRecord.py
+++ b/managers/sfrElasticRecord.py
@@ -75,9 +75,12 @@ class SFRElasticRecordManager:
             for l in list(filter(None, self.dbWork.languages))
         ]
         
-        self.work.is_government_document = SFRElasticRecordManager.addGovDocStatus(
-            self.work.editions
-        )
+        for editions in self.work.editions:      
+            self.work.is_government_document = SFRElasticRecordManager.addGovDocStatus(
+            editions.measurements
+            )
+            if self.work.is_government_document == True:
+                break
 
         self.work.editions = [self.createEdition(e) for e in self.dbWork.editions]
 
@@ -88,14 +91,20 @@ class SFRElasticRecordManager:
         return agent
     
     @staticmethod
-    def addGovDocStatus(editions):
-        '''Iterates through each editions' measurement array to return True if a gov doc type exists'''
-        for edit in editions:
-            for measurement in edit.measurements:
+    def addGovDocStatus(measurements):
+        '''
+        Iterates through each dictionary in the measurement arrays to return True if a gov doc type and value exists
+        '''
+
+        if measurements != [] and measurements != [{}]:
+            for measurement in measurements:
                 if measurement['type'] == "government_document":
                     if measurement['value'] == "1":
                         return True
-        return False
+            return False
+
+        else:
+            return False
 
     def createEdition(self, edition):
         newEd = ESEdition(**{

--- a/managers/sfrElasticRecord.py
+++ b/managers/sfrElasticRecord.py
@@ -75,11 +75,11 @@ class SFRElasticRecordManager:
             for l in list(filter(None, self.dbWork.languages))
         ]
         
-        for editions in self.work.editions:      
+        for edition in self.work.editions:      
             self.work.is_government_document = SFRElasticRecordManager.addGovDocStatus(
-            editions.measurements
+            edition.measurements
             )
-            if self.work.is_government_document == True:
+            if self.work.is_government_document is True:
                 break
 
         self.work.editions = [self.createEdition(e) for e in self.dbWork.editions]

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,5 +1,6 @@
 from .extractAllEditions import main as editionExtraction
 from .updateOldInTechOpenLinks import main as updateInTechOpenLinks
-from .updateESEditionFormats import main as updateESEditionFormats
+from .updateESEditionFormats import main as updateESEditionFormat
 from .updateLinksCatalog import main as updateLinks
 from .updateRecordsCatalogLink import main as updateRecordCatalogs
+from .govDocES import main as govDocUpdate

--- a/scripts/govDocES.py
+++ b/scripts/govDocES.py
@@ -32,17 +32,21 @@ def main():
         .filter(Edition.measurements != None) \
         .filter(Edition.measurements != []) \
         .filter(Edition.measurements != [{}]).all():
-            for dict in work.edition.measurements:
-                if dict['type'] == "government_document":
-                    if dict['value'] == "1":
-                        try:
-                            workRec = ESWork.get(work.uuid, index=esManager.index)
-                            workRec.is_government_document = True
-                            workRec.save()
-                            break
-                        except NotFoundError:
-                            print('Work not indexed, skipping')
-                            continue
+            for edition in work.editions:
+                for measurement in edition.measurements:
+                    if measurement['type'] == "government_document":
+                        if measurement['value'] == "1":
+                            try:
+                                workRec = ESWork.get(work.uuid, index=esManager.index)
+                                workRec.is_government_document = True
+                                workRec.save()
+                                break_out_flag = True
+                                break
+                            except NotFoundError:
+                                print('Work not indexed, skipping')
+                                continue
+                if break_out_flag:
+                    break
 
     dbManager.closeConnection()
 

--- a/scripts/govDocES.py
+++ b/scripts/govDocES.py
@@ -32,6 +32,9 @@ def main():
         .filter(Edition.measurements != None) \
         .filter(Edition.measurements != []) \
         .filter(Edition.measurements != [{}]).all():
+
+            break_out_flag = False
+            
             for edition in work.editions:
                 for measurement in edition.measurements:
                     if measurement['type'] == "government_document":

--- a/scripts/govDocES.py
+++ b/scripts/govDocES.py
@@ -8,6 +8,8 @@ from managers import DBManager, ElasticsearchManager
 
 def main():
 
+    '''Updating is_government_document field of current gov doc works in ES to be the boolean value True'''
+
     loadEnvFile('local-qa', fileString='config/{}.yaml')
 
     dbManager = DBManager(
@@ -30,20 +32,17 @@ def main():
         .filter(Edition.measurements != None) \
         .filter(Edition.measurements != []) \
         .filter(Edition.measurements != [{}]).all():
-            for dict in work.edit.measurements:
+            for dict in work.edition.measurements:
                 if dict['type'] == "government_document":
                     if dict['value'] == "1":
                         try:
                             workRec = ESWork.get(work.uuid, index=esManager.index)
                             workRec.is_government_document = True
                             workRec.save()
+                            break
                         except NotFoundError:
                             print('Work not indexed, skipping')
                             continue
-                    else:
-                        continue
-                else:
-                    continue
 
     dbManager.closeConnection()
 

--- a/scripts/govDocES.py
+++ b/scripts/govDocES.py
@@ -1,0 +1,51 @@
+import os
+from elasticsearch.exceptions import NotFoundError
+
+from model import Work, Edition, ESWork
+from main import loadEnvFile
+from managers import DBManager, ElasticsearchManager
+
+
+def main():
+
+    loadEnvFile('local-qa', fileString='config/{}.yaml')
+
+    dbManager = DBManager(
+        user= os.environ.get('POSTGRES_USER', None),
+        pswd= os.environ.get('POSTGRES_PSWD', None),
+        host= os.environ.get('POSTGRES_HOST', None),
+        port= os.environ.get('POSTGRES_PORT', None),
+        db= os.environ.get('POSTGRES_NAME', None)
+    )
+
+    esManager = ElasticsearchManager()
+    esManager.createElasticConnection()
+
+    dbManager.generateEngine()
+
+    dbManager.createSession()
+
+    for work in dbManager.session.query(Work) \
+        .join(Edition) \
+        .filter(Edition.measurements != None) \
+        .filter(Edition.measurements != []) \
+        .filter(Edition.measurements != [{}]).all():
+            for dict in work.edit.measurements:
+                if dict['type'] == "government_document":
+                    if dict['value'] == "1":
+                        try:
+                            workRec = ESWork.get(work.uuid, index=esManager.index)
+                            workRec.is_government_document = True
+                            workRec.save()
+                        except NotFoundError:
+                            print('Work not indexed, skipping')
+                            continue
+                    else:
+                        continue
+                else:
+                    continue
+
+    dbManager.closeConnection()
+
+if __name__ == '__main__':
+    main()

--- a/tests/unit/test_sfrElastic_manager.py
+++ b/tests/unit/test_sfrElastic_manager.py
@@ -141,22 +141,19 @@ class TestSFRElasticRecordManager:
 
     def test_addGovDocStatus_measurement_present_true(self, mocker):
         govMeasure = mocker.MagicMock()
-        govMeasure.quantity = 'government_document'
-        govMeasure.value = '1'
+        govMeasure = {'type': 'government_document', 'value': '1'}
 
         assert SFRElasticRecordManager.addGovDocStatus([govMeasure]) is True
 
     def test_addGovDocStatus_measurement_present_false(self, mocker):
         govMeasure = mocker.MagicMock()
-        govMeasure.quantity = 'government_document'
-        govMeasure.value = '0'
+        govMeasure = {'type': 'government_document', 'value': '0'}
 
         assert SFRElasticRecordManager.addGovDocStatus([govMeasure]) is False 
 
     def test_addGovDocStatus_measurement_not_present(self, mocker):
         govMeasure = mocker.MagicMock()
-        govMeasure.quantity = 'other'
-        govMeasure.value = '1'
+        govMeasure = {'type': 'other', 'value': '1'}
 
         assert SFRElasticRecordManager.addGovDocStatus([govMeasure]) is False 
 

--- a/tests/unit/test_sfrElastic_manager.py
+++ b/tests/unit/test_sfrElastic_manager.py
@@ -27,6 +27,7 @@ class TestSFRElasticRecordManager:
         testWork.languages = [{'language': 'Language 1'}]
         testWork.measurements = ['Measure 1', 'Measure 2']
         testWork.editions = ['Editions 1', 'Editions 2', 'Editions 3']
+        
 
         return testWork
 
@@ -108,7 +109,7 @@ class TestSFRElasticRecordManager:
         managerMocks['addGovDocStatus'].return_value = False
         managerMocks['createEdition'].side_effect = ['Edition 1', 'Edition 2', 'Edition 3']
 
-        testInstance.work = mocker.MagicMock()
+        testInstance.work = mocker.MagicMock(editions=[mocker.MagicMock()] * 3)
         testInstance.enhanceWork()
 
         assert testInstance.work.date_created == 'testCreatedDate'


### PR DESCRIPTION
I updated the sfrElasticRecord module to utilize the measurements field of editions instead of works when calling the addGovDocStatus() method and made a new script to update old government document works in ES with a True boolean value in their is_government_document fields.