### PR TITLE
HOTFIX_ISACHasPartConditional

### DIFF
--- a/scripts/updatePubLocationAndLinks.py
+++ b/scripts/updatePubLocationAndLinks.py
@@ -28,18 +28,20 @@ def main():
             record.spatial = re.sub(charPattern, '', record.spatial)
 
             #Reversing download and reader values of webpub mainfest in has_part attribute 
-            if record.has_part:
-                hasPartManifest = record.has_part[0].split('|')
+            if not record.has_part:
+                continue
+            
+            hasPartManifest = record.has_part[0].split('|')
 
-                if hasPartManifest[len(hasPartManifest)-2] == 'application/webpub+json' \
-                and hasPartManifest[-1] == '{"catalog": false, "download": true, "reader": false, "embed": false}':
-                    
-                    hasPartManifest[-1] = '{"catalog": false, "download": false, "reader": true, "embed": false}'
-                    newHasPart = []
-                    newHasPart.append('|'.join(hasPartManifest))
-                    for i in record.has_part[1:]:
-                        newHasPart.append(i)
-                    record.has_part = newHasPart
+            if hasPartManifest[len(hasPartManifest)-2] == 'application/webpub+json' \
+            and hasPartManifest[-1] == '{"catalog": false, "download": true, "reader": false, "embed": false}':
+                
+                hasPartManifest[-1] = '{"catalog": false, "download": false, "reader": true, "embed": false}'
+                newHasPart = []
+                newHasPart.append('|'.join(hasPartManifest))
+                for i in record.has_part[1:]:
+                    newHasPart.append(i)
+                record.has_part = newHasPart
                 
     #Removing |publisherLocation from publication_place attribute in Edition Table
     #This makes this change show up on the frontend unlike changing the record spatial attribute

--- a/scripts/updatePubLocationAndLinks.py
+++ b/scripts/updatePubLocationAndLinks.py
@@ -28,17 +28,18 @@ def main():
             record.spatial = re.sub(charPattern, '', record.spatial)
 
             #Reversing download and reader values of webpub mainfest in has_part attribute 
-            hasPartManifest = record.has_part[0].split('|')
+            if record.has_part:
+                hasPartManifest = record.has_part[0].split('|')
 
-            if hasPartManifest[len(hasPartManifest)-2] == 'application/webpub+json' \
-            and hasPartManifest[-1] == '{"catalog": false, "download": true, "reader": false, "embed": false}':
-                
-                hasPartManifest[-1] = '{"catalog": false, "download": false, "reader": true, "embed": false}'
-                newHasPart = []
-                newHasPart.append('|'.join(hasPartManifest))
-                for i in record.has_part[1:]:
-                    newHasPart.append(i)
-                record.has_part = newHasPart
+                if hasPartManifest[len(hasPartManifest)-2] == 'application/webpub+json' \
+                and hasPartManifest[-1] == '{"catalog": false, "download": true, "reader": false, "embed": false}':
+                    
+                    hasPartManifest[-1] = '{"catalog": false, "download": false, "reader": true, "embed": false}'
+                    newHasPart = []
+                    newHasPart.append('|'.join(hasPartManifest))
+                    for i in record.has_part[1:]:
+                        newHasPart.append(i)
+                    record.has_part = newHasPart
                 
     #Removing |publisherLocation from publication_place attribute in Edition Table
     #This makes this change show up on the frontend unlike changing the record spatial attribute


### PR DESCRIPTION
This hotfix adds one if conditional to avoid running the `updatePubLocation&Links` script for ISAC records with an empty `has_part` array.