### PR TITLE
Add ISAC to Source Priority dictionary

### DIFF
--- a/api/utils.py
+++ b/api/utils.py
@@ -32,9 +32,10 @@ class APIUtils():
         'doab': 2,
         'muse': 3,
         'met': 4,
-        'hathitrust': 5,
-        'oclc': 6,
-        'nypl': 7
+        'isac': 5,
+        'hathitrust': 6,
+        'oclc': 7,
+        'nypl': 8
     }
 
     @staticmethod


### PR DESCRIPTION
This hotfix adds ISAC to the Source Priority dictionary which allows ISAC works to be searched for in the API and on the frontend.