### PR TITLE
SFR-1614_New collection endpoint to selectively update metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unreleased version -- v0.11.3
 ### Added
-- New endpoint to update whole collection JSON objects in the API response
+- New endpoint to replace whole collection JSON objects in the API response
 - New endpoint to update specific parts of collection objects in API response
 ### Fixed
 - Add new DB entities for automatic collections

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased version -- v0.11.3
 ### Added
 - New endpoint to update whole collection JSON objects in the API response
+- New endpoint to update specific parts of collection objects in API response
 ### Fixed
 - Add new DB entities for automatic collections
 - Add support for 'Most Recent' automatic collection

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unreleased version -- v0.11.3
 ### Added
-- New endpoint to replace whole collection JSON objects in the API response
+- New endpoint to replace collection JSON objects in the API response
 - New endpoint to update specific parts of collection objects in API response
 ### Fixed
 - Add new DB entities for automatic collections

--- a/api/blueprints/drbCollection.py
+++ b/api/blueprints/drbCollection.py
@@ -165,6 +165,8 @@ def collectionUpdate(uuid):
     collection.creator = creator
     collection.description = description
 
+    dbClient.session.commit()
+
     try:
         opdsFeed = constructOPDSFeed(uuid, dbClient)
     except NoResultFound:

--- a/api/blueprints/drbCollection.py
+++ b/api/blueprints/drbCollection.py
@@ -154,6 +154,14 @@ def collectionUpdate(uuid):
     creator = request.args.get('creator', None)
     description = request.args.get('description', None)
 
+    if len(set(request.args) & set(['title', 'creator', 'description'])) == 0:
+        errMsg = {
+            'message':
+                'At least one of these fields(title, creator and description) are required'
+        }
+
+        return APIUtils.formatResponseObject(400, 'updateCollection', errMsg)
+
     #Getting the collection the user wants to update
     try:
         collection = dbClient.fetchSingleCollection(uuid)
@@ -161,9 +169,12 @@ def collectionUpdate(uuid):
         errMsg = {'message': 'Unable to locate collection {}'.format(uuid)}
         return APIUtils.formatResponseObject(404, 'fetchSingleCollection', errMsg)
 
-    collection.title = title
-    collection.creator = creator
-    collection.description = description
+    if title:
+        collection.title = title
+    if creator:
+        collection.creator = creator
+    if description:
+        collection.description = description
 
     dbClient.session.commit()
 

--- a/swagger.v4.json
+++ b/swagger.v4.json
@@ -770,11 +770,11 @@
                 }
             }
         },
-        "/collection/update/{uuid}": {
+        "/collection/replace/{uuid}": {
             "post": {
                 "tags": ["digital-research-books"],
-                "summary": "Update a DRB Collection",
-                "description": "Return an updated collection of selected edition records as a formatted OPDS2 feed",
+                "summary": "Replace a DRB Collection",
+                "description": "Replace a collection of selected edition records with a new one as a formatted OPDS2 feed",
                 "security": [
                     {
                         "BasicAuth": []
@@ -820,6 +820,74 @@
                                 }
                             ]
                         }
+                    }
+                ],              
+                "responses": {
+                    "201": {
+                        "description": "A basic OPDS2 feed response",
+                        "schema": {
+                            "$ref": "#/definitions/OPDSFeedResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Collection not found",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "default": {
+                        "description": "Unexpected Error",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    } 
+                }
+            }
+        },
+        "/collection/update/{uuid}": {
+            "post": {
+                "tags": ["digital-research-books"],
+                "summary": "Update a DRB Collection",
+                "description": "Return an updated collection of selected edition records as a formatted OPDS2 feed",
+                "security": [
+                    {
+                        "BasicAuth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "uuid",
+                        "in": "path",
+                        "description": "UUID for publication record",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "name": "title",
+                        "in": "query",
+                        "description": "New title of collection",
+                        "type": "string",
+                        "required": false
+                    },
+                    {
+                        "name": "creator",
+                        "in": "query",
+                        "description": "New creator of collection",
+                        "type": "string",
+                        "required": false
+                    },
+                    {
+                        "name": "description",
+                        "in": "query",
+                        "description": "New description of collection",
+                        "type": "string",
+                        "required": false
                     }
                 ],              
                 "responses": {


### PR DESCRIPTION
This endpoint will be tailored to have the user choose which metadata values to update through request parameters. In later commits, I will update the swagger file and unit tests in consideration of this new endpoint.