### PR TITLE
feat: Simplify dev setup for newrelic

### DIFF
--- a/main.py
+++ b/main.py
@@ -73,7 +73,7 @@ def createArgParser():
     parser.add_argument('-r', '--singleRecord',
                         help='Single record ID for ingesting an individual record (only applicable for DOAB)')
     parser.add_argument('options', nargs='*', help='Additional arguments')
-    
+
     return parser
 
 
@@ -111,11 +111,11 @@ def loadEnvFile(runType, fileString=None):
     if envDict:
         for key, value in envDict.items():
             os.environ[key] = value
-    
+
 
 if __name__ == '__main__':
     parser = createArgParser()
-    args = parser.parse_args() 
+    args = parser.parse_args()
 
     loadEnvFile(args.environment, './config/{}.yaml')
     os.environ['ENVIRONMENT'] = args.environment

--- a/main.py
+++ b/main.py
@@ -7,14 +7,15 @@ import yaml
 
 from logger import createLog
 
-#NEW_RELIC_LICENSE_KEY = Put license key here
-#ENVIRONMENT = Put environment here
-
-if os.environ.get('NEW_RELIC_LICENSE_KEY', None):
-    newrelic.agent.initialize(
-        config_file='newrelic.ini',
-        environment=os.environ.get('ENVIRONMENT', 'local')
-        )
+# The prod and QA environments get a `NEW_RELIC_LICENSE_KEY` env var injected
+# during the build. For testing against new relic in dev, either set that env
+# directly or update the `license_key` field in `newrelic.ini`. In either case,
+# to actually send data to newrelic, you'll need to ensure your environment's
+# 'monitor_enabled' entry is set to `true` in `newrelic.ini`
+newrelic.agent.initialize(
+    config_file='newrelic.ini',
+    environment=os.environ.get('ENVIRONMENT', 'local'),
+)
 
 def main(args):
     logger = createLog(__name__)


### PR DESCRIPTION
This shouldn't be a common issue, since testing new relic changes
locally should be pretty rare, but I found this a tad confusing. Instead
of the conditional and commented out variables, I think we can just
point the dev at the appropriate configs. The other upside to this
approach is that with `monitor_enabled` set to false and with an empty
license key, the newrelic agent gives us nice logs without sending data
up:
```
drb_local_webapp    | 2023-01-23 17:53:08,786 (41/MainThread) newrelic.api.transaction DEBUG - record_log_event has been called but no transaction or application was running. As a result, the following event has not been recorded. message: 'Starting API...' level: 'INFO' timestamp 1674496388785. To correct this problem, supply an application object as a parameter to this record_log_event call.
drb_local_webapp    | {"timestamp":1674496388785,"message":"Starting API...","log.level":"INFO","logger.name":"processes.api","thread.id":139994393364288,"thread.name":"MainThread","process.id":41,"process.name":"MainProcess","file.name":"/src/processes/api.py","line.number":24,"entity.type":"SERVICE"}
```
Maybe noisy, but also perhaps useful?