### PR TITLE
Change Hathi data files source to new URL

### DIFF
--- a/config/sample-compose.yaml
+++ b/config/sample-compose.yaml
@@ -36,7 +36,7 @@ FILE_QUEUE: drb_files
 FILE_ROUTING_KEY: drb_files
 
 # HATHITRUST CONFIGURATION
-HATHI_DATAFILES: https://www.hathitrust.org/filebrowser/download/244651
+HATHI_DATAFILES: https://www.hathitrust.org/files/hathifiles/hathi_file_list.json
 HATHI_API_ROOT: https://babel.hathitrust.org/cgi/htd
 #HATHI_API_KEY: 
 #HATHI_API_SECRET: 


### PR DESCRIPTION
Change an outdated Hathi file listing to a JSON file at a new URL containing the same information.