### PR TITLE
SFR-1578: Updated identifier search for escaped characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 ### Added
 - Format filter parameters for work and edition detail pages
 ### Fixed
--
+- Identifier search for identifiers with special characters now work
+
 ## 2022-11-28 -- v0.11.0
 ### Added
 - Docker Compose file to set up local dev environment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 - Format filter parameters for work and edition detail pages
 ### Fixed
-- Identifier search for identifiers with special characters now work
+- Identifier search for identifiers with special characters work now
 
 ## 2022-11-28 -- v0.11.0
 ### Added

--- a/api/elastic.py
+++ b/api/elastic.py
@@ -239,7 +239,6 @@ class ElasticClient():
 
         #User will type in authority|identifier in the url
         authIdentList = authIdentText.split('|')
-        print(authIdentList)
 
         #When user only types in the identifier in the search bar
         if len(authIdentList) < 2:

--- a/api/elastic.py
+++ b/api/elastic.py
@@ -49,7 +49,7 @@ class ElasticClient():
         return self.executeSearchQuery(params, page, perPage)
 
     def generateSearchQuery(self, params):
-        authorityList =['isbn', 'issn', 'lcc', 'lccn', 'oclc', 'owi', 'nypl', 'hathi', 'gutenberg', 'doab']
+        authorityList =['isbn', 'issn', 'lcc', 'lccn', 'oclc', 'owi', 'nypl', 'hathi', 'gutenberg', 'doab', 'doi']
 
         search = self.createSearch()
         search.source(['uuid', 'editions'])
@@ -71,9 +71,9 @@ class ElasticClient():
             elif field == 'subject':
                 searchClauses.append(self.subjectQuery(escapedQuery))
             elif field == 'viaf' or field == 'lcnaf':
-                searchClauses.append(self.authorityQuery(field, escapedQuery))
+                searchClauses.append(self.authorityQuery(field, query))
             elif field == 'identifier':
-                searchClauses.append(self.identifierQuery(authorityList, escapedQuery))
+                searchClauses.append(self.identifierQuery(authorityList, query))
             else:
                 searchClauses.append(Q('match', **{field: escapedQuery}))
 
@@ -238,8 +238,8 @@ class ElasticClient():
                                     'identifiers.authority', 'editions.identifiers.authority'])
 
         #User will type in authority|identifier in the url
-        #Need backslash to avoid the pipe character from being escaped due to the escapeSearchQuery method
-        authIdentList = authIdentText.split('\|')
+        authIdentList = authIdentText.split('|')
+        print(authIdentList)
 
         #When user only types in the identifier in the search bar
         if len(authIdentList) < 2:

--- a/tests/unit/test_api_es.py
+++ b/tests/unit/test_api_es.py
@@ -221,7 +221,8 @@ class TestElasticClient:
         searchMocks['titleQuery'].assert_not_called()
         searchMocks['authorQuery'].assert_not_called()
         searchMocks['subjectQuery'].assert_not_called()
-        searchMocks['authorityQuery'].assert_called_once_with('viaf', 'escapedQuery')
+        searchMocks['authorityQuery'].assert_called_once_with('viaf', 'test')
+        searchMocks['identifierQuery'].assert_not_called()
 
         mockSearch.query.assert_called_once_with('searchClauses')
 
@@ -252,7 +253,7 @@ class TestElasticClient:
         searchMocks['authorityQuery'].assert_not_called()
         searchMocks['identifierQuery'].assert_called_once_with(['isbn', 'issn', 'lcc', 'lccn', \
                                                             'oclc', 'owi', 'nypl', 'hathi', 'gutenberg', \
-                                                            'doab'], 'escapedQuery')
+                                                            'doab', 'doi'], 'test')
 
 
         mockSearch.query.assert_called_once_with('searchClauses')
@@ -315,7 +316,8 @@ class TestElasticClient:
         searchMocks['titleQuery'].assert_called_once_with('escapedQuery')
         searchMocks['authorQuery'].assert_not_called()
         searchMocks['subjectQuery'].assert_not_called()
-        searchMocks['authorityQuery'].assert_called_once_with('lcnaf', 'escapedQuery')
+        searchMocks['authorityQuery'].assert_called_once_with('lcnaf', 'test')
+        searchMocks['identifierQuery'].assert_not_called()
 
         mockSearch.query.assert_called_once_with('searchClauses')
 
@@ -547,9 +549,11 @@ class TestElasticClient:
         assert testInstance.searchedFields == ['identifiers.identifier', 'editions.identifiers.identifier',
                                                 'identifiers.authority', 'editions.identifiers.authority']
         assert testQuery['bool']['should'][0]['nested']['path'] == 'identifiers'
-        assert testQuery['bool']['should'][0]['nested']['query']['bool']['must'][0]['term']== {'identifiers.identifier': 'testAuth|testIdent'}
+        assert testQuery['bool']['should'][0]['nested']['query']['bool']['must'][0]['term'] == {'identifiers.authority': 'testAuth'}
+        assert testQuery['bool']['should'][0]['nested']['query']['bool']['must'][1]['term'] == {'identifiers.identifier': 'testIdent'}
         assert testQuery['bool']['should'][1]['nested']['path'] == 'editions.identifiers'
-        assert testQuery['bool']['should'][1]['nested']['query']['bool']['must'][0]['term'] == {'editions.identifiers.identifier': 'testAuth|testIdent'}
+        assert testQuery['bool']['should'][1]['nested']['query']['bool']['must'][0]['term'] == {'editions.identifiers.authority': 'testAuth'}
+        assert testQuery['bool']['should'][1]['nested']['query']['bool']['must'][1]['term'] == {'editions.identifiers.identifier': 'testIdent'}
        
         
     def test_getFromSize(self):


### PR DESCRIPTION
In this PR, I replaced the escapedQuery in the `identifierQuery` and `authorityQuery` method with the original query, so special characters aren't escaped when searching for specific identifiers like DOAB or DOI. Also, I removed the backslash when splitting the `authIdent` list by the pipe character since the query is no longer being escaped.