### PR TITLE
fix: Pass DBClient to work formatter in search

### DIFF
--- a/api/blueprints/drbSearch.py
+++ b/api/blueprints/drbSearch.py
@@ -77,7 +77,7 @@ def standardQuery():
     dataBlock = {
         'totalWorks': searchResult.hits.total.value,
         'works': APIUtils.formatWorkOutput(
-            works, results, formats=filteredFormats, reader=readerVersion
+            works, results, dbClient=dbClient, formats=filteredFormats, reader=readerVersion
         ),
         'paging': paging,
         'facets': facets

--- a/api/utils.py
+++ b/api/utils.py
@@ -88,7 +88,7 @@ class APIUtils():
                 print(key, value)
                 aggs[parentKey] = [
                     {'value': b['key'], 'count': b['editions_per']['doc_count']}
-                    if 'editions_per' in b.keys() else 
+                    if 'editions_per' in b.keys() else
                     {'value': b['key_as_string'],'count': b['doc_count']}
                     for b in value
                 ]
@@ -101,7 +101,7 @@ class APIUtils():
                 }
 
         return aggs
-        
+
     @staticmethod
     def formatFilters(terms):
         formats = [
@@ -130,7 +130,7 @@ class APIUtils():
 
     @classmethod
     def formatWorkOutput(
-        cls, works, identifiers, showAll=True, dbClient=None, formats=None, reader=None
+        cls, works, identifiers, dbClient, showAll=True, formats=None, reader=None
     ):
         #Multiple formatted works with formats specified
         if isinstance(works, list):
@@ -228,7 +228,7 @@ class APIUtils():
         editionWorkTitle = edition.work.title
         editionWorkAuthors = edition.work.authors
         editionInCollection = cls.checkEditionInCollection(None, edition, dbClient)
-        
+
         return cls.formatEdition(
             edition, editionWorkTitle, editionWorkAuthors, editionInCollection, records, formats, showAll=showAll, reader=reader
         )
@@ -252,8 +252,8 @@ class APIUtils():
                                 'numberOfItems': len(collection.editions)
                                 }
                             collectionIDs.append(metadataOBJ)
-                            
-        else:          
+
+        else:
             for collection in dbClient.session.query(Collection) \
                 .join(COLLECTION_EDITIONS) \
                 .filter(COLLECTION_EDITIONS.c.edition_id == edition.id):

--- a/tests/unit/test_api_search_blueprint.py
+++ b/tests/unit/test_api_search_blueprint.py
@@ -137,6 +137,7 @@ class TestSearchBlueprint:
             mockUtils['formatWorkOutput'].assert_called_once_with(
                 ['work1', 'work2', 'work3', 'work4', 'work5'],
                 testResultIds,
+                dbClient=mockDB,
                 formats=['text/html'],
                 reader='test'
             )

--- a/tests/unit/test_api_utils.py
+++ b/tests/unit/test_api_utils.py
@@ -31,7 +31,7 @@ class TestAPIUtils:
 
     @pytest.fixture
     def testHitObject(self, mocker):
-        mockHits = [mocker.MagicMock(), mocker.MagicMock(), mocker.MagicMock()] 
+        mockHits = [mocker.MagicMock(), mocker.MagicMock(), mocker.MagicMock()]
         mockHits[0].meta.sort = ('firstSort',)
         mockHits[-1].meta.sort = ('lastSort',)
 
@@ -44,7 +44,7 @@ class TestAPIUtils:
                 self.attrs = []
                 for key, value in kwargs.items():
                     self.attrs.append(key)
-                    setattr(self, key, value)     
+                    setattr(self, key, value)
 
             def __iter__(self):
                 for attr in self.attrs:
@@ -225,7 +225,7 @@ class TestAPIUtils:
         testReadFormats = APIUtils.formatFilters({'filter': [('format', 'readable')]})
         testDownloadFormats = APIUtils.formatFilters({'filter': [('format', 'downloadable')]})
         testRequestFormats = APIUtils.formatFilters({'filter': [('format', 'requestable')]})
-        
+
         assert testReadFormats == ['application/epub+xml', 'text/html', 'application/webpub+json']
         assert testDownloadFormats == ['application/pdf', 'application/epub+zip']
         assert testRequestFormats == ['application/html+edd', 'application/x.html+edd']
@@ -265,12 +265,12 @@ class TestAPIUtils:
             ]
         }
 
-        outWork = APIUtils.formatWorkOutput('testWork', None)
+        outWork = APIUtils.formatWorkOutput('testWork', None, mocker.sentinel.dbClient)
 
         assert outWork['uuid'] == 1
         assert outWork['editions'][0]['id'] == 'ed3'
         assert outWork['editions'][2]['id'] == 'ed1'
-        mockFormat.assert_called_once_with('testWork', None, True, None, reader=None)
+        mockFormat.assert_called_once_with('testWork', None, True, mocker.sentinel.dbClient, reader=None)
 
     def test_formatWorkOutput_multiple_works(self, mocker):
         mockFormat = mocker.patch.object(APIUtils, 'formatWork')
@@ -288,13 +288,14 @@ class TestAPIUtils:
                 ('uuid1', 1, 'highlight1'),
                 ('uuid2', 2, 'highlight2'),
                 ('uuid3', 3, 'highlight3')
-            ]
+            ],
+            dbClient=mocker.sentinel.dbClient,
         )
 
         assert outWorks == ['formattedWork1', 'formattedWork2']
         mockFormat.assert_has_calls([
-            mocker.call(testWorks[0], 1, True, None, formats=None, reader=None),
-            mocker.call(testWorks[1], 2, True, None, formats=None, reader=None)
+            mocker.call(testWorks[0], 1, True, mocker.sentinel.dbClient, formats=None, reader=None),
+            mocker.call(testWorks[1], 2, True, mocker.sentinel.dbClient, formats=None, reader=None),
         ])
 
         mockAddMeta.assert_has_calls([


### PR DESCRIPTION
Looks like we weren't passing the client object, but failing with a default of `None`. Since the dbClient appears to be required for this to run, remove the default and pass it in.  Might make sense to require keyword args on some of these methods at some point.