### PR TITLE
fix: Install pybind11 as fasttext dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ### Added
 - Script to delete current duplicate authors/contributors in the PSQL database
 ### Fixed
-- 
+- Explicitly install pybind11 as fasttext dependency
 
 ## 2023-04-03 -- v0.12.0
 ### Added

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ boto3
 elastic-transport
 elasticsearch-dsl>7.0.0
 elasticsearch==7.16.3
-fasttext
+fasttext==0.9.2
 flasgger
 flask
 flask-cors
@@ -14,6 +14,7 @@ pandas
 pika
 pillow
 psycopg2-binary
+pybind11==2.10.4
 python-levenshtein==0.20.4
 pycountry
 pyjwt[crypto]


### PR DESCRIPTION
pybind11 is not an explicit pip dependency of fasttext, but is instead required for the build step of fasttext (I guess there's a cpp binary or something in there that gets compiled during build-wheels). So explicitly install pybind11 to see if that does the trick. While we're here, pin the versions of both libs

i also don't think this will work