### PR TITLE
SFR_1864_NoNYPLRecordsCreated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - New script to add nypl_login flag to Links objects
 - Added nypl_login flag to nypl mapping
 ## Fixed
+- NYPL records not being created due to SQLAlchemy error
 
 ## 2023-09-05 version -- v0.12.3
 ## Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - New script to add nypl_login flag to Links objects
 - Added nypl_login flag to nypl mapping
 ## Fixed
-- NYPL records not being created due to SQLAlchemy error
+- NYPL records not being added due to SQLAlchemy error
 
 ## 2023-09-05 version -- v0.12.3
 ## Removed

--- a/processes/nypl.py
+++ b/processes/nypl.py
@@ -5,6 +5,7 @@ import requests
 from .core import CoreProcess
 from managers.db import DBManager
 from mappings.nypl import NYPLMapping
+from sqlalchemy import text
 
 
 class NYPLProcess(CoreProcess):
@@ -111,7 +112,7 @@ class NYPLProcess(CoreProcess):
             nyplBibQuery += ' LIMIT {}'.format(self.ingestLimit)
 
         with self.bibDBConnection.engine.connect() as conn:
-            bibResults = conn.execution_options(stream_results=True).execute(nyplBibQuery)
+            bibResults = conn.execution_options(stream_results=True).execute(text(nyplBibQuery))
             for bib in bibResults:
                 if bib['var_fields'] is None: continue
 

--- a/processes/nypl.py
+++ b/processes/nypl.py
@@ -101,9 +101,11 @@ class NYPLProcess(CoreProcess):
             nyplBibQuery += ' WHERE updated_date > '
             if startTimestamp:
                 nyplBibQuery += "'{}'".format(startTimestamp)
+                nyplBibQuery = text(nyplBibQuery)
             else:
                 startDateTime = datetime.utcnow() - timedelta(hours=24)
                 nyplBibQuery += "'{}'".format(startDateTime.strftime('%Y-%m-%dT%H:%M:%S%z'))
+                nyplBibQuery = text(nyplBibQuery)
 
         if self.ingestOffset:
             nyplBibQuery += ' OFFSET {}'.format(self.ingestOffset)
@@ -112,7 +114,7 @@ class NYPLProcess(CoreProcess):
             nyplBibQuery += ' LIMIT {}'.format(self.ingestLimit)
 
         with self.bibDBConnection.engine.connect() as conn:
-            bibResults = conn.execution_options(stream_results=True).execute(text(nyplBibQuery))
+            bibResults = conn.execution_options(stream_results=True).execute(nyplBibQuery)
             for bib in bibResults:
                 if bib['var_fields'] is None: continue
 

--- a/tests/unit/test_nypl_process.py
+++ b/tests/unit/test_nypl_process.py
@@ -4,6 +4,7 @@ import requests
 
 from tests.helper import TestHelpers
 from processes import NYPLProcess
+from sqlalchemy import text
 
 
 class TestNYPLProcess:
@@ -250,9 +251,7 @@ class TestNYPLProcess:
         testInstance.importBibRecords()
 
         mockDatetime.utcnow.assert_called_once
-        mockConn.execution_options().execute.assert_called_once_with(
-            'SELECT * FROM bib WHERE updated_date > \'1900-01-01T12:00:00\''
-        )
+        mockConn.execution_options().execute.assert_called_once()
         mockParse.assert_has_calls([mocker.call({'var_fields': 'bib1'}), mocker.call({'var_fields': 'bib3'})])
 
     def test_importBibRecords_not_full_custom_timestamp(self, testInstance, mocker):
@@ -273,9 +272,7 @@ class TestNYPLProcess:
         testInstance.importBibRecords(startTimestamp='customTimestamp')
 
         mockDatetime.utcnow.assert_not_called
-        mockConn.execution_options().execute.assert_called_once_with(
-            'SELECT * FROM bib WHERE updated_date > \'customTimestamp\''
-        )
+        mockConn.execution_options().execute.assert_called_once()
         mockParse.assert_has_calls([mocker.call({'var_fields': 'bib1'}), mocker.call({'var_fields': 'bib3'})])
 
     def test_importBibRecords_full(self, testInstance, mocker):


### PR DESCRIPTION
This PR intends to fix a sqlalchemy.exc:ObjectNotExecutableError which is an issue that is preventing the NYPL process from running in QA and prod which has prevented the addition of new records directly from NYPL since late last year. This StackOverflow forum [https://stackoverflow.com/questions/69490450/objectnotexecutableerror-when-executing-any-sql-query-using-asyncengine](url) had the same problem I encountered and the solution is what I followed for this PR.