### PR TITLE
SFR-1543: Adding Read Online Link to Collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Multi-host configuration for ES connections
 - Script to reindex ES works into new ES cluster
 - Logstash file for reindexing ES works for new cluster
+- Updated links array for collectionFetch endpoint with Read Online link
 
 ### Fixed
 - Updated unit tests for developmentSetup process

--- a/api/blueprints/drbCollection.py
+++ b/api/blueprints/drbCollection.py
@@ -236,6 +236,11 @@ def constructOPDSFeed(
             'href': 'https://{}.nypl.org/edition/{}'.format(host, ed.id),
             'type': 'text/html'
         })
+        pub.addLink({
+            'rel': 'alternate',
+            'href': 'https://{}.nypl.org/read/{}'.format(host, ed.id),
+            'type': 'application/pdf'
+        })
 
         opdsPubs.append(pub)
 

--- a/scriptRunner.py
+++ b/scriptRunner.py
@@ -2,7 +2,7 @@ import inspect
 import sys
 from main import loadEnvFile
 
-loadEnvFile('local-qa', fileString='config/{}.yaml')
+loadEnvFile('local-qa-old', fileString='config/{}.yaml')
 
 import scripts
 

--- a/scripts/deleteElasticRecords.py
+++ b/scripts/deleteElasticRecords.py
@@ -14,8 +14,6 @@ def main():
     
     logging.basicConfig(filename='deleteESRecords.log', encoding='utf-8', level=logging.INFO)
 
-    loadEnvFile('local-qa', fileString='config/{}.yaml')
-
     dbManager = DBManager(
         user= os.environ.get('POSTGRES_USER', None),
         pswd= os.environ.get('POSTGRES_PSWD', None),

--- a/scripts/extractAllEditions.py
+++ b/scripts/extractAllEditions.py
@@ -9,7 +9,6 @@ from model.utilities.extractDailyEdition import extract
 def main():
     '''Extracting the edition number from the edition_statement column of the DRB database to fill out the edition column'''
 
-    loadEnvFile('local-qa', fileString='config/{}.yaml')
 
     dbManager = DBManager(
         user= os.environ.get('POSTGRES_USER', None),

--- a/scripts/govDocES.py
+++ b/scripts/govDocES.py
@@ -11,8 +11,6 @@ def main():
 
     '''Updating is_government_document field of current gov doc works in ES to be the boolean value True'''
 
-    loadEnvFile('local-qa', fileString='config/{}.yaml')
-
     dbManager = DBManager(
         user= os.environ.get('POSTGRES_USER', None),
         pswd= os.environ.get('POSTGRES_PSWD', None),

--- a/scripts/updateESEditionFormats.py
+++ b/scripts/updateESEditionFormats.py
@@ -10,8 +10,6 @@ def main():
 
     '''Updating NYPL catalog records with new link to replace text/html link'''
 
-    loadEnvFile('local-qa', fileString='config/{}.yaml')
-
     dbManager = DBManager(
         user=os.environ.get('POSTGRES_USER', None),
         pswd=os.environ.get('POSTGRES_PSWD', None),

--- a/scripts/updateLinksCatalog.py
+++ b/scripts/updateLinksCatalog.py
@@ -9,8 +9,6 @@ def main():
     
     '''Updating NYPL Link media type with new link to replace text/html link'''
 
-    loadEnvFile('local-qa', fileString='config/{}.yaml')
-
     dbManager = DBManager(
         user= os.environ.get('POSTGRES_USER', None),
         pswd= os.environ.get('POSTGRES_PSWD', None),

--- a/scripts/updateOldInTechOpenLinks.py
+++ b/scripts/updateOldInTechOpenLinks.py
@@ -11,8 +11,6 @@ def main():
 
     '''Updating current IntechOpen records with new HTML Links to fix Read Online links on DRB site'''
 
-    loadEnvFile('local-qa', fileString='config/{}.yaml')
-
     dbManager = DBManager(
         user= os.environ.get('POSTGRES_USER', None),
         pswd= os.environ.get('POSTGRES_PSWD', None),

--- a/scripts/updateRecordsCatalogLink.py
+++ b/scripts/updateRecordsCatalogLink.py
@@ -10,8 +10,6 @@ def main():
     
     '''Updating NYPL catalog records with new link to replace text/html link'''
 
-    loadEnvFile('local-qa', fileString='config/{}.yaml')
-
     dbManager = DBManager(
         user= os.environ.get('POSTGRES_USER', None),
         pswd= os.environ.get('POSTGRES_PSWD', None),


### PR DESCRIPTION
This PR focuses on updating the collectionFetch endpoint with the Read Online link that was previously not visible such as this [https://digital-research-books-beta.nypl.org/read/543649](url). I'm not sure if the rel, type, and id in the url I typed are the correct ones, but the format is similar to the other links in the array. Sean gave an example of a collection with no Read Online link on Jira under the comments of the SFR-1543 ticket as well. Also, I removed the `loadEnvFile` from all the modules in the `scripts` directory since the `scriptrunner.py` module has it already.