### PR TITLE
SFR_1826_NYPLLoginFlag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased version -- v0.12.4
 ## Added
 - New script to add nypl_login flag to Links objects
+- Added nypl_login flag to nypl mapping
 ## Fixed
 
 ## 2023-09-05 version -- v0.12.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## unreleased version -- v0.12.4
+## Added
+- New script to add nypl_login flag to Links objects
+## Fixed
+
 ## 2023-09-05 version -- v0.12.3
 ## Removed
 - The "*" character is escaped from queries passed to ElasticSearch, limiting wildcard searches

--- a/mappings/nypl.py
+++ b/mappings/nypl.py
@@ -144,7 +144,7 @@ class NYPLMapping(SQLMapping):
                     item['location']['code'], item['location']['name'], pos
                 ))
 
-                self.record.has_part.append('{}|{}|nypl|application/x.html+edd|{{"edd": true, "catalog": false, "download": false, "reader": false}}'.format(
+                self.record.has_part.append('{}|{}|nypl|application/x.html+edd|{{"edd": true, "catalog": false, "download": false, "reader": false, "nypl_login": true}}'.format(
                     pos,
                     'http://www.nypl.org/research/collections/shared-collection-catalog/hold/request/b{}-i{}'.format(self.source['id'], item['id'])
                 ))

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -11,4 +11,5 @@ from .chicago_isac_scraper import main as isacScraper
 from .interstitialPagesSFR1410 import main as interstitialPages
 from .ingestS3Metadata import main as ingestS3
 from .updatePubLocationAndLinks import main as updateLocationAndLinks
-from .countCABooks import main as countCABooks
+from .countCABooks import main as countCA
+from .nyplLoginFlags import main as nyplFlags

--- a/scripts/nyplLoginFlags.py
+++ b/scripts/nyplLoginFlags.py
@@ -1,0 +1,35 @@
+import os
+
+from model import Link
+from managers import DBManager
+from sqlalchemy import or_
+import json
+
+def main():
+    
+    '''Updating NYPL Link flags with a new nypl_login flag'''
+
+    dbManager = DBManager(
+        user= os.environ.get('POSTGRES_USER', None),
+        pswd= os.environ.get('POSTGRES_PSWD', None),
+        host= os.environ.get('POSTGRES_HOST', None),
+        port= os.environ.get('POSTGRES_PORT', None),
+        db= os.environ.get('POSTGRES_NAME', None)
+    )
+
+    dbManager.generateEngine()
+
+    dbManager.createSession()
+
+    for link in dbManager.session.query(Link) \
+        .filter(or_(Link.media_type == 'application/html+edd', Link.media_type == 'application/x.html+edd')).all():
+            if link.flags['edd'] == True:
+                #The link.flags doesn't update if the dict method isn't called on it
+                newLinkFlag = dict(link.flags)
+                newLinkFlag['nypl_login'] = True
+                link.flags = newLinkFlag
+
+    dbManager.commitChanges()
+
+if __name__ == '__main__':
+    main()

--- a/tests/unit/test_nypl_mapping.py
+++ b/tests/unit/test_nypl_mapping.py
@@ -104,5 +104,5 @@ class TestNYPLMapping:
         assert testMapping.record.coverage == ['tst|Test|2']
         assert testMapping.record.has_part == [
             '1|https://www.nypl.org/research/collections/shared-collection-catalog/bib/b1|nypl|application/html+catalog|{"catalog": true, "download": false, "reader": false}',
-            '2|http://www.nypl.org/research/collections/shared-collection-catalog/hold/request/b1-i1|nypl|application/x.html+edd|{"edd": true, "catalog": false, "download": false, "reader": false}'
+            '2|http://www.nypl.org/research/collections/shared-collection-catalog/hold/request/b1-i1|nypl|application/x.html+edd|{"edd": true, "catalog": false, "download": false, "reader": false, "nypl_login": true}'
         ]


### PR DESCRIPTION
This PR adds a script to add an nypl_login flag to the Links objects of DRB. For right now, the nypl_login flag will only be inserted for links that have requestable formats like application/html+edd and application/x.html+edd with a True boolean value. My second commit adds the nypl_login flag to nypl records that are requestable and these records seem to be the only ones that have the requestable formats.