### PR TITLE
SFR-153 Ingest Report Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Government document search filter 
 - Unit tests for government document filter and aggregation
 - Script to delete ESC works that don't correspond with works in the PSQL database
+- Maintenance script for routine database maintenance processes
 ### Fixed
 - Increased processing speed of govDocES script
 

--- a/processes/__init__.py
+++ b/processes/__init__.py
@@ -13,3 +13,4 @@ from .muse import MUSEProcess
 from .ingestReport import IngestReportProcess
 from .met import METProcess
 from .migration import MigrationProcess
+from .dbMaintenance import DatabaseMaintenanceProcess

--- a/tests/unit/test_dbMaintenance_process.py
+++ b/tests/unit/test_dbMaintenance_process.py
@@ -1,0 +1,50 @@
+import pytest
+
+from processes import DatabaseMaintenanceProcess
+
+
+class TestIngestReportProcess:
+    @pytest.fixture
+    def testInstance(self, mocker):
+        class TestDatabaseMaintenanceProcess(DatabaseMaintenanceProcess):
+            def __init__(self, *args):
+                self.engine = mocker.MagicMock()
+
+        return TestDatabaseMaintenanceProcess('TestProcess', 'testFile', 'testDate')
+
+    def test_runProcess(self, testInstance, mocker):
+        mockVacuum = mocker.patch.object(DatabaseMaintenanceProcess, 'vacuumTables')
+        mockClose = mocker.patch.object(DatabaseMaintenanceProcess, 'closeConnection')
+
+        testInstance.runProcess()
+
+        mockVacuum.assert_called_once()
+        mockClose.assert_called_once()
+
+    def test_vacuumTables(self, testInstance, mocker):
+        mockConnEnter = mocker.MagicMock()
+        mockConn = mocker.MagicMock()
+        testInstance.engine.connect.return_value = mockConnEnter
+        mockConnEnter.__enter__.return_value = mockConn
+
+        mockVacuum = mocker.patch.object(DatabaseMaintenanceProcess, 'vacuumTable')
+
+        testInstance.vacuumTables()
+
+        mockConn.execution_options.assert_called_once_with(isolation_level='AUTOCOMMIT')
+        mockVacuum.assert_has_calls([
+            mocker.call(mockConn, 'records'),
+            mocker.call(mockConn, 'items'),
+            mocker.call(mockConn, 'editions'),
+            mocker.call(mockConn, 'works'),
+            mocker.call(mockConn, 'links'),
+            mocker.call(mockConn, 'rights'),
+            mocker.call(mockConn, 'identifiers')
+        ])
+
+    def test_vacuumTable(self, testInstance, mocker):
+        mockConn = mocker.MagicMock()
+
+        testInstance.vacuumTable(mockConn, 'testTable')
+
+        mockConn.execute.assert_called_once_with('VACUUM ANALYZE testTable;')


### PR DESCRIPTION
This addresses an issue raised by the project/product teams to fix broken reporting of daily ingest volume. There are two related fixes for this issue in this PR:
1. The immediate issue is resolved by updating the analytics queries. an ineffecient strategy was being used to create date-based queries. This has been removed and replaced with a more standard query structure.
2. This is supported by the addition of a database maintenance process. Without this standard process database table can grow slow and harder to query. This provides a tool that can be used to ensure that the database is regularly pruned of unused rows.

Overall this should restore intended functionality to the database and ensure that similar situations do not occur in the future. It should also provide a safeguard against degradation and improve performance, if in a small way.