### PR TITLE
Add 'automatic' collections DB entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## unreleased version -- v0.11.3
+### Added
+- Add new DB entities for automatic collections
+### Fixed
+
 ## 2023-02-02 -- v0.11.2
 ### Added
 - inCollection property to the work and edition API responses

--- a/migrations/versions/e46b30dd3ff5_automatic_collections.py
+++ b/migrations/versions/e46b30dd3ff5_automatic_collections.py
@@ -9,7 +9,6 @@ from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
-
 # revision identifiers, used by Alembic.
 revision = 'e46b30dd3ff5'
 down_revision = '9e33fa16ba82'
@@ -18,10 +17,8 @@ depends_on = None
 
 
 def upgrade():
-    # TODO: Maybe add some CHECK constraints around some of these fields? Or just
-    # enforce in code upon creation.
     op.create_table(
-        "automatic_collection_definition",
+        "automatic_collection",
         sa.Column(
             'collection_id',
             sa.Integer,
@@ -29,16 +26,30 @@ def upgrade():
             primary_key=True,
         ),
         sa.Column(
-            'query',
-            sa.ARRAY(sa.String),
+            'keyword_query',
+            sa.String,
         ),
         sa.Column(
-            'sort',
-            sa.ARRAY(sa.String),
+            'author_query',
+            sa.String,
         ),
         sa.Column(
-            'filter',
-            sa.ARRAY(sa.String),
+            'title_query',
+            sa.String,
+        ),
+        sa.Column(
+            'subject_query',
+            sa.String,
+        ),
+        sa.Column(
+            'sort_field',
+            sa.String,
+            sa.CheckConstraint(r"sort_field is NULL OR sort_field IN ('title', 'author', 'date')"),
+        ),
+        sa.Column(
+            'sort_direction',
+            sa.String,
+            sa.CheckConstraint(r"sort_direction is NULL OR sort_direction IN ('ASC', 'DESC')"),
         ),
         sa.Column(
             'limit',
@@ -60,6 +71,6 @@ def upgrade():
 
 def downgrade():
     op.drop_column("collections", "type")
-    op.drop_table("automatic_collection_definition")
+    op.drop_table("automatic_collection")
     collection_type = postgresql.ENUM('static', 'automatic', name="collection_type")
     collection_type.drop(op.get_bind())

--- a/migrations/versions/e46b30dd3ff5_automatic_collections.py
+++ b/migrations/versions/e46b30dd3ff5_automatic_collections.py
@@ -1,0 +1,65 @@
+"""automatic_collections
+
+Revision ID: e46b30dd3ff5
+Revises: 9e33fa16ba82
+Create Date: 2023-02-06 11:44:29.000880
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision = 'e46b30dd3ff5'
+down_revision = '9e33fa16ba82'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # TODO: Maybe add some CHECK constraints around some of these fields? Or just
+    # enforce in code upon creation.
+    op.create_table(
+        "automatic_collection_definition",
+        sa.Column(
+            'collection_id',
+            sa.Integer,
+            sa.ForeignKey('collections.id', ondelete='CASCADE'),
+            primary_key=True,
+        ),
+        sa.Column(
+            'query',
+            sa.ARRAY(sa.String),
+        ),
+        sa.Column(
+            'sort',
+            sa.ARRAY(sa.String),
+        ),
+        sa.Column(
+            'filter',
+            sa.ARRAY(sa.String),
+        ),
+        sa.Column(
+            'limit',
+            sa.Integer,
+            nullable=False,
+        ),
+    )
+    collection_type = postgresql.ENUM('static', 'automatic', name="collection_type")
+    collection_type.create(op.get_bind(), checkfirst=True)
+    op.add_column(
+        'collections',
+        sa.Column(
+            "type",
+            collection_type,
+            default="static",
+        ),
+    )
+
+
+def downgrade():
+    op.drop_column("collections", "type")
+    op.drop_table("automatic_collection_definition")
+    collection_type = postgresql.ENUM('static', 'automatic', name="collection_type")
+    collection_type.drop(op.get_bind())

--- a/migrations/versions/e46b30dd3ff5_automatic_collections.py
+++ b/migrations/versions/e46b30dd3ff5_automatic_collections.py
@@ -44,17 +44,21 @@ def upgrade():
         sa.Column(
             'sort_field',
             sa.String,
-            sa.CheckConstraint(r"sort_field is NULL OR sort_field IN ('title', 'author', 'date')"),
+            sa.CheckConstraint(r"sort_field IN ('uuid', 'title', 'author', 'date')"),
+            server_default='uuid',
+            nullable=False,
         ),
         sa.Column(
             'sort_direction',
             sa.String,
-            sa.CheckConstraint(r"sort_direction is NULL OR sort_direction IN ('ASC', 'DESC')"),
+            sa.CheckConstraint(r"sort_direction IN ('ASC', 'DESC')"),
+            server_default='ASC',
+            nullable=False,
         ),
         sa.Column(
             'limit',
             sa.Integer,
-            nullable=False,
+            sa.CheckConstraint(r'"limit" IS NULL OR "limit" > 0'),
         ),
     )
     collection_type = postgresql.ENUM('static', 'automatic', name="collection_type")
@@ -64,7 +68,8 @@ def upgrade():
         sa.Column(
             "type",
             collection_type,
-            default="static",
+            server_default="static",
+            nullable=False,
         ),
     )
 


### PR DESCRIPTION
To support defining 'automatic' collections, define a new 'automatic collection definition' defining search terms to define an automatic collection. These terms will essentially mirror what we already use to hit ES when searching for works. We'll probably special case the example of the 'most recent' collection to just hit the DB, but otherwise we'll dynamically load the search terms into an ES query.

Otherwise, these automatic collections will simply be collections with a new collection 'type' of 'automatic' (defaulting all existing collections to 'static'), so we can reuse all the metadata fields on the existing collection.

Some specific things I have questions / would like feedback around:

  - Reusing the collection table for storing collection metadata (as opposed to creating a new table with separate PKs)
  - naming
  - should I add more constraints at the DB level? either way, I'd like to iron out the full implementation first before adding those.