### PR TITLE
HOTFIX: Added new parameters to collection/uuid endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unreleased version -- v0.11.2
 ### Added
-- 
+- Sort and Perpage parameters for collection/uuid endpoint in swagger file
 ### Fixed
 - drb_local_devSetUp Docker container exiting out due to ES authentication error
 

--- a/swagger.v4.json
+++ b/swagger.v4.json
@@ -681,6 +681,20 @@
                         "description": "UUID for publication record",
                         "type": "string",
                         "required": true
+                    },
+                    {
+                        "name": "sort",
+                        "in": "query",
+                        "description": "Method of sorting collections. Either title or creator",
+                        "type": "string",
+                        "required": false
+                    },
+                    {
+                        "name": "perPage",
+                        "in": "query",
+                        "description": "Number of collections to load per page",
+                        "type": "integer",
+                        "required": false
                     }
                 ],
                 "responses": {
@@ -777,7 +791,7 @@
                         "required": false
                     },
                     {
-                        "name": "perGage",
+                        "name": "perPage",
                         "in": "query",
                         "description": "Number of collections to load per page",
                         "type": "integer",


### PR DESCRIPTION
Jackie informed me that `perPage` and `sortBy` parameters are missing from the /collection/{uuid} GET request endpoint since they’ll be needed when retrieving data from the Collections page on the frontend, so I added the parameters in the swagger file and they should appear in the QA apidocs site (https://drb-api-qa.nypl.org/apidocs/#/) when this branch is merged into main.