### PR TITLE
SFR-1509_v3: Replacing colon with pipe character in identifier query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Updated search endpoint to add 'identifier' as a keyword
 - Identifier & Authority as query terms in APIUtils class 
 - Multi-host configuration for ES connections
-- Script to reindex ES works into new ES cluster
+- Script to reindex ES records into new ES cluster
 - Logstash file for reindexing ES works for new cluster
 
 ### Fixed

--- a/api/elastic.py
+++ b/api/elastic.py
@@ -49,7 +49,7 @@ class ElasticClient():
         return self.executeSearchQuery(params, page, perPage)
 
     def generateSearchQuery(self, params):
-        authorityList =['isbn', 'issn', 'lcc', 'lccn', 'oclc', 'nypl', 'hathi', 'gutenberg', 'doab']
+        authorityList =['isbn', 'issn', 'lcc', 'lccn', 'oclc', 'owi', 'nypl', 'hathi', 'gutenberg', 'doab']
 
         search = self.createSearch()
         search.source(['uuid', 'editions'])
@@ -237,7 +237,7 @@ class ElasticClient():
         self.searchedFields.extend(['identifiers.identifier', 'editions.identifiers.identifier',
                                     'identifiers.authority', 'editions.identifiers.authority'])
 
-        authIdentList = authIdentText.split(': ')
+        authIdentList = authIdentText.split('|')
 
         #When user only types in the identifier in the search bar
         if len(authIdentList) < 2:

--- a/tests/unit/test_api_es.py
+++ b/tests/unit/test_api_es.py
@@ -251,7 +251,7 @@ class TestElasticClient:
         searchMocks['subjectQuery'].assert_not_called()
         searchMocks['authorityQuery'].assert_not_called()
         searchMocks['identifierQuery'].assert_called_once_with(['isbn', 'issn', 'lcc', 'lccn', \
-                                                            'oclc', 'nypl', 'hathi', 'gutenberg', \
+                                                            'oclc', 'owi', 'nypl', 'hathi', 'gutenberg', \
                                                             'doab'], 'escapedQuery')
 
 
@@ -541,7 +541,7 @@ class TestElasticClient:
 
 
     def test_identifierQuery_AuthIdent(self, testInstance):
-        testQueryES = testInstance.identifierQuery(['testAuth'], 'testAuth: testIdent')
+        testQueryES = testInstance.identifierQuery(['testAuth'], 'testAuth|testIdent')
         testQuery = testQueryES.to_dict()
 
         assert testInstance.searchedFields == ['identifiers.identifier', 'editions.identifiers.identifier',


### PR DESCRIPTION
In this branch, I decided to replace the colon and space characters when splitting the identifier query into just a pipe character which should help fix the tests in QA concerning the search results of "identifier type: value" returning nothing. However, this fix doesn't attempt to fix the identifier query when a doab identifier is given, so I think it best to create a separate bug ticket to fix this edge case at a later date.