### PR TITLE
fix: Bump python version for CI tests

### DIFF
--- a/.github/workflows/tests-regression.yaml
+++ b/.github/workflows/tests-regression.yaml
@@ -1,6 +1,6 @@
 name: ETL Pipeline Tests (Regression)
 
-on: 
+on:
   push:
     branches: [ main ]
   schedule:
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: '3.9'
       - name: Cache dependencies
         uses: actions/cache@v2
         with:
@@ -56,7 +56,7 @@ jobs:
           PUBLISH_DIR: allure-history
       - name: DRB Pipeline Slack Notification
         uses: rtCamp/action-slack-notify@v2
-        env: 
+        env:
           SLACK_CHANNEL: test_reports
           #SLACK_MESSAGE: 'https://nypl.github.io/drb-etl-pipeline'
           SLACK_TITLE: DRB Pipeline Test Results

--- a/.github/workflows/tests-unit.yaml
+++ b/.github/workflows/tests-unit.yaml
@@ -1,6 +1,6 @@
 name: ETL Pipeline Tests (Pull Request)
 
-on: 
+on:
   pull_request:
     actions: [ opened ]
 
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: '3.9'
       - name: Cache dependencies
         uses: actions/cache@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - drb_local_devSetUp Docker container exiting out due to ES authentication error
 - Handle `ConnectTimeout` from OCLC Classify API
 - Updated newrelic instrumentation to encompass all background jobs
+- Bumped to python 3.9 for CI testing to match production
 
 ## 2022-12-22 -- v0.11.1
 ### Added


### PR DESCRIPTION
Noticed we're still running 3.8 for our test workflows while running 3.9 in prod