### PR TITLE
SFR-1503: Added format filter for work and edition pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+
+## unreleased version -- v0.11.1
+### Added
+- Filter parameter for formats on work and edition detail pages
+### Fixed
+-
 ## 2022-11-28 -- v0.11.0
 ### Added
 - Docker Compose file to set up local dev environment

--- a/api/blueprints/drbWork.py
+++ b/api/blueprints/drbWork.py
@@ -16,15 +16,26 @@ def workFetch(uuid):
     dbClient.createSession()
 
     searchParams = APIUtils.normalizeQueryParams(request.args)
+
+    terms = {}
+    for param in ['filter']:
+        terms[param] = APIUtils.extractParamPairs(param, searchParams)
+    
     showAll = searchParams.get('showAll', ['true'])[0].lower() != 'false'
     readerVersion = searchParams.get('readerVersion', [None])[0]\
         or current_app.config['READER_VERSION']
 
-    work = dbClient.fetchSingleWork(uuid)
+    filteredFormats = [
+        mediaType for f in list(filter(
+            lambda x: x[0] == 'format', terms['filter']
+         ))
+         for mediaType in APIUtils.FORMAT_CROSSWALK[f[1]]
+     ]
 
+    work = dbClient.fetchSingleWork(uuid)
     if work:
         statusCode = 200
-        responseBody = APIUtils.formatWorkOutput(work, None, showAll=showAll, reader=readerVersion)
+        responseBody = APIUtils.formatWorkOutput(work, None, showAll=showAll, formats=filteredFormats, reader=readerVersion)
         
     else:
         statusCode = 404

--- a/api/utils.py
+++ b/api/utils.py
@@ -121,7 +121,8 @@ class APIUtils():
     def formatWorkOutput(
         cls, works, identifiers, showAll=True, formats=None, reader=None
     ):
-        if isinstance(works, list):
+        #Multiple formatted works with formats specified
+        if isinstance(works, list) and identifiers != None:
             outWorks = []
             workDict = {str(work.uuid): work for work in works}
 
@@ -144,6 +145,19 @@ class APIUtils():
                 outWorks.append(outWork)
 
             return outWorks
+        #Formatted work with a specific format given
+        elif formats != None and identifiers == None:
+            formattedWork = cls.formatWork(
+                works, None, showAll, formats, reader=reader
+            )
+
+            formattedWork['editions'].sort(
+                key=lambda x: x['publication_date']
+                if x['publication_date'] else 9999
+            )
+
+            return formattedWork
+        #Formatted work with no format specified
         else:
             formattedWork = cls.formatWork(
                 works, None, showAll, reader=reader
@@ -194,13 +208,13 @@ class APIUtils():
 
     @classmethod
     def formatEditionOutput(
-        cls, edition, records=None, showAll=False, reader=None
+        cls, edition, records=None, showAll=False, formats=None, reader=None
     ):
         editionWorkTitle = edition.work.title
         editionWorkAuthors = edition.work.authors
         
         return cls.formatEdition(
-            edition, editionWorkTitle, editionWorkAuthors, records, showAll=showAll, reader=reader
+            edition, editionWorkTitle, editionWorkAuthors, records, formats, showAll=showAll, reader=reader
         )
     
 

--- a/tests/unit/test_api_edition_blueprint.py
+++ b/tests/unit/test_api_edition_blueprint.py
@@ -11,6 +11,7 @@ class TestEditionBlueprint:
         return mocker.patch.multiple(
             APIUtils,
             normalizeQueryParams=mocker.DEFAULT,
+            extractParamPairs=mocker.DEFAULT,
             formatResponseObject=mocker.DEFAULT,
             formatEditionOutput=mocker.DEFAULT
         )
@@ -23,7 +24,7 @@ class TestEditionBlueprint:
 
         return flaskApp
 
-    def test_editionFetch_success(self, mockUtils, testApp, mocker):
+    def test_editionFetch_success_noFormat(self, mockUtils, testApp, mocker):
         mockDB = mocker.MagicMock()
         mockDBClient = mocker.patch('api.blueprints.drbEdition.DBClient')
         mockDBClient.return_value = mockDB
@@ -47,11 +48,52 @@ class TestEditionBlueprint:
 
             mockUtils['normalizeQueryParams'].assert_called_once()
             mockUtils['formatEditionOutput'].assert_called_once_with(
-                mockEdition, records='testRecords', showAll=True, reader='test'
+                mockEdition, records='testRecords', showAll=True, formats=[], reader='test'
             )
             mockUtils['formatResponseObject'].assert_called_once_with(
                 200, 'singleEdition', 'testEdition'
             )
+
+    def test_editionFetch_success_format(self, mockUtils, testApp, mocker):
+        mockDB = mocker.MagicMock()
+        mockDBClient = mocker.patch('api.blueprints.drbEdition.DBClient')
+        mockDBClient.return_value = mockDB
+
+        queryParams = {'showAll': ['true']}
+        mockUtils['normalizeQueryParams'].return_value = {'showAll': ['true']}
+
+        mockEdition = mocker.MagicMock(dcdw_uuids='testUUID')
+
+        mockUtils['extractParamPairs'].side_effect = [
+            [('format', 'requestable')]
+        ]
+
+        mockDB.fetchSingleEdition.return_value = mockEdition
+        mockDB.fetchRecordsByUUID.return_value = 'testRecords'
+
+        mockUtils['formatEditionOutput'].return_value = 'testEdition'
+        mockUtils['formatResponseObject'].return_value\
+            = 'singleEditionResponse'
+
+        with testApp.test_request_context('/'):
+            testAPIResponse = editionFetch(1)
+
+            assert testAPIResponse == 'singleEditionResponse'
+            mockDBClient.assert_called_once_with('testDBClient')
+
+            mockUtils['normalizeQueryParams'].assert_called_once()
+            mockUtils['extractParamPairs'].assert_has_calls([
+                mocker.call('filter', queryParams)
+            ])
+            mockUtils['formatEditionOutput'].assert_called_once_with(
+                mockEdition, records='testRecords', showAll=True, 
+                                    formats=['application/html+edd', 'application/x.html+edd'], reader='test'
+            )
+            mockUtils['formatResponseObject'].assert_called_once_with(
+                200, 'singleEdition', 'testEdition'
+            )
+
+
 
     def test_editionFetch_missing(self, mockUtils, testApp, mocker):
         mockDB = mocker.MagicMock()

--- a/tests/unit/test_api_utils.py
+++ b/tests/unit/test_api_utils.py
@@ -366,7 +366,7 @@ class TestAPIUtils:
         ) == 'testEdition'
 
         mockFormatEdition.assert_called_once_with(
-            mockEdition, mockEdition.work.title, mockEdition.work.authors, 'testRecords', showAll=True, reader=None
+            mockEdition, mockEdition.work.title, mockEdition.work.authors, 'testRecords', None, showAll=True, reader=None
         )
 
     def test_formatEdition_no_records(self, testEdition):


### PR DESCRIPTION
In this PR, I updated the work and edition blueprints to extract the filter parameter and the format values of not just requestable, but also readable and downloadable formats due to `formatEditionOutput` already doing the work of filtering out links that don't match the given formats. Also, I updated the unit tests for APIUtils and the work and edition blueprints as well. This work (`096911fb-3875-4763-adaf-de97fcafc526`) is an example of a readable and downloadable work to test the format filter out. This work (`1f944742-2789-4cbc-98bd-a74505645a37`) is an example of a requestable work with a readable edition so this is another good test example.