### PR TITLE
HOTFIX-Added type parameter to dbClient.createCollection

### DIFF
--- a/api/blueprints/drbCollection.py
+++ b/api/blueprints/drbCollection.py
@@ -81,7 +81,8 @@ def collectionCreate(user=None):
         collectionData['description'],
         user,
         workUUIDs=collectionData.get('workUUIDs', []),
-        editionIDs=collectionData.get('editionIDs', [])
+        editionIDs=collectionData.get('editionIDs', []),
+        type='static'
     )
 
     dbClient.session.commit()

--- a/api/db.py
+++ b/api/db.py
@@ -169,14 +169,15 @@ class DBClient():
         )
 
     def createCollection(
-        self, title, creator, description, owner, workUUIDs=[], editionIDs=[]
+        self, title, creator, description, owner, workUUIDs=[], editionIDs=[], type=None
     ):
         newCollection = Collection(
             uuid=uuid4(),
             title=title,
             creator=creator,
             description=description,
-            owner=owner
+            owner=owner,
+            type=type
         )
 
         collectionEditions = []

--- a/tests/unit/test_api_collection_blueprint.py
+++ b/tests/unit/test_api_collection_blueprint.py
@@ -182,7 +182,7 @@ class TestCollectionBlueprint:
             mockDB.createCollection.assert_called_once_with(
                 'Test Collection', 'Test Creator', 'Test Description',
                 'testUser', workUUIDs=['uuid1', 'uuid2'],
-                editionIDs=['ed1', 'ed2', 'ed3']
+                editionIDs=['ed1', 'ed2', 'ed3'], type='static'
             )
             mockDB.session.commit.assert_called_once()
 

--- a/tests/unit/test_api_db.py
+++ b/tests/unit/test_api_db.py
@@ -155,7 +155,7 @@ class TestDBClient:
 
         testNewCollection = testInstance.createCollection(
             'Test Coll', 'Test Creator', 'Test Description', 'testOwner',
-            workUUIDs=['testUUID'], editionIDs=['ed1', 'ed2']
+            workUUIDs=['testUUID'], editionIDs=['ed1', 'ed2'], type='static'
         )
 
         assert len(testNewCollection.editions) == 3
@@ -164,7 +164,7 @@ class TestDBClient:
 
         mockCollection.assert_called_once_with(
             uuid='testUUID', title='Test Coll', creator='Test Creator',
-            description='Test Description', owner='testOwner'
+            description='Test Description', owner='testOwner', type='static'
         )
 
         testInstance.session.query().join().filter().all.assert_called_once()


### PR DESCRIPTION
Due to the recent database migration for automated collections, the createCollection endpoint returned a 500 integrity error due to the createCollection method in the dbClient not specifying a 'type' as a parameter which is now a column in the collections table. Now, I have defaulted the 'type' in the endpoint and dbClient method to be static at all times to resolve this issue.