### PR TITLE
SFR-1684_Title&AuthorChicagoISAC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@
 ### Added
 - Script to delete current duplicate authors/contributors in the PSQL database
 - Web scraper script for the Chicago ISAC catalog of publications
+-
 ### Fixed
 - Modify agentParser method to reduce number of future duplicate agents
 - Install `wheel` with pip to fix fasttext build
+- Cleaned web scraped metadata from Chicago ISAC catalogs
 
 
 ## 2023-04-03 -- v0.12.0

--- a/scripts/deleteDuplicateAgents.py
+++ b/scripts/deleteDuplicateAgents.py
@@ -8,11 +8,11 @@ from Levenshtein import jaro_winkler
 from logger import createLog
 from sqlalchemy import or_, func
 
-logger = createLog(__name__)
-
-logging.basicConfig(filename='duplicateAgents.log', encoding='utf-8', level=logging.INFO)
-
 def main(dryRun=False):
+
+    logger = createLog(__name__)
+
+    logging.basicConfig(filename='duplicateAgents.log', encoding='utf-8', level=logging.INFO)
 
     '''Deleting current duplicate authors/contributors with improved Levenshtein implementation'''
 


### PR DESCRIPTION
This PR adds the title and author metadata to the Chicago ISAC json file that will be created and eventually mapped into the DRB PSQL database. It also modifies the `cleanedText` method to make it more robust and compact. The change to the `deleteDuplicates` methods is simply to avoid the log file running when `scriptrunner.py` is called for other scripts.