### PR TITLE
Remove remaining background_task decorators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
 - Updated .gitignore to ignore vim generated `.swp` files and `ctags` file
 ### Fixed
 - drb_local_devSetUp Docker container exiting out due to ES authentication error
-- Fixed newrelic instrumentation for OCLC Classification process
 - Handle `ConnectTimeout` from OCLC Classify API
+- Updated newrelic instrumentation to encompass all background jobs
 
 ## 2022-12-22 -- v0.11.1
 ### Added

--- a/processes/core.py
+++ b/processes/core.py
@@ -1,8 +1,7 @@
-import newrelic.agent
-
 from managers import DBManager, RabbitMQManager, RedisManager, ElasticsearchManager, S3Manager, NyplApiManager
 from model import Record
 from static.manager import StaticManager
+
 
 class CoreProcess(DBManager, NyplApiManager, RabbitMQManager, RedisManager, StaticManager,
                   ElasticsearchManager, S3Manager):
@@ -15,8 +14,7 @@ class CoreProcess(DBManager, NyplApiManager, RabbitMQManager, RedisManager, Stat
 
         self.batchSize = batchSize
         self.records = set()
-    
-    @newrelic.agent.background_task()
+
     def addDCDWToUpdateList(self, rec):
         existing = self.session.query(Record)\
             .filter(Record.source_id == rec.record.source_id).first()
@@ -33,12 +31,11 @@ class CoreProcess(DBManager, NyplApiManager, RabbitMQManager, RedisManager, Stat
         else:
             print('NEW', rec.record)
             self.records.add(rec.record)
-        
+
         if len(self.records) >= self.batchSize:
             self.saveRecords()
             self.records = set()
-            
-    @newrelic.agent.background_task()
+
     def windowedQuery(self, table, query, windowSize=100):
         singleEntity = query.is_single_entity
         query = query.add_column(table.date_modified).order_by(table.date_modified)
@@ -63,12 +60,10 @@ class CoreProcess(DBManager, NyplApiManager, RabbitMQManager, RedisManager, Stat
 
             for row in queryChunk:
                 yield row[0] if singleEntity else row[0:-2]
-    
-    @newrelic.agent.background_task()
+
     def saveRecords(self):
         self.bulkSaveObjects(self.records)
 
-    @newrelic.agent.background_task()
     def sendFileToProcessingQueue(self, fileURL, s3Location):
         s3Message = {
             'fileData': {

--- a/processes/covers.py
+++ b/processes/covers.py
@@ -1,6 +1,5 @@
 from datetime import datetime, timedelta
 import os
-import newrelic.agent
 
 from .core import CoreProcess
 from managers import CoverManager
@@ -27,7 +26,6 @@ class CoverProcess(CoreProcess):
         self.ingestLimit = None
         self.runTime = datetime.utcnow()
 
-    @newrelic.agent.background_task()
     def runProcess(self):
         coverQuery = self.generateQuery()
 
@@ -36,7 +34,6 @@ class CoverProcess(CoreProcess):
         self.saveRecords()
         self.commitChanges()
 
-    @newrelic.agent.background_task()
     def generateQuery(self):
         baseQuery = self.session.query(Edition)
 
@@ -57,7 +54,6 @@ class CoverProcess(CoreProcess):
 
         return baseQuery.filter(*filters)
 
-    @newrelic.agent.background_task()
     def fetchEditionCovers(self, coverQuery):
         for edition in self.windowedQuery(Edition, coverQuery, windowSize=self.batchSize):
             coverManager = self.searchForCover(edition)
@@ -66,7 +62,6 @@ class CoverProcess(CoreProcess):
 
             if (self.runTime + timedelta(hours=12)) < datetime.utcnow(): break
 
-    @newrelic.agent.background_task()
     def searchForCover(self, edition):
         identifiers = [i for i in self.getEditionIdentifiers(edition)]
         manager = CoverManager(identifiers, self.session)
@@ -77,16 +72,14 @@ class CoverProcess(CoreProcess):
 
             return manager if manager.coverContent else None
 
-    @newrelic.agent.background_task()
     def getEditionIdentifiers(self, edition):
         for iden in edition.identifiers:
             if self.checkSetRedis('sfrCovers', iden.identifier, iden.authority, expirationTime=60*60*24*30):
                 logger.debug('{} recently queried. Skipping'.format(iden))
                 continue
-            
+
             yield (iden.identifier, iden.authority)
 
-    @newrelic.agent.background_task()
     def storeFoundCover(self, manager, edition):
         coverPath = 'covers/{}/{}.{}'.format(
             manager.fetcher.SOURCE,

--- a/processes/dbMaintenance.py
+++ b/processes/dbMaintenance.py
@@ -1,5 +1,3 @@
-import newrelic.agent
-
 from .core import CoreProcess
 from logger import createLog
 
@@ -24,7 +22,6 @@ class DatabaseMaintenanceProcess(CoreProcess):
 
         self.closeConnection()
 
-    @newrelic.agent.background_task()
     def vacuumTables(self):
         logger.info('Starting Vacuum of in-use tables')
         with self.engine.connect() as conn:

--- a/processes/hathiTrust.py
+++ b/processes/hathiTrust.py
@@ -3,7 +3,6 @@ from datetime import datetime
 from io import BytesIO
 import gzip
 import os
-import newrelic.agent
 import requests
 from requests.exceptions import ReadTimeout, HTTPError
 
@@ -31,12 +30,10 @@ class HathiTrustProcess(CoreProcess):
 
         self.saveRecords()
         self.commitChanges()
-        
-    @newrelic.agent.background_task()
+
     def importRemoteRecords(self, fullOrPartial=False):
         self.importFromHathiTrustDataFile(fullDump=fullOrPartial)
 
-    @newrelic.agent.background_task()
     def importFromSpecificFile(self, filePath):
         try:
             hathiFile = open(filePath, newline='')
@@ -46,14 +43,12 @@ class HathiTrustProcess(CoreProcess):
         hathiReader = csv.reader(hathiFile, delimiter='\t')
         self.readHathiFile(hathiReader)
 
-    @newrelic.agent.background_task()
     def parseHathiDataRow(self, dataRow):
         hathiRec = HathiMapping(dataRow, self.statics)
         hathiRec.applyMapping()
         self.addDCDWToUpdateList(hathiRec)
 
 
-    @newrelic.agent.background_task()
     def importFromHathiTrustDataFile(self, fullDump=False):
         try:
             fileList = requests.get(os.environ['HATHI_DATAFILES'], timeout=15)
@@ -85,7 +80,6 @@ class HathiTrustProcess(CoreProcess):
         else:
             return '%Y-%m-%d %H:%M:%S %z'
 
-    @newrelic.agent.background_task()
     def importFromHathiFile(self, hathiURL):
         try:
             hathiResp = requests.get(hathiURL, stream=True, timeout=30)
@@ -99,7 +93,6 @@ class HathiTrustProcess(CoreProcess):
             hathiTSV = csv.reader(hathiGzip, delimiter='\t')
             self.readHathiFile(hathiTSV)
 
-    @newrelic.agent.background_task()
     def readHathiFile(self, hathiTSV):
         while True:
             try:

--- a/processes/ingestReport.py
+++ b/processes/ingestReport.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timedelta
-import newrelic.agent
 from sqlalchemy import func
 
 from .core import CoreProcess
@@ -25,7 +24,6 @@ class IngestReportProcess(CoreProcess):
     def runProcess(self):
         self.generateReport()
 
-    @newrelic.agent.background_task()
     def generateReport(self):
         ingestDate = datetime.today()
         ingestDateStart = ingestDate.replace(hour=0, minute=0, second=0)
@@ -38,7 +36,6 @@ class IngestReportProcess(CoreProcess):
 
         self.smartsheet.insertRow(dailyRow)
 
-    @newrelic.agent.background_task()
     def getTableCounts(self, table, ingestStart, ingestEnd):
         logger.info('Getting Totals for {}'.format(table.__name__))
 
@@ -60,10 +57,9 @@ class IngestReportProcess(CoreProcess):
         return {
             'Total {}s'.format(table.__name__): totals['total'],
             '{}s Modified'.format(table.__name__): totals['modified'],
-            '{}s Created'.format(table.__name__): totals['created'] 
+            '{}s Created'.format(table.__name__): totals['created']
         }
 
-    @newrelic.agent.background_task()
     @staticmethod
     def setAnomalyStatus(total, modified, created):
         anomalyThreshold = total / 10

--- a/processes/met.py
+++ b/processes/met.py
@@ -1,7 +1,6 @@
 from datetime import datetime, timedelta
 import json
 import os
-import newrelic.agent
 import requests
 from requests.exceptions import HTTPError, ConnectionError
 
@@ -45,7 +44,6 @@ class METProcess(CoreProcess):
         self.s3Bucket = os.environ['FILE_BUCKET']
         self.createS3Client()
 
-    @newrelic.agent.background_task()
     def runProcess(self):
         self.setStartTime()
         self.importDCRecords()
@@ -53,7 +51,6 @@ class METProcess(CoreProcess):
         self.saveRecords()
         self.commitChanges()
 
-    @newrelic.agent.background_task()
     def setStartTime(self):
         if not self.fullImport:
             if not self.ingestPeriod:
@@ -63,7 +60,6 @@ class METProcess(CoreProcess):
                     self.ingestPeriod, '%Y-%m-%dT%H:%M:%S'
                 )
 
-    @newrelic.agent.background_task()
     def importDCRecords(self):
         currentPosition = self.ingestOffset
         pageSize = 50
@@ -82,7 +78,6 @@ class METProcess(CoreProcess):
 
             currentPosition += pageSize
 
-    @newrelic.agent.background_task()
     def processMetBatch(self, metRecords):
         for record in metRecords:
             if (
@@ -99,7 +94,6 @@ class METProcess(CoreProcess):
                     record['pointer'])
                 )
 
-    @newrelic.agent.background_task()
     def processMetRecord(self, record):
         try:
             detailQuery = self.DETAIL_QUERY.format(record['pointer'])
@@ -120,7 +114,6 @@ class METProcess(CoreProcess):
 
         self.addDCDWToUpdateList(metRec)
 
-    @newrelic.agent.background_task()
     def addCoverAndStoreInS3(self, record, filetype):
         recordID = record.identifiers[0].split('|')[0]
 
@@ -142,7 +135,6 @@ class METProcess(CoreProcess):
 
         self.sendFileToProcessingQueue(sourceURL, bucketLocation)
 
-    @newrelic.agent.background_task()
     def setCoverPath(self, filetype, recordID):
         if filetype == 'cpd':
             try:
@@ -165,7 +157,6 @@ class METProcess(CoreProcess):
         else:
             return 'api/singleitem/image/pdf/p15324coll10/{}/default.png'.format(recordID)
 
-    @newrelic.agent.background_task()
     def sendFileToProcessingQueue(self, fileURL, s3Location):
         s3Message = {
             'fileData': {
@@ -175,7 +166,6 @@ class METProcess(CoreProcess):
         }
         self.sendMessageToQueue(self.fileQueue, self.fileRoute, s3Message)
 
-    @newrelic.agent.background_task()
     def storePDFManifest(self, record):
         for link in record.has_part:
             itemNo, uri, source, mediaType, flags = link.split('|')
@@ -203,13 +193,11 @@ class METProcess(CoreProcess):
 
                 break
 
-    @newrelic.agent.background_task()
     def createManifestInS3(self, manifestPath, manifestJSON):
         self.putObjectInBucket(
             manifestJSON.encode('utf-8'), manifestPath, self.s3Bucket
         )
 
-    @newrelic.agent.background_task()
     @staticmethod
     def generateManifest(record, sourceURI, manifestURI):
         manifest = WebpubManifest(sourceURI, 'application/pdf')
@@ -229,7 +217,6 @@ class METProcess(CoreProcess):
 
         return manifest.toJson()
 
-    @newrelic.agent.background_task()
     @staticmethod
     def queryMetAPI(query, method='GET'):
         method = method.upper()

--- a/processes/muse.py
+++ b/processes/muse.py
@@ -4,7 +4,6 @@ from datetime import datetime, timedelta
 from io import BytesIO
 from pymarc import MARCReader
 import requests
-import newrelic.agent
 from requests.exceptions import ReadTimeout, HTTPError
 
 from .core import CoreProcess
@@ -18,7 +17,7 @@ logger = createLog(__name__)
 
 class MUSEProcess(CoreProcess):
     MUSE_ROOT_URL = 'https://muse.jhu.edu'
-    
+
     def __init__(self, *args):
         super(MUSEProcess, self).__init__(*args[:4])
 
@@ -34,8 +33,7 @@ class MUSEProcess(CoreProcess):
         self.fileRoute = os.environ['FILE_ROUTING_KEY']
         self.createRabbitConnection()
         self.createOrConnectQueue(self.fileQueue, self.fileRoute)
-        
-    @newrelic.agent.background_task()
+
     def runProcess(self):
         if self.process == 'daily':
             self.importMARCRecords()
@@ -49,7 +47,6 @@ class MUSEProcess(CoreProcess):
         self.saveRecords()
         self.commitChanges()
 
-    @newrelic.agent.background_task()
     def parseMuseRecord(self, marcRec):
         museRec = MUSEMapping(marcRec)
         museRec.applyMapping()
@@ -82,7 +79,6 @@ class MUSEProcess(CoreProcess):
 
         self.addDCDWToUpdateList(museRec)
 
-    @newrelic.agent.background_task()
     def importMARCRecords(self, full=False, startTimestamp=None, recID=None):
         self.downloadRecordUpdates()
 
@@ -109,7 +105,6 @@ class MUSEProcess(CoreProcess):
                 logger.warning('Unable to parse MUSE record')
                 logger.debug(e)
 
-    @newrelic.agent.background_task()
     def downloadMARCRecords(self):
         marcURL = os.environ['MUSE_MARC_URL']
 
@@ -127,7 +122,6 @@ class MUSEProcess(CoreProcess):
 
         return BytesIO(content)
 
-    @newrelic.agent.background_task()
     def downloadRecordUpdates(self):
         marcCSVURL = os.environ['MUSE_CSV_URL']
 
@@ -156,7 +150,6 @@ class MUSEProcess(CoreProcess):
                 logger.warning('Unable to parse MUSE')
                 logger.debug(row)
 
-    @newrelic.agent.background_task()
     def recordToBeUpdated(self, record, startDate, recID):
         recordURL = record.get_fields('856')[0]['u']
 

--- a/processes/oclcCatalog.py
+++ b/processes/oclcCatalog.py
@@ -1,6 +1,5 @@
 import json
 import os
-import newrelic.agent
 from lxml import etree
 from time import sleep
 
@@ -31,7 +30,6 @@ class CatalogProcess(CoreProcess):
         self.saveRecords()
         self.commitChanges()
 
-    @newrelic.agent.background_task()
     def receiveAndProcessMessages(self):
         attempts = 1
 
@@ -60,7 +58,6 @@ class CatalogProcess(CoreProcess):
             self.processCatalogQuery(msgBody)
             self.acknowledgeMessageProcessed(msgProps.delivery_tag)
 
-    @newrelic.agent.background_task()
     def processCatalogQuery(self, msgBody):
         message = json.loads(msgBody)
         catalogManager = OCLCCatalogManager(message['oclcNo'])
@@ -69,7 +66,6 @@ class CatalogProcess(CoreProcess):
             self.parseCatalogRecord(catalogXML, message['owiNo'])
 
 
-    @newrelic.agent.background_task()
     def parseCatalogRecord(self, catalogXML, owiNo):
         try:
             parseMARC = etree.fromstring(catalogXML.encode('utf-8'))

--- a/processes/s3Files.py
+++ b/processes/s3Files.py
@@ -2,7 +2,6 @@ import json
 from multiprocessing import Process
 import os
 import requests
-import newrelic.agent
 from time import sleep
 from urllib.parse import quote_plus
 
@@ -18,11 +17,9 @@ class S3Process(CoreProcess):
     def __init__(self, *args):
         super(S3Process, self).__init__(*args[:4])
 
-    @newrelic.agent.background_task()
     def runProcess(self):
         self.receiveAndProcessMessages()
 
-    @newrelic.agent.background_task()
     def receiveAndProcessMessages(self):
         processes = 4
         epubProcesses = []
@@ -33,8 +30,7 @@ class S3Process(CoreProcess):
 
         for proc in epubProcesses:
             proc.join()
-    
-    @newrelic.agent.background_task()
+
     @staticmethod
     def storeFilesInS3():
         storageManager = S3Manager()
@@ -60,7 +56,7 @@ class S3Process(CoreProcess):
                     continue
                 else:
                     break
-            
+
             attempts = 1
 
             fileMeta = json.loads(msgBody)['fileData']
@@ -74,7 +70,7 @@ class S3Process(CoreProcess):
                 storageManager.putObjectInBucket(epubB, filePath, bucket)
 
                 if '.epub' in filePath:
-                    fileRoot = '.'.join(filePath.split('.')[:-1]) 
+                    fileRoot = '.'.join(filePath.split('.')[:-1])
 
                     webpubManifest = S3Process.generateWebpub(
                         epubConverterURL, fileRoot, bucket
@@ -95,7 +91,6 @@ class S3Process(CoreProcess):
                 logger.error('Unable to store file in S3')
                 logger.debug(e)
 
-    @newrelic.agent.background_task()
     @staticmethod
     def getFileContents(epubURL):
         timeout = 15
@@ -112,10 +107,9 @@ class S3Process(CoreProcess):
                 content += byteChunk
 
             return content
-        
+
         raise Exception('Unable to fetch ePub file')
 
-    @newrelic.agent.background_task()
     @staticmethod
     def generateWebpub(converterRoot, fileRoot, bucket):
         s3Path = 'https://{}.s3.amazonaws.com/{}/META-INF/container.xml'.format(


### PR DESCRIPTION
Verified the new intrumentation approach works in QA, so we don't need to decorate all these methods anymore

https://jira.nypl.org/browse/SFR-1603