### PR TITLE
HOTFIX Remove trailing slashes from API Endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Added improved error handling around unexpected `media_type` values
 - Improve handling of NYPL Catalog records without EDD links
 - Future government document works in ES now have 'True' boolean value in their is_government_document field
+- Standardized API endpoint to remove trailing slash from `collection` and `search` endpoints
 
 ## 2022-06-09 -- v0.10.4
 ### Added

--- a/api/blueprints/drbCollection.py
+++ b/api/blueprints/drbCollection.py
@@ -51,7 +51,7 @@ def validateToken(func):
     return decorator
 
 
-@collection.route('/', methods=['POST'])
+@collection.route('', methods=['POST'])
 @validateToken
 def collectionCreate(user=None):
     logger.info('Creating new collection')

--- a/api/blueprints/drbSearch.py
+++ b/api/blueprints/drbSearch.py
@@ -9,7 +9,7 @@ logger = createLog(__name__)
 search = Blueprint('search', __name__, url_prefix='/search')
 
 
-@search.route('/', methods=['GET'])
+@search.route('', methods=['GET'])
 def standardQuery():
     esClient = ElasticClient(current_app.config['REDIS_CLIENT'])
     dbClient = DBClient(current_app.config['DB_CLIENT'])


### PR DESCRIPTION
This removes trailing slashes from two API endpoints -- `search` and `collection`. This misconfiguration was causing issues with the Swagger documentation, resulting in false errors when interacting with the API.

The only effect of this change should be to resolve those errors, any other interaction with the API should result in a `308` redirect, which is invisible in other use cases.