### PR TITLE
SFR-1708_FixISACPubLocaton&Links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## unreleased version -- v0.12.2
+### Added
+
+### Fixed
+- Publisher location and webpub manifest links for ISAC records
+
 ## 2023-07-20 -- v0.12.1
 ### Added
 - Script to delete current duplicate authors/contributors in the PSQL database

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -10,3 +10,4 @@ from .deleteDuplicateAgents import main as deleteDuplicates
 from .chicago_isac_scraper import main as isacScraper
 from .interstitialPagesSFR1410 import main as interstitialPages
 from .ingestS3Metadata import main as ingestS3
+from .updatePubLocationAndLinks import main as updateLocationAndLinks

--- a/scripts/updatePubLocationAndLinks.py
+++ b/scripts/updatePubLocationAndLinks.py
@@ -1,0 +1,62 @@
+import os
+import re
+
+from model import Record, Edition, Link
+from managers import DBManager
+
+
+def main():
+
+    '''Updating the publisher location and links flags for ISAC records'''
+
+    dbManager = DBManager(
+        user= os.environ.get('POSTGRES_USER', None),
+        pswd= os.environ.get('POSTGRES_PSWD', None),
+        host= os.environ.get('POSTGRES_HOST', None),
+        port= os.environ.get('POSTGRES_PORT', None),
+        db= os.environ.get('POSTGRES_NAME', None)
+    )
+
+    dbManager.generateEngine()
+
+    dbManager.createSession()
+
+    for record in dbManager.session.query(Record) \
+        .filter(Record.source == 'isac').all():
+            #Removing |publisherLocation from spatial attribute in Record Table
+            charPattern = re.compile(r'\|publisherLocation')
+            record.spatial = re.sub(charPattern, '', record.spatial)
+
+            #Reversing download and reader values of webpub mainfest in has_part attribute 
+            hasPartManifest = record.has_part[0].split('|')
+
+            if hasPartManifest[len(hasPartManifest)-2] == 'application/webpub+json' \
+            and hasPartManifest[-1] == '{"catalog": false, "download": true, "reader": false, "embed": false}':
+                
+                hasPartManifest[-1] = '{"catalog": false, "download": false, "reader": true, "embed": false}'
+                newHasPart = []
+                newHasPart.append('|'.join(hasPartManifest))
+                for i in record.has_part[1:]:
+                    newHasPart.append(i)
+                record.has_part = newHasPart
+                
+    #Removing |publisherLocation from publication_place attribute in Edition Table
+    #This makes this change show up on the frontend unlike changing the record spatial attribute
+    for edition in dbManager.session.query(Edition) \
+        .filter(Edition.publication_place == 'Chicago|publisherLocation'):
+            charPattern = re.compile(r'\|publisherLocation')
+            edition.publication_place = re.sub(charPattern, '', edition.publication_place)
+
+
+    
+    #Reversing download and reader values of webpub mainfest links in Link Table
+    #This change wil show up on the frontend unlike changing the record has_part attribute
+    for link in dbManager.session.query(Link) \
+        .filter(Link.media_type == 'application/webpub+json') \
+        .filter(Link.flags == '{"embed": false,"reader": false,"catalog": false,"download": true}').all():
+            link.flags = {"embed": False, "reader": True, "catalog": False, "download": False}
+
+    dbManager.commitChanges()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This branch intends to fix the publisher location of Chicago ISAC records from `Chicago|publisherLocation` to just `Chicago` which will show up on the frontend as well. Also, this branch intends to fix the web-pub manifest links so that the Read Online link on the frontend will go to the actual web-pub instead of it's JSON form in AWS S3.