### PR TITLE
Updated ES API generateSearchQuery method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Added
 - Docker Compose file to set up local dev environment
 - Updated README steps for setting up local dev environment 
+- Updated search endpoint to include identifier and authority as keywords
 ### Fixed
 - Updated unit tests for developmentSetup process
 - Removed front end configurations from tugboat

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ### Added
 - Docker Compose file to set up local dev environment
 - Updated README steps for setting up local dev environment 
-- Updated search endpoint to include identifier and authority as keywords
+- Updated search endpoint to include identifier value and authority as keywords
 ### Fixed
 - Updated unit tests for developmentSetup process
 - Removed front end configurations from tugboat

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ### Added
 - Docker Compose file to set up local dev environment
 - Updated README steps for setting up local dev environment 
-- Updated search endpoint to include identifier value and authority as keywords
+- Updated search endpoint to add identifier value and authority as keywords
 ### Fixed
 - Updated unit tests for developmentSetup process
 - Removed front end configurations from tugboat

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ### Added
 - Docker Compose file to set up local dev environment
 - Updated README steps for setting up local dev environment 
-- Updated search endpoint to add identifier value and authority as keywords
+- Updated search endpoint to add identifier as a keyword
 - Identifier & Authority as query terms in APIUtils class 
 ### Fixed
 - Updated unit tests for developmentSetup process

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## unreleased version -- v0.10.7
 ### Added
 - Docker Compose file to set up local dev environment
-- Updated README steps for setting up local dev environment
+- Updated README steps for setting up local dev environment 
+- Updated search endpoint to add identifier value and authority as keywords
 - Identifier & Authority as query terms in APIUtils class 
 ### Fixed
 - Updated unit tests for developmentSetup process

--- a/api/utils.py
+++ b/api/utils.py
@@ -8,7 +8,7 @@ import re
 
 class APIUtils():
     QUERY_TERMS = [
-        'keyword', 'title', 'author', 'subject', 'viaf', 'lcnaf',
+        'keyword', 'title', 'author', 'subject', 'lccn', 'isbn', 'viaf', 'lcnaf',
         'date', 'startYear', 'endYear', 'language', 'format', 'govDoc', 'showAll'
     ]
 

--- a/api/utils.py
+++ b/api/utils.py
@@ -8,7 +8,7 @@ import re
 
 class APIUtils():
     QUERY_TERMS = [
-        'keyword', 'title', 'author', 'subject', 'lccn', 'isbn', 'viaf', 'lcnaf',
+        'keyword', 'title', 'author', 'subject', 'viaf', 'lcnaf',
         'date', 'startYear', 'endYear', 'language', 'format', 'govDoc', 'showAll'
     ]
 

--- a/api/utils.py
+++ b/api/utils.py
@@ -8,7 +8,7 @@ import re
 
 class APIUtils():
     QUERY_TERMS = [
-        'keyword', 'title', 'author', 'subject', 'viaf', 'lcnaf',
+        'keyword', 'title', 'author', 'subject', 'identifier', 'authority: identifier', 'viaf', 'lcnaf',
         'date', 'startYear', 'endYear', 'language', 'format', 'govDoc', 'showAll'
     ]
 

--- a/tests/unit/test_api_es.py
+++ b/tests/unit/test_api_es.py
@@ -38,7 +38,7 @@ class TestElasticClient:
         return mockSearch
 
     @pytest.fixture
-    def searchMocks(self, mockSearch, mocker):
+    def searchMocks(self, mocker):
         return mocker.patch.multiple(
             ElasticClient,
             getFromSize=mocker.DEFAULT,
@@ -47,6 +47,8 @@ class TestElasticClient:
             authorQuery=mocker.DEFAULT,
             subjectQuery=mocker.DEFAULT,
             authorityQuery=mocker.DEFAULT,
+            identifierQuery=mocker.DEFAULT,
+            authIdentQuery=mocker.DEFAULT,
             createFilterClausesAndAggregations=mocker.DEFAULT,
             addSortClause=mocker.DEFAULT,
             addFiltersAndAggregations=mocker.DEFAULT,
@@ -221,6 +223,67 @@ class TestElasticClient:
         searchMocks['authorQuery'].assert_not_called()
         searchMocks['subjectQuery'].assert_not_called()
         searchMocks['authorityQuery'].assert_called_once_with('viaf', 'escapedQuery')
+
+        mockSearch.query.assert_called_once_with('searchClauses')
+
+        searchMocks['createFilterClausesAndAggregations'].assert_called_once_with(['filter'])
+        searchMocks['addSortClause'].assert_called_once_with(['sort'])
+        searchMocks['addFiltersAndAggregations'].assert_called_once_with(3)
+        searchMocks['addSearchHighlighting'].assert_called_once()
+
+    def test_generateSearchQuery_identifier_search(self, testInstance, mockSearch, searchMocks, mocker):
+        searchMocks['createSearch'].return_value = mockSearch
+        searchMocks['escapeSearchQuery'].return_value = 'escapedQuery'
+        searchMocks['identifierQuery'].return_value = 'identifierQuery'
+        searchMocks['createFilterClausesAndAggregations'].return_value = mockSearch
+        searchMocks['addSortClause'].return_value = mockSearch
+
+        mockQuery = mocker.patch('api.elastic.Q')
+        mockQuery.side_effect = ['searchClauses']
+
+        testInstance.generateSearchQuery({
+            'query': [('identifier', 'test'),], 'sort': ['sort'], 'filter': ['filter']
+        })
+
+        mockQuery.assert_called_once_with('bool', must=['identifierQuery'])
+        searchMocks['escapeSearchQuery'].assert_called_once_with('test')
+        searchMocks['titleQuery'].assert_not_called()
+        searchMocks['authorQuery'].assert_not_called()
+        searchMocks['subjectQuery'].assert_not_called()
+        searchMocks['authorityQuery'].assert_not_called()
+        searchMocks['identifierQuery'].assert_called_once_with('escapedQuery')
+
+        mockSearch.query.assert_called_once_with('searchClauses')
+
+        searchMocks['createFilterClausesAndAggregations'].assert_called_once_with(['filter'])
+        searchMocks['addSortClause'].assert_called_once_with(['sort'])
+        searchMocks['addFiltersAndAggregations'].assert_called_once_with(3)
+        searchMocks['addSearchHighlighting'].assert_called_once()
+
+    def test_generateSearchQuery_authIdentifier_search(self, testInstance, mockSearch, searchMocks, mocker):
+        searchMocks['createSearch'].return_value = mockSearch
+        searchMocks['escapeSearchQuery'].return_value = 'escapedQuery'
+        searchMocks['authIdentQuery'].return_value = 'authIdentQuery'
+        searchMocks['createFilterClausesAndAggregations'].return_value = mockSearch
+        searchMocks['addSortClause'].return_value = mockSearch
+
+        mockQuery = mocker.patch('api.elastic.Q')
+        mockQuery.side_effect = ['searchClauses']
+
+        testInstance.generateSearchQuery({
+            'query': [('authority: identifier', 'isbn: 0123456789'),], 'sort': ['sort'], 'filter': ['filter']
+        })
+
+        mockQuery.assert_called_once_with('bool', must=['authIdentQuery'])
+        searchMocks['escapeSearchQuery'].assert_called_once_with('isbn: 0123456789')
+        searchMocks['titleQuery'].assert_not_called()
+        searchMocks['authorQuery'].assert_not_called()
+        searchMocks['subjectQuery'].assert_not_called()
+        searchMocks['authorityQuery'].assert_not_called()
+        searchMocks['identifierQuery'].assert_not_called()
+        searchMocks['authIdentQuery'].assert_called_once_with(['isbn', 'issn', 'lcc', 'lccn', \
+                                                            'oclc', 'nypl', 'hathi', 'gutenberg', \
+                                                            'doab'], 'escapedQuery')
 
         mockSearch.query.assert_called_once_with('searchClauses')
 
@@ -493,6 +556,32 @@ class TestElasticClient:
         assert testQuery['nested']['path'] == 'subjects'
         assert testQuery['nested']['query']['query_string']['query'] == 'testSubject'
         assert testQuery['nested']['query']['query_string']['fields'] == ['subjects.heading.*']
+
+    def test_identifierQuery(self, testInstance):
+        testQueryES = testInstance.identifierQuery('testAuth')
+        testQuery = testQueryES.to_dict()
+
+        assert testInstance.searchedFields == ['identifiers', 'editions.identifiers']
+        assert testQuery['bool']['should'][0]['query_string']['query'] == 'testAuth'
+        assert testQuery['bool']['should'][0]['query_string']['fields'] == ['identifiers.*']
+        assert testQuery['bool']['should'][1]['nested']['path'] == 'editions'
+        assert testQuery['bool']['should'][1]['nested']['query']['query_string']['query'] == 'testAuth'
+        assert testQuery['bool']['should'][1]['nested']['query']['query_string']['fields'] == ['editions.identifiers.*']
+        assert testQuery['bool']['should'][1]['nested']['query']['query_string']['default_operator'] == 'and'
+
+    def test_authIdentQuery(self, testInstance):
+        testQueryES = testInstance.authIdentQuery(['testAuth'], 'testAuth: testIdent')
+        testQuery = testQueryES.to_dict()
+
+        assert testInstance.searchedFields == ['identifiers', 'editions.identifiers']
+        assert testQuery['bool']['should'][0]['query_string']['query'] == 'testAuth'
+        assert testQuery['bool']['should'][0]['query_string']['fields'] == ['identifiers.authority']
+        assert testQuery['bool']['should'][1]['query_string']['query'] == 'testIdent'
+        assert testQuery['bool']['should'][1]['query_string']['fields'] == ['identifiers.identifier']
+        assert testQuery['bool']['should'][2]['nested']['path'] == 'editions'
+        assert testQuery['bool']['should'][2]['nested']['query']['query_string']['query'] == 'testIdent'
+        assert testQuery['bool']['should'][2]['nested']['query']['query_string']['fields'] == ['editions.identifiers.identifier']
+        assert testQuery['bool']['should'][2]['nested']['query']['query_string']['default_operator'] == 'and'
 
     def test_getFromSize(self):
         startPosition, endPosition = ElasticClient.getFromSize(3, 15)

--- a/tests/unit/test_api_es.py
+++ b/tests/unit/test_api_es.py
@@ -48,7 +48,6 @@ class TestElasticClient:
             subjectQuery=mocker.DEFAULT,
             authorityQuery=mocker.DEFAULT,
             identifierQuery=mocker.DEFAULT,
-            authIdentQuery=mocker.DEFAULT,
             createFilterClausesAndAggregations=mocker.DEFAULT,
             addSortClause=mocker.DEFAULT,
             addFiltersAndAggregations=mocker.DEFAULT,
@@ -251,46 +250,18 @@ class TestElasticClient:
         searchMocks['authorQuery'].assert_not_called()
         searchMocks['subjectQuery'].assert_not_called()
         searchMocks['authorityQuery'].assert_not_called()
-        searchMocks['identifierQuery'].assert_called_once_with('escapedQuery')
-
-        mockSearch.query.assert_called_once_with('searchClauses')
-
-        searchMocks['createFilterClausesAndAggregations'].assert_called_once_with(['filter'])
-        searchMocks['addSortClause'].assert_called_once_with(['sort'])
-        searchMocks['addFiltersAndAggregations'].assert_called_once_with(3)
-        searchMocks['addSearchHighlighting'].assert_called_once()
-
-    def test_generateSearchQuery_authIdentifier_search(self, testInstance, mockSearch, searchMocks, mocker):
-        searchMocks['createSearch'].return_value = mockSearch
-        searchMocks['escapeSearchQuery'].return_value = 'escapedQuery'
-        searchMocks['authIdentQuery'].return_value = 'authIdentQuery'
-        searchMocks['createFilterClausesAndAggregations'].return_value = mockSearch
-        searchMocks['addSortClause'].return_value = mockSearch
-
-        mockQuery = mocker.patch('api.elastic.Q')
-        mockQuery.side_effect = ['searchClauses']
-
-        testInstance.generateSearchQuery({
-            'query': [('authority: identifier', 'isbn: 0123456789'),], 'sort': ['sort'], 'filter': ['filter']
-        })
-
-        mockQuery.assert_called_once_with('bool', must=['authIdentQuery'])
-        searchMocks['escapeSearchQuery'].assert_called_once_with('isbn: 0123456789')
-        searchMocks['titleQuery'].assert_not_called()
-        searchMocks['authorQuery'].assert_not_called()
-        searchMocks['subjectQuery'].assert_not_called()
-        searchMocks['authorityQuery'].assert_not_called()
-        searchMocks['identifierQuery'].assert_not_called()
-        searchMocks['authIdentQuery'].assert_called_once_with(['isbn', 'issn', 'lcc', 'lccn', \
+        searchMocks['identifierQuery'].assert_called_once_with(['isbn', 'issn', 'lcc', 'lccn', \
                                                             'oclc', 'nypl', 'hathi', 'gutenberg', \
                                                             'doab'], 'escapedQuery')
 
+
         mockSearch.query.assert_called_once_with('searchClauses')
 
         searchMocks['createFilterClausesAndAggregations'].assert_called_once_with(['filter'])
         searchMocks['addSortClause'].assert_called_once_with(['sort'])
         searchMocks['addFiltersAndAggregations'].assert_called_once_with(3)
         searchMocks['addSearchHighlighting'].assert_called_once()
+
 
     def test_generateSearchQuery_generic_search(self, testInstance, mockSearch, searchMocks, mocker):
         searchMocks['createSearch'].return_value = mockSearch
@@ -557,20 +528,20 @@ class TestElasticClient:
         assert testQuery['nested']['query']['query_string']['query'] == 'testSubject'
         assert testQuery['nested']['query']['query_string']['fields'] == ['subjects.heading.*']
 
-    def test_identifierQuery(self, testInstance):
-        testQueryES = testInstance.identifierQuery('testAuth')
+    def test_identifierQuery_OnlyIdentifier(self, testInstance):
+        testQueryES = testInstance.identifierQuery(['testIdent'], 'testIdent')
         testQuery = testQueryES.to_dict()
 
         assert testInstance.searchedFields == ['identifiers', 'editions.identifiers']
-        assert testQuery['bool']['should'][0]['query_string']['query'] == 'testAuth'
+        assert testQuery['bool']['should'][0]['query_string']['query'] == 'testIdent'
         assert testQuery['bool']['should'][0]['query_string']['fields'] == ['identifiers.*']
         assert testQuery['bool']['should'][1]['nested']['path'] == 'editions'
-        assert testQuery['bool']['should'][1]['nested']['query']['query_string']['query'] == 'testAuth'
+        assert testQuery['bool']['should'][1]['nested']['query']['query_string']['query'] == 'testIdent'
         assert testQuery['bool']['should'][1]['nested']['query']['query_string']['fields'] == ['editions.identifiers.*']
         assert testQuery['bool']['should'][1]['nested']['query']['query_string']['default_operator'] == 'and'
 
-    def test_authIdentQuery(self, testInstance):
-        testQueryES = testInstance.authIdentQuery(['testAuth'], 'testAuth: testIdent')
+    def test_identifierQuery_AuthIdent(self, testInstance):
+        testQueryES = testInstance.identifierQuery(['testAuth'], 'testAuth: testIdent')
         testQuery = testQueryES.to_dict()
 
         assert testInstance.searchedFields == ['identifiers', 'editions.identifiers']


### PR DESCRIPTION
With this PR I added a new conditional for the `generateSearchQuery` method to include identifier as a field and made a `identifierQuery` method to account for that. In addition, instead of adding another conditional for an authority field, I decided to update the existing viaf and lcnaf conditional since they seemingly utilize an authorityQuery method which is similar to what we want for when one searches for a specific authority and the identifier afterwards. What are your thoughts on doing this rather than creating a separate conditional and new authorityQuery method? Also, I only included isbn and lccn as new authorities for right now, since I'm not aware and don't have access to the ES QA database to check all the types of authorities that exist for each record. Could you assist me on finding all the types of authorities that exist in the ES database?