### PR TITLE
Support automatic collections in POST /collection 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,11 @@
 - New endpoint to update specific parts of collection objects in API response
 - Publication rights data object to fetchCollection API response
 - Identifier value to publication links of fetchCollection API response
-### Fixed
 - Add new DB entities for automatic collections
 - Add support for 'Most Recent' automatic collection
 - Supported ES backed automatic collections
+- Add ability to create automatic collections
+### Fixed
 
 ## 2023-02-02 -- v0.11.2
 ### Added

--- a/api/automaticCollectionUtils.py
+++ b/api/automaticCollectionUtils.py
@@ -27,7 +27,12 @@ def fetchAutomaticCollectionEditions(dbClient, esClient, collectionId, page: int
         (totalCount, editionIds) = _doAutoCollectionSearch(esClient, automaticCollection, page, nextPageSize)
         editions = dbClient.fetchEditions(editionIds)
 
-    return (min(totalCount, automaticCollection.limit), editions)
+    limit = (
+        min(totalCount, automaticCollection.limit)
+        if automaticCollection.limit
+        else totalCount
+    )
+    return (limit, editions)
 
 
 def _doAutoCollectionSearch(esClient, automaticCollection, page, perPage):

--- a/api/blueprints/drbCollection.py
+++ b/api/blueprints/drbCollection.py
@@ -63,12 +63,9 @@ def collectionCreate(user=None):
     collectionData = request.json
     dataKeys = collectionData.keys()
 
-    if len(set(dataKeys) & set(['title', 'creator', 'description'])) < 3\
-            or len(set(dataKeys) & set(['workUUIDs', 'editionIDs'])) == 0:
+    if len(set(dataKeys) & set(['title', 'creator', 'description'])) < 3:
         errMsg = {
-            'message':
-                'title, creator and description fields are required'
-                ', with one of workUUIDs or editionIDs to create a collection'
+            'message': 'title, creator and description fields are required',
         }
 
         return APIUtils.formatResponseObject(400, 'createCollection', errMsg)
@@ -76,15 +73,41 @@ def collectionCreate(user=None):
     dbClient = DBClient(current_app.config['DB_CLIENT'])
     dbClient.createSession()
 
-    newCollection = dbClient.createCollection(
-        collectionData['title'],
-        collectionData['creator'],
-        collectionData['description'],
-        user,
-        workUUIDs=collectionData.get('workUUIDs', []),
-        editionIDs=collectionData.get('editionIDs', []),
-        type='static'
-    )
+    if "workUUIDs" in collectionData or "editionIDs" in collectionData:
+        newCollection = dbClient.createStaticCollection(
+            collectionData['title'],
+            collectionData['creator'],
+            collectionData['description'],
+            user,
+            workUUIDs=collectionData.get('workUUIDs', []),
+            editionIDs=collectionData.get('editionIDs', []),
+        )
+
+    elif "autoDef" in collectionData:
+        autoDef = collectionData["autoDef"]
+        queryFields = ["keywordQuery", "authorQuery", "titleQuery", "subjectQuery"]
+        errMsg = _validateAutoCollectionDef(autoDef)
+        if errMsg:
+            return APIUtils.formatResponseObject(400, "createCollection", errMsg)
+        newCollection = dbClient.createAutomaticCollection(
+            collectionData['title'],
+            collectionData['creator'],
+            collectionData['description'],
+            owner=user,
+            sortField=autoDef.get("sortField"),
+            sortDirection=autoDef.get("sortDirection"),
+            limit=autoDef.get("limit"),
+            **{field: autoDef.get(field) for field in queryFields},
+        )
+
+    else:
+        errMsg = {
+            "message": (
+                "Need either workUUIDs, editionIDs, or an automatic collection "
+                "definition to create a collection"
+            ),
+        }
+        return APIUtils.formatResponseObject(400, "createCollection", errMsg)
 
     dbClient.session.commit()
 
@@ -93,6 +116,18 @@ def collectionCreate(user=None):
     opdsFeed = constructOPDSFeed(newCollection.uuid, dbClient)
 
     return APIUtils.formatOPDS2Object(201, opdsFeed)
+
+
+def _validateAutoCollectionDef(autoDef: dict) -> str:
+    """Return an error message if the definition is not valid"""
+    sortField = autoDef.get("sortField", "uuid")
+    if sortField not in ["uuid", "title", "author", "date"]:
+        return f"Invalid sort field {sortField}"
+
+    sortDirection = autoDef.get("sortDirection", "ASC")
+    if sortDirection not in ["ASC", "DESC"]:
+        return f"Invalid sort direction {sortDirection}"
+
 
 @collection.route('/replace/<uuid>', methods=['POST'])
 @validateToken
@@ -349,6 +384,7 @@ def _addStaticPubsToFeed(opdsFeed, collection, path, page, perPage, sort):
 def _addAutomaticPubsToFeed(opdsFeed, dbClient, esClient, collectionId, path, page, perPage):
     totalCount, editions = fetchAutomaticCollectionEditions(
         dbClient,
+        esClient,
         collectionId,
         page=page,
         perPage=perPage,
@@ -377,7 +413,7 @@ def _buildPublications(editions):
         })
 
         opdsPubs.append(pub)
-        
+
     return opdsPubs
 
 def removeEditionsFromCollection(dbClient, collection):

--- a/api/db.py
+++ b/api/db.py
@@ -200,8 +200,8 @@ class DBClient():
                 .one()
         )
 
-    def createCollection(
-        self, title, creator, description, owner, workUUIDs=[], editionIDs=[], type=None
+    def createStaticCollection(
+        self, title, creator, description, owner, workUUIDs=[], editionIDs=[],
     ):
         newCollection = Collection(
             uuid=uuid4(),
@@ -209,7 +209,7 @@ class DBClient():
             creator=creator,
             description=description,
             owner=owner,
-            type=type
+            type="static",
         )
 
         collectionEditions = []
@@ -242,6 +242,47 @@ class DBClient():
 
         self.session.add(newCollection)
 
+        return newCollection
+
+    def createAutomaticCollection(
+        self,
+        title,
+        creator,
+        description,
+        owner, *,
+        sortField,
+        sortDirection,
+        limit=None,
+        keywordQuery=None,
+        authorQuery=None,
+        titleQuery=None,
+        subjectQuery=None,
+    ):
+        newCollection = Collection(
+            uuid=uuid4(),
+            title=title,
+            creator=creator,
+            description=description,
+            owner=owner,
+            type='automatic',
+        )
+        nonNullKwargs = {
+            k: v for k, v in {
+                "sort_field": sortField,
+                "sort_direction": sortDirection,
+                "limit": limit,
+            }.items()
+            if v
+        }
+        automaticCollection = AutomaticCollection(
+            keyword_query=keywordQuery,
+            author_query=authorQuery,
+            title_query=titleQuery,
+            subject_query=subjectQuery,
+            **nonNullKwargs,
+        )
+        newCollection.auto.append(automaticCollection)
+        self.session.add(automaticCollection)
         return newCollection
 
     def deleteCollection(self, uuid, owner):

--- a/api/db.py
+++ b/api/db.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta, date
+from sqlalchemy import Integer
 from sqlalchemy.orm import joinedload, sessionmaker
-from sqlalchemy.sql import func, text
+from sqlalchemy.sql import column, func, select, text, values
 from uuid import uuid4
 
 from model import Work, Edition, Link, Item, Record, Collection, User, AutomaticCollection
@@ -126,10 +127,10 @@ class DBClient():
 
         # First build a CTE of the passed in ids and their index in the
         # given list
-        editionIdCTE = sa.select(
-            sa.values(
-                sa.column("idx", sa.Integer),
-                sa.column("edition_id", sa.Integer),
+        editionIdCTE = select(
+            values(
+                column("idx", Integer),
+                column("edition_id", Integer),
                 name="subquery",
             ).data(list(enumerate(editionIDs)))
         ).cte("edition_ids")

--- a/model/postgres/collection.py
+++ b/model/postgres/collection.py
@@ -50,8 +50,8 @@ class AutomaticCollection(Base):
     title_query = Column('title_query', String)
     subject_query = Column('subject_query', String)
 
-    sort_field = Column('sort_field', String, nullable=False)
-    sort_direction = Column('sort_direction', String, nullable=False)
+    sort_field = Column('sort_field', String, nullable=False, default="uuid")
+    sort_direction = Column('sort_direction', String, nullable=False, default="ASC")
 
     limit = Column('limit', Integer)
 
@@ -73,6 +73,8 @@ class Collection(Base, Core):
         backref='collections',
         cascade='all, delete'
     )
+
+    auto = relationship("AutomaticCollection", backref="collections")
 
     def __repr__(self):
         return '<Collection(uuid={}, title={}, creator={}, items={})>'.format(

--- a/swagger.v4.json
+++ b/swagger.v4.json
@@ -177,7 +177,7 @@
                         }
                     }
                 }
-           } 
+           }
         },
         "/edition/{id}": {
             "get": {
@@ -422,7 +422,7 @@
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
-                    } 
+                    }
                 }
             }
         },
@@ -450,7 +450,7 @@
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
-                    } 
+                    }
                 }
             }
         },
@@ -550,7 +550,7 @@
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
-                    } 
+                    }
                 }
             }
         },
@@ -594,7 +594,7 @@
                          }
                      }
                  }
-            } 
+            }
         },
         "/collection": {
             "post": {
@@ -635,6 +635,36 @@
                                         "items": {
                                             "type": "string"
                                         }
+                                    },
+                                    "autoDef": {
+                                      "type": "object",
+                                      "properties": {
+                                          "sortField": {
+                                              "type": "string",
+                                              "enum": ["uuid", "title", "author", "date"],
+                                              "default": "uuid"
+                                          },
+                                          "sortDirection": {
+                                              "type": "string",
+                                              "enum": ["ASC", "DESC"],
+                                              "default": "ASC"
+                                          },
+                                          "limit": {
+                                              "type": "number"
+                                          },
+                                          "keywordQuery": {
+                                              "type": "string"
+                                          },
+                                          "authorQuery": {
+                                              "type": "string"
+                                          },
+                                          "titleQuery": {
+                                              "type": "string"
+                                          },
+                                          "subjectQuery": {
+                                              "type": "string"
+                                          }
+                                      }
                                     }
                                 }
                             ]
@@ -665,7 +695,7 @@
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
-                    } 
+                    }
                 }
             }
         },
@@ -721,7 +751,7 @@
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
-                    } 
+                    }
                 }
             },
             "delete": {
@@ -766,7 +796,7 @@
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
-                    } 
+                    }
                 }
             }
         },
@@ -821,7 +851,7 @@
                             ]
                         }
                     }
-                ],              
+                ],
                 "responses": {
                     "201": {
                         "description": "A basic OPDS2 feed response",
@@ -846,7 +876,7 @@
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
-                    } 
+                    }
                 }
             }
         },
@@ -964,7 +994,7 @@
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
-                    } 
+                    }
                 }
             }
         }
@@ -1448,7 +1478,7 @@
                     "format": "uri"
                 },
                 "flags": {
-                   "type": "object" 
+                   "type": "object"
                 }
             }
         },

--- a/tests/unit/test_api_collection_blueprint.py
+++ b/tests/unit/test_api_collection_blueprint.py
@@ -360,11 +360,61 @@ class TestCollectionBlueprint:
             mockDB.createAutomaticCollection.assert_not_called()
             mockUtils['formatResponseObject'].assert_called_once_with(
                 400, "createCollection",
-                "Invalid sort field bad_sort_field",
+                {'message': "Invalid sort field bad_sort_field"},
             )
 
             mockBase64.assert_called_once_with(b'testAuth')
 
+    def test_collectionCreate_invalid(self, testApp, mockUtils, mocker):
+        mockDB = mocker.MagicMock(session=mocker.MagicMock())
+        mockDBClient = mocker.patch('api.blueprints.drbCollection.DBClient')
+        mockDBClient.return_value = mockDB
+
+        mockDB.fetchUser.return_value = mocker.MagicMock(
+            user='testUser', password='testPswd', salt='testSalt'
+        )
+
+        testRequestBody = {
+            'title': 'Test Collection',
+            'creator': 'Test Creator',
+            'description': 'Test Description',
+            'editionIDs': [1, 2, 3],
+            'autoDef': {
+                'sortField': 'bad_sort_field',
+                'keywordQuery': 'bikes',
+            },
+        }
+
+        mocker.patch.dict(os.environ, {'NYPL_API_CLIENT_PUBLIC_KEY': 'test'})
+
+        mockBase64 = mocker.patch('api.blueprints.drbCollection.b64decode')
+        mockBase64.return_value = b'testUser:testPswd'
+
+        mockUtils['validatePassword'].return_value = True
+
+        mockUtils['formatResponseObject'].return_value = 'testErrorResponse'
+
+        with testApp.test_request_context(
+            '/',
+            json=testRequestBody,
+            headers={'Authorization': 'Basic testAuth'}
+        ):
+            testAPIResponse = collectionCreate()
+
+            assert testAPIResponse == 'testErrorResponse'
+
+            mockDB.createAutomaticCollection.assert_not_called()
+            mockUtils['formatResponseObject'].assert_called_once_with(
+                400, "createCollection",
+                {
+                    'message': (
+                        "Cannot create a collection with both an automatic collection "
+                        "definition and editionIDs or workUUIDs"
+                    ),
+                },
+            )
+
+            mockBase64.assert_called_once_with(b'testAuth')
 
     def test_collectionCreate_error(self, testApp, mockUtils, mocker):
         mockDB = mocker.MagicMock(session=mocker.MagicMock())

--- a/tests/unit/test_api_collection_blueprint.py
+++ b/tests/unit/test_api_collection_blueprint.py
@@ -134,6 +134,7 @@ class TestCollectionBlueprint:
                 }
             )
 
+
     def test_collectionUpdate_success(self, testApp, mockUtils, mocker):
         mockDB = mocker.MagicMock(session=mocker.MagicMock())
         mockDBClient = mocker.patch('api.blueprints.drbCollection.DBClient')
@@ -198,7 +199,7 @@ class TestCollectionBlueprint:
                 }
             )
 
-    def test_collectionCreate_success(self, testApp, mockUtils, mocker):
+    def test_staticCollectionCreate_success(self, testApp, mockUtils, mocker):
         mockDB = mocker.MagicMock(session=mocker.MagicMock())
         mockDBClient = mocker.patch('api.blueprints.drbCollection.DBClient')
         mockDBClient.return_value = mockDB
@@ -207,7 +208,7 @@ class TestCollectionBlueprint:
             user='testUser', password='testPswd', salt='testSalt'
         )
 
-        mockDB.createCollection\
+        mockDB.createStaticCollection\
             .return_value = mocker.MagicMock(uuid='testUUID')
 
         mockFeedConstruct = mocker.patch(
@@ -243,10 +244,10 @@ class TestCollectionBlueprint:
 
             assert mockDBClient.call_count == 2
             assert mockDB.createSession.call_count == 2
-            mockDB.createCollection.assert_called_once_with(
+            mockDB.createStaticCollection.assert_called_once_with(
                 'Test Collection', 'Test Creator', 'Test Description',
                 'testUser', workUUIDs=['uuid1', 'uuid2'],
-                editionIDs=['ed1', 'ed2', 'ed3'], type='static'
+                editionIDs=['ed1', 'ed2', 'ed3']
             )
             mockDB.session.commit.assert_called_once()
 
@@ -257,6 +258,113 @@ class TestCollectionBlueprint:
             mockUtils['formatOPDS2Object'].assert_called_once_with(
                 201, 'testOPDS2Feed'
             )
+
+    def test_automaticCollectionCreate_success(self, testApp, mockUtils, mocker):
+        mockDB = mocker.MagicMock(session=mocker.MagicMock())
+        mockDBClient = mocker.patch('api.blueprints.drbCollection.DBClient')
+        mockDBClient.return_value = mockDB
+
+        mockDB.fetchUser.return_value = mocker.MagicMock(
+            user='testUser', password='testPswd', salt='testSalt'
+        )
+
+        mockDB.createAutomaticCollection.return_value = mocker.MagicMock(uuid='testUUID')
+
+        mockFeedConstruct = mocker.patch(
+            'api.blueprints.drbCollection.constructOPDSFeed'
+        )
+        mockFeedConstruct.return_value = 'testOPDS2Feed'
+
+        testRequestBody = {
+            'title': 'Test Collection',
+            'creator': 'Test Creator',
+            'description': 'Test Description',
+            'autoDef': {
+                'sortField': 'date',
+                'sortDirection': 'ASC',
+                'keywordQuery': 'bikes',
+            },
+        }
+
+        mocker.patch.dict(os.environ, {'NYPL_API_CLIENT_PUBLIC_KEY': 'test'})
+
+        mockBase64 = mocker.patch('api.blueprints.drbCollection.b64decode')
+        mockBase64.return_value = b'testUser:testPswd'
+
+        mockUtils['validatePassword'].return_value = True
+
+        mockUtils['formatOPDS2Object'].return_value = 'testOPDS2Response'
+
+        with testApp.test_request_context(
+            '/',
+            json=testRequestBody,
+            headers={'Authorization': 'Basic testAuth'}
+        ):
+            testAPIResponse = collectionCreate()
+
+            assert testAPIResponse == 'testOPDS2Response'
+
+            mockDB.createAutomaticCollection.assert_called_once_with(
+                'Test Collection', 'Test Creator', 'Test Description',
+                owner='testUser', sortField='date', sortDirection='ASC',
+                limit=None, keywordQuery='bikes', authorQuery=None, titleQuery=None,
+                subjectQuery=None,
+            )
+            mockDB.session.commit.assert_called_once()
+
+            mockFeedConstruct.assert_called_once_with('testUUID', mockDB)
+
+            mockBase64.assert_called_once_with(b'testAuth')
+
+            mockUtils['formatOPDS2Object'].assert_called_once_with(
+                201, 'testOPDS2Feed'
+            )
+
+    def test_automaticCollectionCreate_invalid(self, testApp, mockUtils, mocker):
+        mockDB = mocker.MagicMock(session=mocker.MagicMock())
+        mockDBClient = mocker.patch('api.blueprints.drbCollection.DBClient')
+        mockDBClient.return_value = mockDB
+
+        mockDB.fetchUser.return_value = mocker.MagicMock(
+            user='testUser', password='testPswd', salt='testSalt'
+        )
+
+        testRequestBody = {
+            'title': 'Test Collection',
+            'creator': 'Test Creator',
+            'description': 'Test Description',
+            'autoDef': {
+                'sortField': 'bad_sort_field',
+                'keywordQuery': 'bikes',
+            },
+        }
+
+        mocker.patch.dict(os.environ, {'NYPL_API_CLIENT_PUBLIC_KEY': 'test'})
+
+        mockBase64 = mocker.patch('api.blueprints.drbCollection.b64decode')
+        mockBase64.return_value = b'testUser:testPswd'
+
+        mockUtils['validatePassword'].return_value = True
+
+        mockUtils['formatResponseObject'].return_value = 'testErrorResponse'
+
+        with testApp.test_request_context(
+            '/',
+            json=testRequestBody,
+            headers={'Authorization': 'Basic testAuth'}
+        ):
+            testAPIResponse = collectionCreate()
+
+            assert testAPIResponse == 'testErrorResponse'
+
+            mockDB.createAutomaticCollection.assert_not_called()
+            mockUtils['formatResponseObject'].assert_called_once_with(
+                400, "createCollection",
+                "Invalid sort field bad_sort_field",
+            )
+
+            mockBase64.assert_called_once_with(b'testAuth')
+
 
     def test_collectionCreate_error(self, testApp, mockUtils, mocker):
         mockDB = mocker.MagicMock(session=mocker.MagicMock())
@@ -296,11 +404,7 @@ class TestCollectionBlueprint:
                 400,
                 'createCollection',
                 {
-                    'message':
-                    'title, creator and description fields are required'
-                    ', with one of workUUIDs or editionIDs to create a'
-                    ' collection'
-
+                    'message': 'title, creator and description fields are required',
                 }
             )
 

--- a/tests/unit/test_api_db.py
+++ b/tests/unit/test_api_db.py
@@ -131,7 +131,7 @@ class TestDBClient:
 
         assert testInstance.fetchCollections() == 'testCollections'
 
-    def test_createCollection(self, testInstance, mocker):
+    def test_createStaticCollection(self, testInstance, mocker):
         mockUUID = mocker.patch('api.db.uuid4')
         mockUUID.return_value = 'testUUID'
 
@@ -153,9 +153,9 @@ class TestDBClient:
         mockEditions = [mocker.MagicMock(id=4), mocker.MagicMock(id=5)]
         testInstance.session.query().filter().all.return_value = mockEditions
 
-        testNewCollection = testInstance.createCollection(
+        testNewCollection = testInstance.createStaticCollection(
             'Test Coll', 'Test Creator', 'Test Description', 'testOwner',
-            workUUIDs=['testUUID'], editionIDs=['ed1', 'ed2'], type='static'
+            workUUIDs=['testUUID'], editionIDs=['ed1', 'ed2']
         )
 
         assert len(testNewCollection.editions) == 3


### PR DESCRIPTION
https://jira.nypl.org/browse/SFR-1611

Accept some new data in the request body that indicates the user wants
to create an automatic collection. Do some validation and then do the
creation.

Note, I had to augment the sqlalchemy models to allow for creating both
entities in a single transaction.
