### PR TITLE
SFR-1633: Updated OCLC Classify API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ### Added
 - New endpoint to replace collection JSON objects in the API response
 - New endpoint to update specific parts of collection JSON objects in the API response
-- Publication rights data object to fetchCollection API response
+- Publication rights data object to the fetchCollection API response
 - Identifier value to publication links of fetchCollection API response
 - Add new DB entities for automatic collections
 - Add support for 'Most Recent' automatic collection

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add support for 'Most Recent' automatic collection
 - Supported ES backed automatic collections
 - Add ability to create automatic collections
+- Updated OCLC Classify manager with new key and header
 ### Fixed
 
 ## 2023-02-02 -- v0.11.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Add support for 'Most Recent' automatic collection
 - Supported ES backed automatic collections
 - Add ability to create automatic collections
-- Updated OCLC Classify manager with new key and header
+- Updated OCLC Classify manager with new API key and header
 ### Fixed
 
 ## 2023-02-02 -- v0.11.2

--- a/config/production.yaml
+++ b/config/production.yaml
@@ -36,7 +36,7 @@ HATHI_DATAFILES: https://www.hathitrust.org/filebrowser/download/244651
 HATHI_API_ROOT: https://babel.hathitrust.org/cgi/htd
 
 # OCLC CONFIGURATION
-# OCLC_API_KEY must be configured in secrets file
+# OCLC_API_KEY and OCLC_CLASSIFY_API_KEY must be configured in secrets file
 OCLC_QUERY_LIMIT: '390000'
 
 # AWS CONFIGURATION

--- a/config/qa.yaml
+++ b/config/qa.yaml
@@ -36,7 +36,7 @@ HATHI_DATAFILES: https://www.hathitrust.org/filebrowser/download/244651
 HATHI_API_ROOT: https://babel.hathitrust.org/cgi/htd
 
 # OCLC CONFIGURATION
-# OCLC_API_KEY must be configured in secrets file
+# OCLC_API_KEY and OCLC_CLASSIFY_API_KEY must be configured in secrets file
 OCLC_QUERY_LIMIT: '390000'
 
 # AWS CONFIGURATION

--- a/managers/oclcClassify.py
+++ b/managers/oclcClassify.py
@@ -125,8 +125,8 @@ class ClassifyManager:
             [str] -- A string of XML data comprising of the body of the
             Classify response.
         """
-        classifyResp = requests.get(self.query, \
-            headers={'X-OCLC-API-Key': os.environ['OCLC_API_KEY']}, \
+        classifyResp = requests.get(self.query, 
+            headers={'X-OCLC-API-Key': os.environ['OCLC_CLASSIFY_API_KEY']}, 
             timeout=10
         )
 

--- a/managers/oclcClassify.py
+++ b/managers/oclcClassify.py
@@ -2,6 +2,7 @@ import fasttext
 from lxml import etree
 import re
 import requests
+import os
 from requests.exceptions import ConnectTimeout, HTTPError, ReadTimeout
 
 from logger import createLog
@@ -17,7 +18,7 @@ class ClassifyManager:
     Returns:
         [str] -- A string of XML data comprising of the Classify response body.
     """
-    CLASSIFY_ROOT = 'http://classify.oclc.org/classify2/Classify'
+    CLASSIFY_ROOT = 'https://metadata.api.oclc.org/classify'
 
     LOOKUP_IDENTIFIERS = [
         'oclc', # OCLC Number
@@ -124,7 +125,10 @@ class ClassifyManager:
             [str] -- A string of XML data comprising of the body of the
             Classify response.
         """
-        classifyResp = requests.get(self.query, timeout=10)
+        classifyResp = requests.get(self.query, \
+            headers={'X-OCLC-API-Key': os.environ['OCLC_API_KEY']}, \
+            timeout=10
+        )
 
         classifyResp.raise_for_status()
 

--- a/tests/unit/test_oclcClassify_manager.py
+++ b/tests/unit/test_oclcClassify_manager.py
@@ -1,5 +1,6 @@
 from lxml import etree
 import pytest
+import os
 
 from managers.oclcClassify import ClassifyManager, ClassifyError
 
@@ -82,7 +83,7 @@ class TestClassifyManager:
 
         testInstance.generateAuthorTitleURL()
 
-        assert testInstance.query == 'http://classify.oclc.org/classify2/Classify?title=testTitle&author=testAuthor'
+        assert testInstance.query == 'https://metadata.api.oclc.org/classify?title=testTitle&author=testAuthor'
         mockAddOptions.assert_called_once
 
     def test_generateIdentifierURL(self, testInstance, mocker):
@@ -90,7 +91,7 @@ class TestClassifyManager:
 
         testInstance.generateIdentifierURL()
 
-        assert testInstance.query == 'http://classify.oclc.org/classify2/Classify?test=1'
+        assert testInstance.query == 'https://metadata.api.oclc.org/classify?test=1'
         mockAddOptions.assert_called_once
 
     def test_addClassifyOptions(self, testInstance):
@@ -112,7 +113,7 @@ class TestClassifyManager:
         testInstance.execQuery()
 
         assert testInstance.rawXML == 'testXMLResponse'
-        mockRequest.get.assert_called_once_with('testQuery', timeout=10)
+        mockRequest.get.assert_called_once_with('testQuery', headers={'X-OCLC-API-Key': os.environ['OCLC_CLASSIFY_API_KEY']}, timeout=10)
 
     def test_execQuery_error(self, testInstance, mocker):
         mockResponse = mocker.MagicMock()


### PR DESCRIPTION
With this PR, I updated the OCLC Classify API with an updated root url, adding a header to the query for the classification process, and updated the API keys for the qa and production config files.