### PR TITLE
HOTFIX_DeleteCollectionAuthentication

### DIFF
--- a/api/blueprints/drbCollection.py
+++ b/api/blueprints/drbCollection.py
@@ -287,7 +287,7 @@ def collectionDelete(uuid, user=None):
     dbClient = DBClient(current_app.config['DB_CLIENT'])
     dbClient.createSession()
 
-    deleteCount = dbClient.deleteCollection(uuid, user)
+    deleteCount = dbClient.deleteCollection(uuid)
 
     if deleteCount is None or deleteCount < 1:
         errMsg = {'message': 'No collection with UUID {} exists'.format(uuid)}

--- a/api/db.py
+++ b/api/db.py
@@ -285,9 +285,8 @@ class DBClient():
         self.session.add(automaticCollection)
         return newCollection
 
-    def deleteCollection(self, uuid, owner):
+    def deleteCollection(self, uuid):
         return self.session.query(Collection)\
-            .filter(Collection.owner == owner)\
             .filter(Collection.uuid == uuid).delete()
 
     def fetchUser(self, user):

--- a/tests/unit/test_api_collection_blueprint.py
+++ b/tests/unit/test_api_collection_blueprint.py
@@ -559,7 +559,7 @@ class TestCollectionBlueprint:
 
             assert mockDB.createSession.call_count == 2
             mockDB.deleteCollection.assert_called_once_with(
-                'testUUID', 'testUser'
+                'testUUID'
             )
             mockDB.session.commit.assert_called_once()
 
@@ -592,7 +592,7 @@ class TestCollectionBlueprint:
 
             assert mockDB.createSession.call_count == 2
             mockDB.deleteCollection.assert_called_once_with(
-                'testUUID', 'testUser'
+                'testUUID'
             )
 
             mockUtils['formatResponseObject'].assert_called_once_with(

--- a/tests/unit/test_api_db.py
+++ b/tests/unit/test_api_db.py
@@ -172,12 +172,12 @@ class TestDBClient:
         testInstance.session.add.assert_called_once_with(mockCollInstance)
 
     def test_deleteCollection(self, testInstance):
-        testInstance.session.query().filter().filter().delete\
+        testInstance.session.query().filter().delete\
             .return_value = 'testDelete'
 
-        assert testInstance.deleteCollection('uuid', 'owner') == 'testDelete'
+        assert testInstance.deleteCollection('uuid') == 'testDelete'
 
-        testInstance.session.query().filter().filter().delete\
+        testInstance.session.query().filter().delete\
             .assert_called_once()
 
     def test_fetchUser(self, testInstance):


### PR DESCRIPTION
This hotfix allows any authenticated user to delete a collection even if they're not the owners of that collection.