### PR TITLE
Add logic for search based collection 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,10 @@
 ## unreleased version -- v0.11.3
 ### Added
 - New endpoint to update whole collection JSON objects in the API response
-### Fixed
 - Add new DB entities for automatic collections
 - Add support for 'Most Recent' automatic collection
+- Supported ES backed automatic collections
+### Fixed
 
 ## 2023-02-02 -- v0.11.2
 ### Added

--- a/api/automaticCollectionUtils.py
+++ b/api/automaticCollectionUtils.py
@@ -3,7 +3,7 @@ from logger import createLog
 logger = createLog(__name__)
 
 
-def fetchAutomaticCollectionEditions(dbClient, collectionId, page: int, perPage: int):
+def fetchAutomaticCollectionEditions(dbClient, esClient, collectionId, page: int, perPage: int):
     """Given a collection id for an automatic collection, perform the given
     search and return a list of collection editions
     """
@@ -23,11 +23,40 @@ def fetchAutomaticCollectionEditions(dbClient, collectionId, page: int, perPage:
             perPage=nextPageSize,
         )
 
-    # TODO: Hit ES for query based collections
     else:
-        raise ValueError("Automatic collection search is not yet implemented")
+        (totalCount, editionIds) = _doAutoCollectionSearch(esClient, automaticCollection, page, nextPageSize)
+        editions = dbClient.fetchEditions(editionIds)
 
     return (min(totalCount, automaticCollection.limit), editions)
+
+
+def _doAutoCollectionSearch(esClient, automaticCollection, page, perPage):
+        searchParams = {
+            "query": _buildQueryTerms(automaticCollection),
+            "sort": [(automaticCollection.sort_field, automaticCollection.sort_direction)],
+            "filter": [],
+            "show_all": True,
+        }
+        searchResult = esClient.searchQuery(searchParams, page=page, perPage=perPage)
+        editionIds = []
+        for res in searchResult.hits:
+            editionIds.extend(e.edition_id for e in res.meta.inner_hits.editions.hits)
+
+        totalCount = searchResult.hits.total.value
+        return (totalCount, editionIds)
+
+
+def _buildQueryTerms(automaticCollection) -> list[tuple[str, str]]:
+    return [
+        (field, query)
+        for field, query in [
+            ("keyword", automaticCollection.keyword_query),
+            ("author", automaticCollection.author_query),
+            ("title", automaticCollection.title_query),
+            ("subject", automaticCollection.subject_query),
+        ]
+        if query
+    ]
 
 
 def _requiresSearch(automaticCollection) -> bool:

--- a/api/blueprints/drbCollection.py
+++ b/api/blueprints/drbCollection.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm.exc import NoResultFound
 
 from ..automaticCollectionUtils import fetchAutomaticCollectionEditions
 from ..db import DBClient
+from ..elastic import ElasticClient
 from ..opdsUtils import OPDSUtils
 from ..utils import APIUtils
 from ..opds2 import Feed, Publication
@@ -280,7 +281,8 @@ def constructOPDSFeed(
     if collection.type == "static":
         _addStaticPubsToFeed(opdsFeed, collection, path, page, perPage, sort)
     elif collection.type == "automatic":
-        _addAutomaticPubsToFeed(opdsFeed, dbClient, collection.id, path, page, perPage)
+        esClient = ElasticClient(current_app.config["REDIS_CLIENT"])
+        _addAutomaticPubsToFeed(opdsFeed, dbClient, esClient, collection.id, path, page, perPage)
     else:
         raise ValueError(f"Encountered collection with unhandleable type {collection.type}")
 
@@ -302,7 +304,7 @@ def _addStaticPubsToFeed(opdsFeed, collection, path, page, perPage, sort):
     )
 
 
-def _addAutomaticPubsToFeed(opdsFeed, dbClient, collectionId, path, page, perPage):
+def _addAutomaticPubsToFeed(opdsFeed, dbClient, esClient, collectionId, path, page, perPage):
     totalCount, editions = fetchAutomaticCollectionEditions(
         dbClient,
         collectionId,

--- a/tests/unit/test_api_automatic_collection_utils.py
+++ b/tests/unit/test_api_automatic_collection_utils.py
@@ -17,6 +17,7 @@ def test_fetchAutomaticCollectionEditions_mostRecent(mocker):
     dbClient.fetchAllPreferredEditions.return_value = (20, mocker.sentinel.sortedEditions)
     total, editions = fetchAutomaticCollectionEditions(
         dbClient,
+        mocker.sentinel.esClient,
         mocker.sentinel.collectionId,
         perPage=10,
         page=1,
@@ -36,11 +37,61 @@ def test_fetchAutomaticCollectionEditions_searchBased(mocker):
         sort_direction="DESC",
         limit=100,
     )
-    dbClient.fetchAllPreferredEditions.return_value = mocker.sentinel.sortedEditions
-    with pytest.raises(ValueError):
-        fetchAutomaticCollectionEditions(
-            dbClient,
-            mocker.sentinel.collectionId,
-            perPage=10,
-            page=1,
+    dbClient.fetchEditions.return_value = mocker.sentinel.editions
+    esClient = mocker.MagicMock()
+    def _mockHit(*editionIds):
+        return mocker.MagicMock(
+            meta=mocker.MagicMock(
+                inner_hits=mocker.MagicMock(
+                    editions=mocker.MagicMock(
+                        hits=[
+                            mocker.MagicMock(edition_id=eid)
+                            for eid in editionIds
+                        ],
+                    )
+                ),
+            ),
         )
+
+    class _mockHits(list):
+
+        def __init__(self, totalCount, *items):
+            self.total = mocker.MagicMock(value=totalCount)
+            super().__init__(items)
+
+    esClient.searchQuery.return_value = mocker.MagicMock(
+        hits=_mockHits(
+            20,
+            _mockHit(mocker.sentinel.edition1, mocker.sentinel.edition2),
+            _mockHit(mocker.sentinel.edition3),
+        ),
+    )
+    assert fetchAutomaticCollectionEditions(
+        dbClient,
+        esClient,
+        mocker.sentinel.collectionId,
+        perPage=10,
+        page=1,
+    ) == (20, mocker.sentinel.editions)
+    esClient.searchQuery.assert_called_once_with(
+        {
+            "query": [
+                ("keyword", mocker.sentinel.keyword_query),
+                ("author", mocker.sentinel.author_query),
+                ("title", mocker.sentinel.title_query),
+                ("subject", mocker.sentinel.subject_query),
+            ],
+            "filter": [],
+            "sort": [("date", "DESC")],
+            "show_all": True,
+        },
+        page=1,
+        perPage=10,
+    )
+    dbClient.fetchEditions.assert_called_once_with(
+        [
+            mocker.sentinel.edition1,
+            mocker.sentinel.edition2,
+            mocker.sentinel.edition3,
+        ],
+    )

--- a/tests/unit/test_api_collection_blueprint.py
+++ b/tests/unit/test_api_collection_blueprint.py
@@ -549,6 +549,7 @@ class TestCollectionBlueprint:
             description='Test Description',
             type="automatic",
         )
+        mockES = mocker.MagicMock()
 
         mocker.patch(
             "api.blueprints.drbCollection.fetchAutomaticCollectionEditions",
@@ -558,7 +559,11 @@ class TestCollectionBlueprint:
             ),
         )
 
-        mocker.patch.dict(os.environ, {'ENVIRONMENT': 'test'})
+        mocker.patch.dict(
+            os.environ,
+            {'ENVIRONMENT': 'test', 'ELASTICSEARCH_INDEX': 'test_es_index'},
+        )
+        testApp.config['REDIS_CLIENT'] = 'test_redis_client'
 
         mockPaging = mocker.patch.object(OPDSUtils, 'addPagingOptions')
 


### PR DESCRIPTION
If we encounter an automatic collection with search parameters, build
up an elastic search query and return the results.

https://jira.nypl.org/browse/SFR-1584