### PR TITLE
Implement non search based automatic collection 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased version -- v0.11.3
 ### Added
 - Add new DB entities for automatic collections
+- Add support for 'Most Recent' automatic collection
 ### Fixed
 
 ## 2023-02-02 -- v0.11.2

--- a/api/automaticCollectionUtils.py
+++ b/api/automaticCollectionUtils.py
@@ -3,21 +3,23 @@ from logger import createLog
 logger = createLog(__name__)
 
 
-def fetchAutomaticCollectionEditions(dbClient, collectionId):
+def fetchAutomaticCollectionEditions(dbClient, collectionId, page: int, perPage: int):
     """Given a collection id for an automatic collection, perform the given
     search and return a list of collection editions
     """
     automaticCollection = dbClient.fetchAutomaticCollection(collectionId)
     if not automaticCollection:
         logger.warning("Found invalid automatic collection %s with no search definition", collectionId)
-        return []
+        return (0, [])
 
     # Skip ES and go straight to the DB if there's no actual search to be done
     if not _requiresSearch(automaticCollection):
-        return dbClient.fetchSortedEditions(
+        return dbClient.fetchAllPreferredEditions(
             sortField=automaticCollection.sort_field,
             sortDirection=automaticCollection.sort_direction,
             limit=automaticCollection.limit,
+            page=page,
+            perPage=perPage,
         )
 
     # TODO: Hit ES for query based collections

--- a/api/automaticCollectionUtils.py
+++ b/api/automaticCollectionUtils.py
@@ -1,0 +1,35 @@
+from logger import createLog
+
+logger = createLog(__name__)
+
+
+def fetchAutomaticCollectionEditions(dbClient, collectionId):
+    """Given a collection id for an automatic collection, perform the given
+    search and return a list of collection editions
+    """
+    automaticCollection = dbClient.fetchAutomaticCollection(collectionId)
+    if not automaticCollection:
+        logger.warning("Found invalid automatic collection %s with no search definition", collectionId)
+        return []
+
+    # Skip ES and go straight to the DB if there's no actual search to be done
+    if not _requiresSearch(automaticCollection):
+        return dbClient.fetchSortedEditions(
+            sortField=automaticCollection.sort_field,
+            sortDirection=automaticCollection.sort_direction,
+            limit=automaticCollection.limit,
+        )
+
+    # TODO: Hit ES for query based collections
+    raise ValueError("Automatic collection search is not yet implemented")
+
+
+def _requiresSearch(automaticCollection) -> bool:
+    return any(
+        [
+            automaticCollection.keyword_query,
+            automaticCollection.author_query,
+            automaticCollection.title_query,
+            automaticCollection.subject_query,
+        ],
+    )

--- a/api/automaticCollectionUtils.py
+++ b/api/automaticCollectionUtils.py
@@ -12,18 +12,22 @@ def fetchAutomaticCollectionEditions(dbClient, collectionId, page: int, perPage:
         logger.warning("Found invalid automatic collection %s with no search definition", collectionId)
         return (0, [])
 
+    nextPageSize = _nextPageSize(automaticCollection.limit, page, perPage)
+
     # Skip ES and go straight to the DB if there's no actual search to be done
     if not _requiresSearch(automaticCollection):
-        return dbClient.fetchAllPreferredEditions(
+        (totalCount, editions) = dbClient.fetchAllPreferredEditions(
             sortField=automaticCollection.sort_field,
             sortDirection=automaticCollection.sort_direction,
-            limit=automaticCollection.limit,
             page=page,
-            perPage=perPage,
+            perPage=nextPageSize,
         )
 
     # TODO: Hit ES for query based collections
-    raise ValueError("Automatic collection search is not yet implemented")
+    else:
+        raise ValueError("Automatic collection search is not yet implemented")
+
+    return (min(totalCount, automaticCollection.limit), editions)
 
 
 def _requiresSearch(automaticCollection) -> bool:
@@ -35,3 +39,16 @@ def _requiresSearch(automaticCollection) -> bool:
             automaticCollection.subject_query,
         ],
     )
+
+
+def _nextPageSize(limit, page, perPage):
+    """Given an absolute max limit, a page number, and a standard page
+    page size, determine what the next page size fetched should be."""
+
+    # Just fetch the page size if there is not absolute limit
+    if not limit:
+        return perPage
+    offset = (page - 1) * perPage
+    # If the next page puts us over the absolute limit, only fetch
+    # enough items to hit the limit. Otherwise, fetch a full page
+    return min(limit - offset, perPage)

--- a/api/blueprints/drbCollection.py
+++ b/api/blueprints/drbCollection.py
@@ -5,6 +5,7 @@ import os
 import re
 from sqlalchemy.orm.exc import NoResultFound
 
+from ..automaticCollectionUtils import fetchAutomaticCollectionEditions
 from ..db import DBClient
 from ..opdsUtils import OPDSUtils
 from ..utils import APIUtils
@@ -227,7 +228,11 @@ def constructOPDSFeed(
         if os.environ['ENVIRONMENT'] == 'production' else 'drb-qa'
 
     opdsPubs = []
-    for ed in collection.editions:
+    editions = (
+        collection.editions if collection.type == "static"
+        else fetchAutomaticCollectionEditions(dbClient, collection.id)
+    )
+    for ed in editions:
         pub = Publication()
 
         pub.parseEditionToPublication(ed)

--- a/api/db.py
+++ b/api/db.py
@@ -60,7 +60,6 @@ class DBClient():
         self,
         sortField: str,
         sortDirection: str,
-        limit: int,
         page: int,
         perPage: int,
     ):
@@ -84,10 +83,6 @@ class DBClient():
         ).subquery()
 
         offset = (page - 1) * perPage
-        # Normally, we grab the `perPage` amount, but once we're on the
-        # last page, meaning, we're coming up on the total limit, we just
-        # fetch enough items to reach the page limit.
-        pageLimit = min(limit - offset, perPage) if limit else perPage
 
         sortClause = {
             "title": workQuery.c.title,
@@ -118,8 +113,8 @@ class DBClient():
         )
 
         return (
-            min(editionsQuery.count(), limit),
-            editionsQuery.offset(offset).limit(pageLimit).all(),
+            editionsQuery.count(),
+            editionsQuery.offset(offset).limit(perPage).all(),
         )
 
     def fetchSingleLink(self, linkID):

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -7,7 +7,7 @@ from .postgres.identifier import Identifier
 from .postgres.link import Link
 from .postgres.olCover import OpenLibraryCover
 from .postgres.rights import Rights
-from .postgres.collection import Collection
+from .postgres.collection import Collection, AutomaticCollection
 from .postgres.user import User
 
 from .elasticsearch.agent import Agent as ESAgent

--- a/model/postgres/collection.py
+++ b/model/postgres/collection.py
@@ -30,8 +30,8 @@ COLLECTION_EDITIONS = Table(
 
 
 class CollectionType(str, enum.Enum):
-    static = 1
-    automatic = 2
+    static = "static"
+    automatic = "automatic"
 
 
 class AutomaticCollection(Base):

--- a/model/postgres/collection.py
+++ b/model/postgres/collection.py
@@ -1,4 +1,14 @@
-from sqlalchemy import Unicode, Integer, Column, Table, ForeignKey
+import enum
+
+from sqlalchemy import (
+    Column,
+    Enum,
+    ForeignKey,
+    Integer,
+    String,
+    Table,
+    Unicode,
+)
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 
@@ -19,6 +29,33 @@ COLLECTION_EDITIONS = Table(
 )
 
 
+class CollectionType(str, enum.Enum):
+    static = 1
+    automatic = 2
+
+
+class AutomaticCollection(Base):
+
+    __tablename__ = 'automatic_collection'
+
+    collection_id = Column(
+        'collection_id',
+        Integer,
+        ForeignKey('collections.id', ondelete='CASCADE'),
+        primary_key=True,
+    )
+
+    keyword_query = Column('keyword_query', String)
+    author_query = Column('author_query', String)
+    title_query = Column('title_query', String)
+    subject_query = Column('subject_query', String)
+
+    sort_field = Column('sort_field', String, nullable=False)
+    sort_direction = Column('sort_direction', String, nullable=False)
+
+    limit = Column('limit', Integer)
+
+
 class Collection(Base, Core):
     __tablename__ = 'collections'
 
@@ -28,6 +65,7 @@ class Collection(Base, Core):
     creator = Column(Unicode, index=True)
     description = Column(Unicode)
     owner = Column(Unicode)
+    type = Column(Enum(CollectionType))
 
     editions = relationship(
         'Edition',

--- a/scripts/addMostRecentAutomaticCollection.py
+++ b/scripts/addMostRecentAutomaticCollection.py
@@ -1,0 +1,82 @@
+import argparse
+import os
+from uuid import uuid4
+
+import sqlalchemy as sa
+
+from managers import DBManager
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("user")
+    args = parser.parse_args()
+    user = args.user
+
+    dbManager = DBManager(
+        user=os.environ.get("POSTGRES_USER", "localuser"),
+        pswd=os.environ.get("POSTGRES_PSWD", "localpsql"),
+        host=os.environ.get("POSTGRES_HOST", "localhost"),
+        port=os.environ.get("POSTGRES_PORT", "5432"),
+        db=os.environ.get("POSTGRES_NAME", "drb_test_db"),
+    )
+    dbManager.generateEngine()
+    dbManager.createSession()
+
+    uuid = uuid4()
+
+    with dbManager.session.begin() as _session:
+        # First create the collection
+        collection_id = dbManager.session.execute(
+            sa.text(
+                """
+                INSERT INTO collections (
+                  date_created,
+                  uuid,
+                  title,
+                  creator,
+                  description,
+                  owner,
+                  type
+                ) VALUES (
+                  NOW(),
+                  :uuid,
+                  'Most Recent',
+                  :creator,
+                  'Most recently created editions',
+                  :owner,
+                  'automatic'
+                )
+                RETURNING id
+                """
+            ),
+            {
+                "uuid": uuid,
+                "creator": user,
+                "owner": user,
+            },
+        ).scalar()
+
+        # Now the search terms
+        dbManager.session.execute(
+            sa.text(
+                """
+                INSERT INTO automatic_collection (
+                  collection_id,
+                  sort_field,
+                  sort_direction,
+                  "limit"
+                ) VALUES (:collectionId, :sortField, :sortDirection, :limit)
+                """,
+            ),
+            {
+                "collectionId": collection_id,
+                "sortField": "date",
+                "sortDirection": "DESC",
+                "limit": "100",
+            },
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_api_automatic_collection_utils.py
+++ b/tests/unit/test_api_automatic_collection_utils.py
@@ -14,13 +14,14 @@ def test_fetchAutomaticCollectionEditions_mostRecent(mocker):
         sort_direction="DESC",
         limit=100,
     )
-    dbClient.fetchAllPreferredEditions.return_value = mocker.sentinel.sortedEditions
-    editions = fetchAutomaticCollectionEditions(
+    dbClient.fetchAllPreferredEditions.return_value = (20, mocker.sentinel.sortedEditions)
+    total, editions = fetchAutomaticCollectionEditions(
         dbClient,
         mocker.sentinel.collectionId,
-        perPage=mocker.sentinel.perPage,
-        page=mocker.sentinel.page,
+        perPage=10,
+        page=1,
     )
+    assert total == 20
     assert editions == mocker.sentinel.sortedEditions
 
 
@@ -40,6 +41,6 @@ def test_fetchAutomaticCollectionEditions_searchBased(mocker):
         fetchAutomaticCollectionEditions(
             dbClient,
             mocker.sentinel.collectionId,
-            perPage=mocker.sentinel.perPage,
-            page=mocker.sentinel.page,
+            perPage=10,
+            page=1,
         )

--- a/tests/unit/test_api_automatic_collection_utils.py
+++ b/tests/unit/test_api_automatic_collection_utils.py
@@ -1,0 +1,35 @@
+import pytest
+
+from api.automaticCollectionUtils import fetchAutomaticCollectionEditions
+
+
+def test_fetchAutomaticCollectionEditions_mostRecent(mocker):
+    dbClient = mocker.MagicMock()
+    dbClient.fetchAutomaticCollection.return_value = mocker.MagicMock(
+        keyword_query=None,
+        author_query=None,
+        title_query=None,
+        subject_query=None,
+        sort_field="date",
+        sort_direction="DESC",
+        limit=100,
+    )
+    dbClient.fetchSortedEditions.return_value = mocker.sentinel.sortedEditions
+    editions = fetchAutomaticCollectionEditions(dbClient, mocker.sentinel.collectionId)
+    assert editions == mocker.sentinel.sortedEditions
+
+
+def test_fetchAutomaticCollectionEditions_searchBased(mocker):
+    dbClient = mocker.MagicMock()
+    dbClient.fetchAutomaticCollection.return_value = mocker.MagicMock(
+        keyword_query=mocker.sentinel.keyword_query,
+        author_query=mocker.sentinel.author_query,
+        title_query=mocker.sentinel.title_query,
+        subject_query=mocker.sentinel.subject_query,
+        sort_field="date",
+        sort_direction="DESC",
+        limit=100,
+    )
+    dbClient.fetchSortedEditions.return_value = mocker.sentinel.sortedEditions
+    with pytest.raises(ValueError):
+        fetchAutomaticCollectionEditions(dbClient, mocker.sentinel.collectionId)

--- a/tests/unit/test_api_automatic_collection_utils.py
+++ b/tests/unit/test_api_automatic_collection_utils.py
@@ -14,8 +14,13 @@ def test_fetchAutomaticCollectionEditions_mostRecent(mocker):
         sort_direction="DESC",
         limit=100,
     )
-    dbClient.fetchSortedEditions.return_value = mocker.sentinel.sortedEditions
-    editions = fetchAutomaticCollectionEditions(dbClient, mocker.sentinel.collectionId)
+    dbClient.fetchAllPreferredEditions.return_value = mocker.sentinel.sortedEditions
+    editions = fetchAutomaticCollectionEditions(
+        dbClient,
+        mocker.sentinel.collectionId,
+        perPage=mocker.sentinel.perPage,
+        page=mocker.sentinel.page,
+    )
     assert editions == mocker.sentinel.sortedEditions
 
 
@@ -30,6 +35,11 @@ def test_fetchAutomaticCollectionEditions_searchBased(mocker):
         sort_direction="DESC",
         limit=100,
     )
-    dbClient.fetchSortedEditions.return_value = mocker.sentinel.sortedEditions
+    dbClient.fetchAllPreferredEditions.return_value = mocker.sentinel.sortedEditions
     with pytest.raises(ValueError):
-        fetchAutomaticCollectionEditions(dbClient, mocker.sentinel.collectionId)
+        fetchAutomaticCollectionEditions(
+            dbClient,
+            mocker.sentinel.collectionId,
+            perPage=mocker.sentinel.perPage,
+            page=mocker.sentinel.page,
+        )

--- a/tests/unit/test_api_collection_blueprint.py
+++ b/tests/unit/test_api_collection_blueprint.py
@@ -377,7 +377,8 @@ class TestCollectionBlueprint:
             description='Test Description',
             editions=[
                 mocker.MagicMock(id=1), mocker.MagicMock(id=2)
-            ]
+            ],
+            type="static",
         )
 
         mocker.patch.dict(os.environ, {'ENVIRONMENT': 'test'})

--- a/tests/unit/test_api_collection_blueprint.py
+++ b/tests/unit/test_api_collection_blueprint.py
@@ -427,6 +427,70 @@ class TestCollectionBlueprint:
                 mockFeed, '/collection/testUUID', 2, page=1, perPage=10
             )
 
+    def test_constructOPDSFeed_success_autoCollection(self, testApp, mockUtils, mocker):
+        mockFeed = mocker.MagicMock()
+        mockFeedInit = mocker.patch('api.blueprints.drbCollection.Feed')
+        mockFeedInit.return_value = mockFeed
+
+        mockPub = mocker.MagicMock()
+        mockPubInit = mocker.patch('api.blueprints.drbCollection.Publication')
+        mockPubInit.return_value = mockPub
+
+        mockDB = mocker.MagicMock()
+        mockDB.fetchSingleCollection.return_value = mocker.MagicMock(
+            title='Test Collection',
+            creator='Test Creator',
+            description='Test Description',
+            type="automatic",
+        )
+
+        mocker.patch(
+            "api.blueprints.drbCollection.fetchAutomaticCollectionEditions",
+            return_value=(
+                mocker.sentinel.totalCount,
+                [mocker.MagicMock(id=1), mocker.MagicMock(id=2)],
+            ),
+        )
+
+        mocker.patch.dict(os.environ, {'ENVIRONMENT': 'test'})
+
+        mockPaging = mocker.patch.object(OPDSUtils, 'addPagingOptions')
+
+        with testApp.test_request_context('/collections/test'):
+            testOPDSFeed = constructOPDSFeed('testUUID', mockDB, sort='test')
+
+            assert testOPDSFeed == mockFeed
+
+            mockFeed.addMetadata.assert_called_once_with({
+                'title': 'Test Collection',
+                'creator': 'Test Creator',
+                'description': 'Test Description'
+            })
+            mockFeed.addLink.assert_called_once_with({
+                'rel': 'self',
+                'href': '/collection/testUUID',
+                'type': 'application/opds+json'
+            })
+            mockFeed.addPublications.assert_called_once()
+
+            assert mockPub.parseEditionToPublication.call_count == 2
+            mockPub.addLink.assert_has_calls([
+                mocker.call({
+                    'rel': 'alternate',
+                    'href': 'https://drb-qa.nypl.org/edition/1',
+                    'type': 'text/html'
+                }),
+                mocker.call({
+                    'rel': 'alternate',
+                    'href': 'https://drb-qa.nypl.org/edition/2',
+                    'type': 'text/html'
+                })
+            ])
+
+            mockPaging.assert_called_once_with(
+                mockFeed, '/collection/testUUID', mocker.sentinel.totalCount, page=1, perPage=10
+            )
+
     def test_validateToken_success(self, testApp, mockUtils, mocker):
         mockFunc = mocker.MagicMock()
 


### PR DESCRIPTION
https://jira.nypl.org/browse/SFR-1584

As a first step, add the new models and implement the logic to fetch
editions for any collections not requiring text search. In these cases,
such as with the main example of a 'Most Recent' collection, we can just
hit the DB. This also includes a script to generate the 'Most Recent'
collection.

In a later diff, I'll implement handling of all the text search fields
that we are currenly ignoring.

Note, this branch is based on the migration branch https://github.com/NYPL/drb-etl-pipeline/pull/224 so this PR is currently against the branch on that PR. Once the migration goes in, I'll reset the base on this one to main before merging!