### PR TITLE
SFR-1702v2_IngestUofSCBooksPubInfo

### DIFF
--- a/UofSC_metadata.json
+++ b/UofSC_metadata.json
@@ -3,14 +3,20 @@
             "title": "Ambiguous Anniversary",
             "authors": "David T. Gleeson, Simon Lewis",
             "subject": "",
+            "publicationDate": "2012",
+            "publisher": "University of South Carolina Press",
+            "publisherLocation": "South Carolina",
             "isbn": "9781611170962",
-            "pdf_link": "https://pdfpipelinestoreproduction.s3.amazonaws.com/tagged_pdfs/DCL_01_9781611170962.pdf"
+            "pdf_link": "https://pdf-pipeline-store-production.s3.amazonaws.com/tagged_pdfs/DCL_01_9781611170962.pdf"
       },
       {
             "title": "The Fruits of Exile",
             "authors": "Richard Bodek, Simon Lewis",
             "subject": "",
+            "publicationDate": "2010",
+            "publisher": "University of South Carolina Press",
+            "publisherLocation": "South Carolina",
             "isbn": "9781570038532",
-            "pdf_link": "https://pdfpipelinestoreproduction.s3.amazonaws.com/tagged_pdfs/DCL_02_9781570038532.pdf"
+            "pdf_link": "https://pdf-pipeline-store-production.s3.amazonaws.com/tagged_pdfs/DCL_02_9781570038532.pdf"
       }
 ]

--- a/mappings/UofSC.py
+++ b/mappings/UofSC.py
@@ -5,10 +5,14 @@ class UofSCMapping(JSONMapping):
         super().__init__(source, {})
         self.mapping = self.createMapping()
     
+
     def createMapping(self):
         return {
             'title': ('title', '{0}'),
             'authors': [('authors', '{0}|||true')],
+            'dates': [('publicationDate', '{0}|publication_date')],
+            'publisher': [('publisher', '{0}')],
+            'spatial': ('publisherLocation', '{0}|publisherLocation'),
             'identifiers': 
                 [('isbn', '{0}|isbn')]
             ,


### PR DESCRIPTION
This PR adds the missing publication info from the JSON metadata which made the UofSC books unavailable to read online on the DRB QA site.