### PR TITLE
Wrap DDL in dev setup process in `sqlalchemy.text`

### DIFF
--- a/processes/developmentSetup.py
+++ b/processes/developmentSetup.py
@@ -5,6 +5,7 @@ import gzip
 import os
 from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 import requests
+import sqlalchemy as sa
 from sqlalchemy.exc import ProgrammingError
 from time import sleep
 
@@ -70,16 +71,24 @@ class DevelopmentSetupProcess(CoreProcess):
         with self.adminDBConnection.engine.connect() as conn:
             conn.connection.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
             try:
-                conn.execute('CREATE DATABASE {}'.format(os.environ['POSTGRES_NAME']))
+                conn.execute(
+                    sa.text(f"CREATE DATABASE {os.environ['POSTGRES_NAME']}"),
+                )
             except ProgrammingError:
                 pass
 
             try:
-                conn.execute('CREATE USER {} WITH PASSWORD \'{}\''.format(
-                    os.environ['POSTGRES_USER'], os.environ['POSTGRES_PSWD']
-                ))
-                conn.execute('GRANT ALL PRIVILEGES ON DATABASE {} TO {}'.format(
-                    os.environ['POSTGRES_NAME'], os.environ['POSTGRES_USER'])
+                conn.execute(
+                    sa.text(
+                        f"CREATE USER {os.environ['POSTGRES_USER']} "
+                        f"WITH PASSWORD '{os.environ['POSTGRES_PSWD']}'",
+                    ),
+                )
+                conn.execute(
+                    sa.text(
+                        f"GRANT ALL PRIVILEGES ON DATABASE {os.environ['POSTGRES_NAME']} "
+                        f"TO {os.environ['POSTGRES_USER']}",
+                    ),
                 )
             except ProgrammingError:
                 pass


### PR DESCRIPTION
Noticed when spinning up a new environment that these SQL statements fail because our version of sqlalchemy doesn't accept raw strings, but rather requires wrapping them in executable text objects.

I also switched over to f strings while I was at it