### PR TITLE
HOTFIX_DeleteWorkFromQAFrontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased version -- v0.12.2
 ### Added
 - Script to count and return ids of PD Univ of Cali Books from Hathitrust
+- Script to delete problem work records from PSQL and ESC
 ### Fixed
 - Publisher location and webpub manifest links for ISAC records
 

--- a/scripts/deleteProblemWorks.py
+++ b/scripts/deleteProblemWorks.py
@@ -1,0 +1,32 @@
+import os
+
+from model import Work
+from managers import DBManager, ElasticsearchManager
+from elasticsearch_dsl import Search
+
+def main():
+
+    dbManager = DBManager(
+        user= os.environ.get('POSTGRES_USER', None),
+        pswd= os.environ.get('POSTGRES_PSWD', None),
+        host= os.environ.get('POSTGRES_HOST', None),
+        port= os.environ.get('POSTGRES_PORT', None),
+        db= os.environ.get('POSTGRES_NAME', None)
+    )
+
+    esManager = ElasticsearchManager()
+    esManager.createElasticConnection()
+
+    dbManager.generateEngine()
+
+    dbManager.createSession()
+   
+    uuid = '0288f50c-f2db-47fc-9ff9-b8b95b4cc712'
+
+    dbManager.session.query(Work).filter(Work.uuid == uuid).delete()
+
+    resp = Search(index=os.environ['ELASTICSEARCH_INDEX']).query('match', uuid=uuid)
+    resp.delete()
+
+    dbManager.session.commit()
+    dbManager.session.close()


### PR DESCRIPTION
This hotfix adds a script to remove problem works from PSQL and ES database which I recently created when clustering a record from LOC. 