### PR TITLE
fix: Install pybind11 as fasttext dependency

### DIFF
--- a/.github/workflows/tests-regression.yaml
+++ b/.github/workflows/tests-regression.yaml
@@ -25,7 +25,7 @@ jobs:
             ${{ runner.os }}-
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip wheel
           pip install -r dev-requirements.txt
           pip install -r requirements.txt
       - name: Run test suite with Allure

--- a/.github/workflows/tests-unit.yaml
+++ b/.github/workflows/tests-unit.yaml
@@ -32,7 +32,7 @@ jobs:
             ${{ runner.os }}-
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip wheel
           pip install -r dev-requirements.txt
           pip install -r requirements.txt
       - name: Run test suite

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ### Added
 - Script to delete current duplicate authors/contributors in the PSQL database
 ### Fixed
-- 
+- Install `wheel` with pip to fix fasttext build
 
 ## 2023-04-03 -- v0.12.0
 ### Added

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ boto3
 elastic-transport
 elasticsearch-dsl>7.0.0
 elasticsearch==7.16.3
-fasttext
+fasttext==0.9.2
 flasgger
 flask
 flask-cors


### PR DESCRIPTION
pybind11 is not an explicit pip dependency of fasttext, but is instead required for the build step of fasttext (I guess there's a cpp binary or something in there that gets compiled during build-wheels). So explicitly install pybind11 to see if that does the trick. While we're here, pin the versions of both libs

this may work but is not ideal