### PR TITLE
SFR-1590_inCollection Property in Work and Edition API Responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unreleased version -- v0.11.2
 ### Added
-- 
+- inColection property to the work and edition API responses
 ### Fixed
 - drb_local_devSetUp Docker container exiting out due to ES authentication error
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unreleased version -- v0.11.2
 ### Added
-- inColection property to the work and edition API responses
+- inCollection property to the work and edition API responses
 ### Fixed
 - drb_local_devSetUp Docker container exiting out due to ES authentication error
 

--- a/api/blueprints/drbEdition.py
+++ b/api/blueprints/drbEdition.py
@@ -33,7 +33,7 @@ def editionFetch(editionID):
         records = dbClient.fetchRecordsByUUID(edition.dcdw_uuids)
 
         responseBody = APIUtils.formatEditionOutput(
-            edition, records=records, showAll=showAll, formats=filteredFormats, reader=readerVersion
+            edition, records=records, dbClient=dbClient, showAll=showAll, formats=filteredFormats, reader=readerVersion
         )
     else:
         statusCode = 404

--- a/api/blueprints/drbWork.py
+++ b/api/blueprints/drbWork.py
@@ -30,7 +30,7 @@ def workFetch(uuid):
     work = dbClient.fetchSingleWork(uuid)
     if work:
         statusCode = 200
-        responseBody = APIUtils.formatWorkOutput(work, None, showAll=showAll, formats=filteredFormats, reader=readerVersion)
+        responseBody = APIUtils.formatWorkOutput(work, None, showAll=showAll, dbClient=dbClient, formats=filteredFormats, reader=readerVersion)
         
     else:
         statusCode = 404

--- a/swagger.v4.json
+++ b/swagger.v4.json
@@ -777,7 +777,7 @@
                         "required": false
                     },
                     {
-                        "name": "perGage",
+                        "name": "perPage",
                         "in": "query",
                         "description": "Number of collections to load per page",
                         "type": "integer",

--- a/tests/unit/test_api_edition_blueprint.py
+++ b/tests/unit/test_api_edition_blueprint.py
@@ -48,7 +48,7 @@ class TestEditionBlueprint:
 
             mockUtils['normalizeQueryParams'].assert_called_once()
             mockUtils['formatEditionOutput'].assert_called_once_with(
-                mockEdition, records='testRecords', showAll=True, formats=[], reader='test'
+                mockEdition, records='testRecords', dbClient=mockDB, showAll=True, formats=[], reader='test'
             )
             mockUtils['formatResponseObject'].assert_called_once_with(
                 200, 'singleEdition', 'testEdition'
@@ -86,7 +86,7 @@ class TestEditionBlueprint:
                 mocker.call('filter', queryParams)
             ])
             mockUtils['formatEditionOutput'].assert_called_once_with(
-                mockEdition, records='testRecords', showAll=True, 
+                mockEdition, records='testRecords', showAll=True, dbClient=mockDB, 
                                     formats=['application/html+edd', 'application/x.html+edd'], reader='test'
             )
             mockUtils['formatResponseObject'].assert_called_once_with(

--- a/tests/unit/test_api_work_blueprint.py
+++ b/tests/unit/test_api_work_blueprint.py
@@ -44,7 +44,7 @@ class TestSearchBlueprint:
 
             mockUtils['normalizeQueryParams'].assert_called_once
             mockUtils['formatWorkOutput'].assert_called_once_with(
-                'dbWorkRecord', None, showAll=True, formats=[], reader='test'
+                'dbWorkRecord', None, showAll=True, dbClient=mockDB, formats=[], reader='test'
             )
             mockUtils['formatResponseObject'].assert_called_once_with(
                 200, 'singleWork', 'testWork'
@@ -78,7 +78,7 @@ class TestSearchBlueprint:
                 mocker.call('filter', queryParams)
             ])
             mockUtils['formatWorkOutput'].assert_called_once_with(
-                'dbWorkRecord', None, showAll=True, formats=['application/html+edd', 'application/x.html+edd'], reader='test'
+                'dbWorkRecord', None, showAll=True, dbClient=mockDB, formats=['application/html+edd', 'application/x.html+edd'], reader='test'
             )
             mockUtils['formatResponseObject'].assert_called_once_with(
                 200, 'singleWork', 'testWork'
@@ -104,7 +104,7 @@ class TestSearchBlueprint:
 
             mockUtils['normalizeQueryParams'].assert_called_once
             mockUtils['formatWorkOutput'].assert_called_once_with(
-                'dbWorkRecord', None, showAll=False, formats=[], reader='test'
+                'dbWorkRecord', None, showAll=False, dbClient=mockDB, formats=[], reader='test'
             )
             mockUtils['formatResponseObject'].assert_called_once_with(
                 200, 'singleWork', 'testWork'


### PR DESCRIPTION
In this PR, I updated APIUtils with a new checkEditionInCollection method for the work and edition API responses which adds  the metadata objects of the collections these works/editions are part of within an array. I also adjusted the tests and fixed a small typo in the swagger document. Some feedback on simplifying the queries or conditionals would be helpful.