### PR TITLE
fix: Install `wheel` with pip

### DIFF
--- a/.github/workflows/tests-regression.yaml
+++ b/.github/workflows/tests-regression.yaml
@@ -25,7 +25,7 @@ jobs:
             ${{ runner.os }}-
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip wheel
           pip install -r dev-requirements.txt
           pip install -r requirements.txt
       - name: Run test suite with Allure

--- a/.github/workflows/tests-unit.yaml
+++ b/.github/workflows/tests-unit.yaml
@@ -32,7 +32,7 @@ jobs:
             ${{ runner.os }}-
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip wheel
           pip install -r dev-requirements.txt
           pip install -r requirements.txt
       - name: Run test suite

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ### Added
 - Script to delete current duplicate authors/contributors in the PSQL database
 ### Fixed
-- 
+- Install `wheel` with pip to fix fasttext build
 
 ## 2023-04-03 -- v0.12.0
 ### Added

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ boto3
 elastic-transport
 elasticsearch-dsl>7.0.0
 elasticsearch==7.16.3
-fasttext
+fasttext==0.9.2
 flasgger
 flask
 flask-cors


### PR DESCRIPTION
A change to pip's behavior caused the fasttext install to not dynamically install pybind11 for us. By explicitly adding wheel to pip, we can revert to the old behavior for now.  Eventually, fasttext will need to implement a fix on their end, but for now this works.

See:
  - https://github.com/pypa/pip/issues/8559 for the deprecation
  - https://github.com/pypa/pip/issues/11978#issuecomment-1513360038 for example of the workaround