### PR TITLE
SFR-1647v2_DeleteDuplicateAuthors&Contributors

### DIFF
--- a/scripts/deleteDuplicateAgents.py
+++ b/scripts/deleteDuplicateAgents.py
@@ -49,12 +49,11 @@ def main(dryRun=True):
     for edition in dbManager.session.query(Edition) \
         .filter(func.jsonb_array_length(Edition.contributors) > 1) \
         .yield_per(batchSize):
-            if edition.contributors and len(edition.contributors) > 1:
-                logging.info('_________Edition Duplicate Contributors Deletion_________')
+            logging.info('_________Edition Duplicate Contributors Deletion_________')
 
-                edition.contributors = deleteDuplicateAgents(edition.id, edition.contributors, \
+            edition.contributors = deleteDuplicateAgents(edition.id, edition.contributors, \
                                                             countEditContrib, 'edition contributor')
-                dbManager.session.add(edition)
+            dbManager.session.add(edition)
 
     if dryRun == True:
         logging.info('________DRY RUN COMPLETED________')


### PR DESCRIPTION
This PR addresses an issue that came up with running the original version of this script where any author/contributor JSONB object that had more than 2 author/contributor names would have the next element after the first one delete itself because the `nextIndex` would stay at index of 1 instead of always being one more than than the `currIndex`. The change to the for loop should fix this issue and logging was added for testing and dry run attempts. Lastly, the edition for loop is outside of the work for loop because the query originally would only find editions that were in works with multiple authors/contributors instead of any edition with multiple contributors which broadens the query.