### PR TITLE
HOTFIX: Closed out endpoint with closing curly bracket

### DIFF
--- a/swagger.v4.json
+++ b/swagger.v4.json
@@ -848,7 +848,8 @@
                         }
                     } 
                 }
-            },
+            }
+        },
         "/collection/list": {
             "get": {
                 "tags": ["digital-research-books"],
@@ -1853,4 +1854,4 @@
         }
     }
 }
-}
+


### PR DESCRIPTION
Added a closing curly bracket to close the collectionUpdate endpoint which caused errors on the apidocs QA site when the endpoint wasn't properly closed.