### PR TITLE
SFR-1509v2: Updated identifier query for nested search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Updated README steps for setting up local dev environment 
 - Updated search endpoint to add identifier as a keyword
 - Identifier & Authority as query terms in APIUtils class 
-- Multi-host configuration for ES connection
+- Multi-host configuration for ES connections
 
 ### Fixed
 - Updated unit tests for developmentSetup process

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ### Added
 - Docker Compose file to set up local dev environment
 - Updated README steps for setting up local dev environment 
-- Updated search endpoint to add identifier as a keyword
+- Updated search endpoint to add 'identifier' as a keyword
 - Identifier & Authority as query terms in APIUtils class 
 - Multi-host configuration for ES connections
 

--- a/api/elastic.py
+++ b/api/elastic.py
@@ -245,22 +245,12 @@ class ElasticClient():
             identifier = authIdentText
 
             workIdentQuery = Q('bool', must=[
-                Q(
-                    'term',
-                    query=identifier,
-                    fields=['identifiers.identifier'],
-                    default_operator='and'
-                )
-            ])
+                Q('term', **{'identifiers.identifier': identifier})
+                ])
 
             editionIdentQuery = Q('bool', must=[
-                Q(
-                    'term',
-                    query=identifier,
-                    fields=['editions.identifiers.identifier'],
-                    default_operator='and'
-                )
-            ])
+                Q('term', **{'editions.identifiers.identifier': identifier})
+                ])
 
             return Q('bool', should=[
                 Q('nested', path='identifiers', query=workIdentQuery),
@@ -275,47 +265,19 @@ class ElasticClient():
 
             if authority in authorityList:
 
-                workAuthQuery = Q('bool', must=[
-                    Q(
-                        'term',
-                        query=authority,
-                        fields=['identifiers.authority'],
-                        default_operator='and'
-                    )
+                workIdentAuthQuery = Q('bool', must=[
+                    Q('term', **{'identifiers.authority': authority}),
+                    Q('term', **{'identifiers.identifier': identifier})
                 ])
 
-                editionAuthQuery = Q('bool', must=[
-                    Q(
-                        'term',
-                        query=authority,
-                        fields=['editions.identifiers.authority'],
-                        default_operator='and'
-                    )
-                ])
-
-                workIdentQuery = Q('bool', must=[
-                Q(
-                    'term',
-                    query=identifier,
-                    fields=['identifiers.identifier'],
-                    default_operator='and'
-                )
-                ])
-
-                editionIdentQuery = Q('bool', must=[
-                    Q(
-                        'term',
-                        query=identifier,
-                        fields=['editions.identifiers.identifier'],
-                        default_operator='and'
-                    ),
+                editionIdentAuthQuery = Q('bool', must=[
+                    Q('term', **{'editions.identifiers.authority': authority}),
+                    Q('term', **{'editions.identifiers.identifier': identifier})
                 ])
 
                 return Q('bool', should=[
-                    Q('nested', path='identifiers', query=workAuthQuery),
-                    Q('nested', path='editions.identifiers', query=editionAuthQuery),
-                    Q('nested', path='identifiers', query=workIdentQuery),
-                    Q('nested', path='editions.identifiers', query=editionIdentQuery)
+                    Q('nested', path='identifiers', query=workIdentAuthQuery),
+                    Q('nested', path='editions.identifiers', query=editionIdentAuthQuery)
                 ])
 
     def authorQuery(self, authorText):

--- a/scripts/deleteElasticRecords.py
+++ b/scripts/deleteElasticRecords.py
@@ -8,9 +8,9 @@ from elasticsearch_dsl import Search
 from elasticsearch.exceptions import NotFoundError, ConflictError
 from main import loadEnvFile
 
-logging.basicConfig(filename='deleteESRecords.log', encoding='utf-8', level=logging.INFO)
-
 def main():
+
+    logging.basicConfig(filename='deleteESRecords.log', encoding='utf-8', level=logging.INFO)
 
     '''Deleting ESC works that don't appear in the Postgresql database based on uuid'''
 

--- a/tests/unit/test_api_es.py
+++ b/tests/unit/test_api_es.py
@@ -535,11 +535,9 @@ class TestElasticClient:
         assert testInstance.searchedFields == ['identifiers.identifier', 'editions.identifiers.identifier',
                                                 'identifiers.authority', 'editions.identifiers.authority']
         assert testQuery['bool']['should'][0]['nested']['path'] == 'identifiers'
-        assert testQuery['bool']['should'][0]['nested']['query']['bool']['must'][0]['term']['query'] == 'testIdent'
-        assert testQuery['bool']['should'][0]['nested']['query']['bool']['must'][0]['term']['fields'] == ['identifiers.identifier']
+        assert testQuery['bool']['should'][0]['nested']['query']['bool']['must'][0]['term'] == {'identifiers.identifier': 'testIdent'}
         assert testQuery['bool']['should'][1]['nested']['path'] == 'editions.identifiers'
-        assert testQuery['bool']['should'][1]['nested']['query']['bool']['must'][0]['term']['query'] == 'testIdent'
-        assert testQuery['bool']['should'][1]['nested']['query']['bool']['must'][0]['term']['fields'] == ['editions.identifiers.identifier']
+        assert testQuery['bool']['should'][1]['nested']['query']['bool']['must'][0]['term'] == {'editions.identifiers.identifier': 'testIdent'}
 
 
     def test_identifierQuery_AuthIdent(self, testInstance):
@@ -549,18 +547,12 @@ class TestElasticClient:
         assert testInstance.searchedFields == ['identifiers.identifier', 'editions.identifiers.identifier',
                                                 'identifiers.authority', 'editions.identifiers.authority']
         assert testQuery['bool']['should'][0]['nested']['path'] == 'identifiers'
-        assert testQuery['bool']['should'][0]['nested']['query']['bool']['must'][0]['term']['query'] == 'testAuth'
-        assert testQuery['bool']['should'][0]['nested']['query']['bool']['must'][0]['term']['fields'] == ['identifiers.authority']
+        assert testQuery['bool']['should'][0]['nested']['query']['bool']['must'][0]['term']== {'identifiers.authority': 'testAuth'}
+        testQuery['bool']['should'][0]['nested']['query']['bool']['must'][1]['term']== {'identifiers.identifier': 'testIdent'}  
         assert testQuery['bool']['should'][1]['nested']['path'] == 'editions.identifiers'
-        assert testQuery['bool']['should'][1]['nested']['query']['bool']['must'][0]['term']['query'] == 'testAuth'
-        assert testQuery['bool']['should'][1]['nested']['query']['bool']['must'][0]['term']['fields'] == ['editions.identifiers.authority']
-        assert testQuery['bool']['should'][2]['nested']['path'] == 'identifiers'
-        assert testQuery['bool']['should'][2]['nested']['query']['bool']['must'][0]['term']['query'] == 'testIdent'
-        assert testQuery['bool']['should'][2]['nested']['query']['bool']['must'][0]['term']['fields'] == ['identifiers.identifier']
-        assert testQuery['bool']['should'][3]['nested']['path'] == 'editions.identifiers'
-        assert testQuery['bool']['should'][3]['nested']['query']['bool']['must'][0]['term']['query'] == 'testIdent'
-        assert testQuery['bool']['should'][3]['nested']['query']['bool']['must'][0]['term']['fields'] == ['editions.identifiers.identifier']
-
+        assert testQuery['bool']['should'][1]['nested']['query']['bool']['must'][0]['term'] == {'editions.identifiers.authority': 'testAuth'}
+        assert testQuery['bool']['should'][1]['nested']['query']['bool']['must'][1]['term'] == {'editions.identifiers.identifier': 'testIdent'}
+        
     def test_getFromSize(self):
         startPosition, endPosition = ElasticClient.getFromSize(3, 15)
 

--- a/tests/unit/test_api_es.py
+++ b/tests/unit/test_api_es.py
@@ -532,27 +532,34 @@ class TestElasticClient:
         testQueryES = testInstance.identifierQuery(['testIdent'], 'testIdent')
         testQuery = testQueryES.to_dict()
 
-        assert testInstance.searchedFields == ['identifiers', 'editions.identifiers']
-        assert testQuery['bool']['should'][0]['query_string']['query'] == 'testIdent'
-        assert testQuery['bool']['should'][0]['query_string']['fields'] == ['identifiers.*']
-        assert testQuery['bool']['should'][1]['nested']['path'] == 'editions'
-        assert testQuery['bool']['should'][1]['nested']['query']['query_string']['query'] == 'testIdent'
-        assert testQuery['bool']['should'][1]['nested']['query']['query_string']['fields'] == ['editions.identifiers.*']
-        assert testQuery['bool']['should'][1]['nested']['query']['query_string']['default_operator'] == 'and'
+        assert testInstance.searchedFields == ['identifiers.identifier', 'editions.identifiers.identifier',
+                                                'identifiers.authority', 'editions.identifiers.authority']
+        assert testQuery['bool']['should'][0]['nested']['path'] == 'identifiers'
+        assert testQuery['bool']['should'][0]['nested']['query']['bool']['must'][0]['term']['query'] == 'testIdent'
+        assert testQuery['bool']['should'][0]['nested']['query']['bool']['must'][0]['term']['fields'] == ['identifiers.identifier']
+        assert testQuery['bool']['should'][1]['nested']['path'] == 'editions.identifiers'
+        assert testQuery['bool']['should'][1]['nested']['query']['bool']['must'][0]['term']['query'] == 'testIdent'
+        assert testQuery['bool']['should'][1]['nested']['query']['bool']['must'][0]['term']['fields'] == ['editions.identifiers.identifier']
+
 
     def test_identifierQuery_AuthIdent(self, testInstance):
         testQueryES = testInstance.identifierQuery(['testAuth'], 'testAuth: testIdent')
         testQuery = testQueryES.to_dict()
 
-        assert testInstance.searchedFields == ['identifiers', 'editions.identifiers']
-        assert testQuery['bool']['should'][0]['query_string']['query'] == 'testAuth'
-        assert testQuery['bool']['should'][0]['query_string']['fields'] == ['identifiers.authority']
-        assert testQuery['bool']['should'][1]['query_string']['query'] == 'testIdent'
-        assert testQuery['bool']['should'][1]['query_string']['fields'] == ['identifiers.identifier']
-        assert testQuery['bool']['should'][2]['nested']['path'] == 'editions'
-        assert testQuery['bool']['should'][2]['nested']['query']['query_string']['query'] == 'testIdent'
-        assert testQuery['bool']['should'][2]['nested']['query']['query_string']['fields'] == ['editions.identifiers.identifier']
-        assert testQuery['bool']['should'][2]['nested']['query']['query_string']['default_operator'] == 'and'
+        assert testInstance.searchedFields == ['identifiers.identifier', 'editions.identifiers.identifier',
+                                                'identifiers.authority', 'editions.identifiers.authority']
+        assert testQuery['bool']['should'][0]['nested']['path'] == 'identifiers'
+        assert testQuery['bool']['should'][0]['nested']['query']['bool']['must'][0]['term']['query'] == 'testAuth'
+        assert testQuery['bool']['should'][0]['nested']['query']['bool']['must'][0]['term']['fields'] == ['identifiers.authority']
+        assert testQuery['bool']['should'][1]['nested']['path'] == 'editions.identifiers'
+        assert testQuery['bool']['should'][1]['nested']['query']['bool']['must'][0]['term']['query'] == 'testAuth'
+        assert testQuery['bool']['should'][1]['nested']['query']['bool']['must'][0]['term']['fields'] == ['editions.identifiers.authority']
+        assert testQuery['bool']['should'][2]['nested']['path'] == 'identifiers'
+        assert testQuery['bool']['should'][2]['nested']['query']['bool']['must'][0]['term']['query'] == 'testIdent'
+        assert testQuery['bool']['should'][2]['nested']['query']['bool']['must'][0]['term']['fields'] == ['identifiers.identifier']
+        assert testQuery['bool']['should'][3]['nested']['path'] == 'editions.identifiers'
+        assert testQuery['bool']['should'][3]['nested']['query']['bool']['must'][0]['term']['query'] == 'testIdent'
+        assert testQuery['bool']['should'][3]['nested']['query']['bool']['must'][0]['term']['fields'] == ['editions.identifiers.identifier']
 
     def test_getFromSize(self):
         startPosition, endPosition = ElasticClient.getFromSize(3, 15)


### PR DESCRIPTION
I changed the identifier queries to resemble the author queries since both of them utilize nested fields when searching. Due to this change, I adjusted the unit tests as well.