### PR TITLE
Add script to run prod DB migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Supported ES backed automatic collections
 - Add ability to create automatic collections
 - Updated OCLC Classify manager with new API key and header
+- Added script to run production DB migration
 ### Fixed
 
 ## 2023-02-02 -- v0.11.2

--- a/migrations/migrate-prod.sh
+++ b/migrations/migrate-prod.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+POSTGRES_USER=$(aws ssm get-parameter --profile digital-dev --name /drb/production/postgres/user --with-decryption | jq -r '.Parameter.Value') \
+POSTGRES_PSWD=$(aws ssm get-parameter --profile digital-dev --name /drb/production/postgres/pswd --with-decryption | jq -r '.Parameter.Value') \
+POSTGRES_HOST="sfr-new-metadata-production-cluster.cluster-cvy7z512hcjg.us-east-1.rds.amazonaws.com" \
+POSTGRES_PORT="5432" \
+POSTGRES_NAME="dcdw_production" \
+  alembic -c alembic.ini upgrade head


### PR DESCRIPTION
Whipped this up to be able to run the prod migration from a non prod machine. This does assume a couple things:

  1. You have a profile in your local aws config called 'digital-dev' (this could maybe be passed as a param, but it would be easy enough to alter the script before running :shrug)
  2. You have installed jq (https://stedolan.github.io/jq/) which is an awesome command line JSON parser

A pretty bare bones script, but thought it would be helpful to at least document how I ran the migration.