### PR TITLE
Hotfix: escape "*" in ES queries to prohibit wildcard use in search

### DIFF
--- a/api/elastic.py
+++ b/api/elastic.py
@@ -190,7 +190,7 @@ class ElasticClient():
     @staticmethod
     def escapeSearchQuery(query):
         return re.sub(
-           r'[\+\-\&\|\!\(\)\[\]\{\}\^\~\?\:\\\/]{1}', '\\\\\g<0>', query
+           r'[\*\+\-\&\|\!\(\)\[\]\{\}\^\~\?\:\\\/]{1}', '\\\\\g<0>', query
         )
 
     def languageQuery(self, workTotals):


### PR DESCRIPTION
This change will, at least for the time being, limit the usage of "*" in queries passed to ElasticSearch, since the volume of wildcard queries the app is receiving is creating instability.