### PR TITLE
SFR-1582:Added new collectionUpdate endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## unreleased version -- v0.11.3
+### Added
+- New endpoint to update whole collection objects
+### Fixed
+- 
+
 ## 2023-02-02 -- v0.11.2
 ### Added
 - inCollection property to the work and edition API responses

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unreleased version -- v0.11.3
 ### Added
-- New endpoint to update whole collection objects
+- New endpoint to update whole collection JSON objects
 ### Fixed
 - 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ### Added
 - New endpoint to update whole collection JSON objects in the API response
 ### Fixed
-- 
+-
 
 ## 2023-02-02 -- v0.11.2
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unreleased version -- v0.11.3
 ### Added
-- New endpoint to update whole collection JSON objects
+- New endpoint to update whole collection JSON objects in the API response
 ### Fixed
 - 
 

--- a/api/blueprints/drbCollection.py
+++ b/api/blueprints/drbCollection.py
@@ -92,12 +92,12 @@ def collectionCreate(user=None):
 @collection.route('/update/<uuid>', methods=['POST'])
 @validateToken
 def collectionUpdate(uuid, user=None):
-    logger.info('Updating current collection')
+    logger.info('Handling collection update request')
 
     collectionData = request.json
     dataKeys = collectionData.keys()
 
-    if len(set(dataKeys) & set(['title', 'creator', 'description'])) < 3\
+    if {'title', 'creator', 'description'}.issubset(set(dataKeys))\
             or len(set(dataKeys) & set(['workUUIDs', 'editionIDs'])) == 0:
         errMsg = {
             'message':
@@ -111,7 +111,11 @@ def collectionUpdate(uuid, user=None):
     dbClient.createSession()
 
     #Getting the collection the user wants to replace
-    collection = dbClient.fetchSingleCollection(uuid)
+    try:
+        collection = dbClient.fetchSingleCollection(uuid)
+    except NoResultFound:
+        errMsg = {'message': 'Unable to locate collection {}'.format(uuid)}
+        return APIUtils.formatResponseObject(404, 'fetchSingleCollection', errMsg)
 
     #Creating the new collection that will replace the old collection
     updatedCollection = dbClient.createCollection(

--- a/api/blueprints/drbCollection.py
+++ b/api/blueprints/drbCollection.py
@@ -10,9 +10,8 @@ from ..opdsUtils import OPDSUtils
 from ..utils import APIUtils
 from ..opds2 import Feed, Publication
 from logger import createLog
-from model import Work
+from model import Work, Edition
 from model.postgres.collection import COLLECTION_EDITIONS
-from datetime import date
 
 logger = createLog(__name__)
 
@@ -325,10 +324,11 @@ def addWorkEditionsToCollection(dbClient, collection, workUUIDs):
             .all()
 
     for work in collectionWorks:
-        editions = [ed for ed in work.editions]
-        
+        collectionEditions = dbClient.session.query(Edition)\
+            .filter(Edition.work_id == work.id)\
+            .order_by(Edition.date_created.asc())\
+            .all()
 
         dbClient.session.execute(COLLECTION_EDITIONS.insert().values([ \
-        {"collection_id": collection.id, "edition_id": edition.id} \
-        for edition in editions \
+        {"collection_id": collection.id, "edition_id": collectionEditions[0].id} \
     ]))

--- a/api/blueprints/drbCollection.py
+++ b/api/blueprints/drbCollection.py
@@ -327,8 +327,9 @@ def addWorkEditionsToCollection(dbClient, collection, workUUIDs):
         collectionEditions = dbClient.session.query(Edition)\
             .filter(Edition.work_id == work.id)\
             .order_by(Edition.date_created.asc())\
-            .all()
+            .limit(1)\
+            .scalar()
 
         dbClient.session.execute(COLLECTION_EDITIONS.insert().values([ \
-        {"collection_id": collection.id, "edition_id": collectionEditions[0].id} \
+        {"collection_id": collection.id, "edition_id": collectionEditions.id} \
     ]))

--- a/config/sample-compose.yaml
+++ b/config/sample-compose.yaml
@@ -55,3 +55,5 @@ WEBPUB_PDF_PROFILE: http://librarysimplified.org/terms/profiles/pdf
 API_PROXY_CORS_ALLOWED: '*'
 
 READER_VERSION: v2
+
+DEFAULT_COVER_URL: https://drb-files-qa.s3.amazonaws.com/covers/default/defaultCover.png

--- a/swagger.v4.json
+++ b/swagger.v4.json
@@ -770,6 +770,85 @@
                 }
             }
         },
+        "/collection/update/{uuid}": {
+            "get": {
+                "tags": ["digital-research-books"],
+                "summary": "Update a DRB Collection",
+                "description": "Return an updated collection of selected edition records as a formatted OPDS2 feed",
+                "security": [
+                    {
+                        "BasicAuth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "uuid",
+                        "in": "path",
+                        "description": "UUID for publication record",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "name": "collection",
+                        "in": "body",
+                        "description": "The collection to create",
+                        "schema": {
+                            "type": "object",
+                            "properties": [
+                                {
+                                    "title": {
+                                        "type": "string"
+                                    },
+                                    "creator": {
+                                        "type": "string"
+                                    },
+                                    "description": {
+                                        "type": "string"
+                                    },
+                                    "workUUIDs": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "editionIDs": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ],              
+                "responses": {
+                    "201": {
+                        "description": "A basic OPDS2 feed response",
+                        "schema": {
+                            "$ref": "#/definitions/OPDSFeedResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Collection not found",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "default": {
+                        "description": "Unexpected Error",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    } 
+                }
+            },
         "/collection/list": {
             "get": {
                 "tags": ["digital-research-books"],
@@ -1773,4 +1852,5 @@
             }
         }
     }
+}
 }

--- a/swagger.v4.json
+++ b/swagger.v4.json
@@ -771,7 +771,7 @@
             }
         },
         "/collection/update/{uuid}": {
-            "get": {
+            "post": {
                 "tags": ["digital-research-books"],
                 "summary": "Update a DRB Collection",
                 "description": "Return an updated collection of selected edition records as a formatted OPDS2 feed",

--- a/tests/unit/test_api_collection_blueprint.py
+++ b/tests/unit/test_api_collection_blueprint.py
@@ -72,7 +72,7 @@ class TestCollectionBlueprint:
 
             assert mockDBClient.call_count == 2
             assert mockDB.createSession.call_count == 2
-            assert mockDB.session.execute.call_count == 3
+            assert mockDB.session.execute.call_count == 2
             mockDB.fetchSingleCollection.assert_called_once_with('testUUID')
             mockDB.session.commit.assert_called_once()
 


### PR DESCRIPTION
In this PR, I have created a new endpoint called `collectionUpdate` that for right now is focused on having engineers on the backend able to replace a collection that's currently in the database with a new collection that the user creates. I'm currently working on tests and updating the swagger file to reflect these changes. 