### PR TITLE
Updated search score in agent parser method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 - Removed front end configurations from tugboat
 - Slack incoming webhook now passes in regression tests
 - Improved CI/CD process with all regression tests passing succesfully
+- Score for jaro_winkler search change from 0.9 to 0.85 in agentParser method
+- Specified version 0.20.4 of python-levenshtein in requirements file
 
 ## 2022-09-07 -- v0.10.6
 ### Added

--- a/managers/sfrRecord.py
+++ b/managers/sfrRecord.py
@@ -547,7 +547,7 @@ class SFRRecordManager:
                         break
 
                 if existingMatch is False:
-                    if jaro_winkler(oaKey, recKey) > 0.9:
+                    if jaro_winkler(oaKey, recKey) > 0.85:
                         SFRRecordManager.mergeAgents(oa, rec)
                         existingMatch = True
                         break

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ pandas
 pika
 pillow
 psycopg2-binary
-python-levenshtein
+python-levenshtein==0.20.4
 pycountry
 pyjwt[crypto]
 pymarc


### PR DESCRIPTION
I updated the search score to 0.85 instead of 0.9 and specified the version number of the `python-levenshtein` dependency in the requirements file to be 0.20.4.