### PR TITLE
fix: Close sessions after collection reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Add ability to create automatic collections
 - Updated OCLC Classify manager with new API key and header
 ### Fixed
+- Close DB sessions after collection reads
 
 ## 2023-02-02 -- v0.11.2
 ### Added

--- a/api/blueprints/drbCollection.py
+++ b/api/blueprints/drbCollection.py
@@ -275,6 +275,8 @@ def collectionFetch(uuid):
         errMsg = {'message': 'Unable to locate collection {}'.format(uuid)}
         return APIUtils.formatResponseObject(404, 'fetchCollection', errMsg)
 
+    dbClient.closeSession()
+
     return APIUtils.formatOPDS2Object(200, opdsFeed)
 
 @collection.route('/<uuid>', methods=['DELETE'])
@@ -386,6 +388,8 @@ def collectionList():
         group = constructOPDSFeed(uuid, dbClient, perPage=5, path=path)
 
         opdsFeed.addGroup(group)
+
+    dbClient.closeSession()
 
     return APIUtils.formatOPDS2Object(200, opdsFeed)
 


### PR DESCRIPTION
Seems to be the same fix as
https://github.com/NYPL/drb-etl-pipeline/pull/85 that we're just now noticing with the collections work here.

We should really do something so that Flask does this automatically for us, but lets verify this works first