### PR TITLE
SFR-1636: Make collection links identifiable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 ### Added
 - New endpoint to replace collection JSON objects in the API response
 - New endpoint to update specific parts of collection objects in API response
-- Publication rights data object to collectionFetch API response
+- Publication rights data object to fetchCollection API response
+- Identifier value to pub links of fetchCollection API response
 ### Fixed
 - Add new DB entities for automatic collections
 - Add support for 'Most Recent' automatic collection

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - New endpoint to replace collection JSON objects in the API response
 - New endpoint to update specific parts of collection objects in API response
 - Publication rights data object to fetchCollection API response
-- Identifier value to pub links of fetchCollection API response
+- Identifier value to publication links of fetchCollection API response
 ### Fixed
 - Add new DB entities for automatic collections
 - Add support for 'Most Recent' automatic collection

--- a/api/blueprints/drbCollection.py
+++ b/api/blueprints/drbCollection.py
@@ -372,7 +372,8 @@ def _buildPublications(editions):
         pub.addLink({
             'rel': 'alternate',
             'href': 'https://{}.nypl.org/edition/{}'.format(host, ed.id),
-            'type': 'text/html'
+            'type': 'text/html',
+            'identifier': 'readable'
         })
 
         opdsPubs.append(pub)

--- a/api/opds2/link.py
+++ b/api/opds2/link.py
@@ -2,7 +2,7 @@
 
 class Link:
     ALLOWED_FIELDS = [
-        'href', 'type', 'rel', 'title', 'templated', 'language', 'alternate',
+        'href', 'type', 'rel', 'identifier', 'title', 'templated', 'language', 'alternate',
         'children', 'properties', 'height', 'width', 'duration', 'bitrate'
     ]
 

--- a/api/opds2/publication.py
+++ b/api/opds2/publication.py
@@ -185,7 +185,7 @@ class Publication:
                     })
                     # Non-readable links
                     else:
-                        identifier = self.setLinkIdentifier(link)
+                        identifier = self.getLinkIdentifier(link)
                         self.addLink({
                         'href': link.url,
                         'type': link.media_type,
@@ -195,7 +195,7 @@ class Publication:
 
                 # Non-readable links
                 else:
-                    identifier = self.setLinkIdentifier(link)
+                    identifier = self.getLinkIdentifier(link)
                     self.addLink({
                     'href': link.url,
                     'type': link.media_type,
@@ -251,7 +251,7 @@ class Publication:
             'rel': 'http://opds-spec.org/acquisition/open-access'
         })
     
-    def setLinkIdentifier(self, link):
+    def getLinkIdentifier(self, link):
 
         '''#Setting identifier value based on link media type when fetching collections'''     
 

--- a/api/opds2/publication.py
+++ b/api/opds2/publication.py
@@ -5,6 +5,7 @@ from model import Edition
 from .metadata import Metadata
 from .link import Link
 from .image import Image
+from ..utils import APIUtils
 
 
 class Publication:
@@ -168,6 +169,8 @@ class Publication:
         host = 'digital-research-books-beta'\
             if os.environ['ENVIRONMENT'] == 'production' else 'drb-qa'
 
+        identifier = ''
+
         # Acquisition Links
         for item in editionRecord.items:
             for link in item.links:
@@ -177,22 +180,27 @@ class Publication:
                         self.addLink({
                         'href': 'https://{}.nypl.org/read/{}'.format(host, link.id),
                         'type': link.media_type,
-                        'rel': 'http://opds-spec.org/acquisition/open-access'
+                        'rel': 'http://opds-spec.org/acquisition/open-access',
+                        'identifier': 'readable'
                     })
                     # Non-readable links
                     else:
+                        identifier = self.setLinkIdentifier(link)
                         self.addLink({
                         'href': link.url,
                         'type': link.media_type,
-                        'rel': 'http://opds-spec.org/acquisition/open-access'
+                        'rel': 'http://opds-spec.org/acquisition/open-access',
+                        'identifier': identifier
                         })
 
                 # Non-readable links
                 else:
+                    identifier = self.setLinkIdentifier(link)
                     self.addLink({
                     'href': link.url,
                     'type': link.media_type,
-                    'rel': 'http://opds-spec.org/acquisition/open-access'
+                    'rel': 'http://opds-spec.org/acquisition/open-access',
+                    'identifier': identifier
                 })
             for rights in item.rights:
                 self.metadata.addField('rights', {   
@@ -242,6 +250,23 @@ class Publication:
             'type': firstLink.media_type,
             'rel': 'http://opds-spec.org/acquisition/open-access'
         })
+    
+    def setLinkIdentifier(self, link):
+
+        '''#Setting identifier value based on link media type when fetching collections'''     
+
+        linkIdent = ''
+        if link.media_type in APIUtils.FORMAT_CROSSWALK['readable']:
+            linkIdent = 'readable'
+        elif link.media_type in APIUtils.FORMAT_CROSSWALK['downloadable']:
+            linkIdent = 'downloadable'
+        elif link.media_type in APIUtils.FORMAT_CROSSWALK['requestable']:
+            linkIdent = 'requestable'
+        elif link.media_type in APIUtils.FORMAT_CROSSWALK['html_catalog']:
+            linkIdent = 'catalog'
+        else:
+            linkIdent = 'other'
+        return linkIdent
 
     def findAndAddCover(self, record):
         if isinstance(record, Edition):

--- a/tests/unit/test_api_collection_blueprint.py
+++ b/tests/unit/test_api_collection_blueprint.py
@@ -582,12 +582,14 @@ class TestCollectionBlueprint:
                 mocker.call({
                     'rel': 'alternate',
                     'href': 'https://drb-qa.nypl.org/edition/1',
-                    'type': 'text/html'
+                    'type': 'text/html',
+                    'identifier': 'readable'
                 }),
                 mocker.call({
                     'rel': 'alternate',
                     'href': 'https://drb-qa.nypl.org/edition/2',
-                    'type': 'text/html'
+                    'type': 'text/html',
+                    'identifier': 'readable'
                 })
             ])
 
@@ -653,12 +655,14 @@ class TestCollectionBlueprint:
                 mocker.call({
                     'rel': 'alternate',
                     'href': 'https://drb-qa.nypl.org/edition/1',
-                    'type': 'text/html'
+                    'type': 'text/html',
+                    'identifier': 'readable'
                 }),
                 mocker.call({
                     'rel': 'alternate',
                     'href': 'https://drb-qa.nypl.org/edition/2',
-                    'type': 'text/html'
+                    'type': 'text/html',
+                    'identifier': 'readable'
                 })
             ])
 

--- a/tests/unit/test_opds_publication.py
+++ b/tests/unit/test_opds_publication.py
@@ -213,7 +213,7 @@ class TestOPDSPublication:
             mocker.call('rights', {'source': 'testSource', 'license': 'testLicense', 'rightsStatement': 'testStatement'})
         ])
 
-        pubMocks['addLink'].assert_called_with({'href': 'testURL', 'rel': 'http://opds-spec.org/acquisition/open-access', 'type': 'testType'})
+        pubMocks['addLink'].assert_called_with({'href': 'testURL', 'rel': 'http://opds-spec.org/acquisition/open-access', 'type': 'testType', 'identifier': 'other'})
         pubMocks['setContributors'].assert_called_once_with([{'name': 'Test Contrib'}])
         pubMocks['setBestIdentifier'].assert_called_once_with(['id1', 'id2', 'id3'])
         pubMocks['findAndAddCover'].assert_called_once_with(testEdition)
@@ -265,7 +265,7 @@ class TestOPDSPublication:
             mocker.call('rights', {'source': 'testSource', 'license': 'testLicense', 'rightsStatement': 'testStatement'})
         ])
 
-        pubMocks['addLink'].assert_called_with({'href': 'https://digital-research-books-beta.nypl.org/read/testID', 'type': 'testType', 'rel': 'http://opds-spec.org/acquisition/open-access'})
+        pubMocks['addLink'].assert_called_with({'href': 'https://digital-research-books-beta.nypl.org/read/testID', 'type': 'testType', 'rel': 'http://opds-spec.org/acquisition/open-access', 'identifier': 'readable'})
         pubMocks['setContributors'].assert_called_once_with([{'name': 'Test Contrib'}])
         pubMocks['setBestIdentifier'].assert_called_once_with(['id1', 'id2', 'id3'])
         pubMocks['findAndAddCover'].assert_called_once_with(testEdition)
@@ -323,7 +323,7 @@ class TestOPDSPublication:
         ])
 
         mockAdd.assert_called_once_with({'href': 'url1', 'type': 'testType', 'rel': 'http://opds-spec.org/acquisition/open-access'})
-
+        
     def test_findAndAddCover_present(self, testPubEls, mocker):
         testPub, _ = testPubEls
 


### PR DESCRIPTION
In this PR, I added an identifier value to the publication links for each edition to categorize the links as readable, downloadable, requestable, catalog, and other in the fetchCollection API response.