### PR TITLE
SFR-1865_S3APIAuthentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 ## Added
 - New script to add nypl_login flag to Links objects
 - Added nypl_login flag to nypl mapping
-- New API to return a unique, presigned link to an S3 object
+- New APIUtils method to return a unique, presigned link to an S3 object
+- New API and endpoint to return a link to S3 objects
 ## Fixed
 
 ## 2023-09-05 version -- v0.12.3

--- a/swagger.v4.json
+++ b/swagger.v4.json
@@ -251,6 +251,11 @@
                 "tags": ["digital-research-books"],
                 "summary": "v4 Get AWS S3 Object Link",
                 "description": "Return a single s3 object link from DRB buckets",
+                "security": [
+                    {
+                        "BasicAuth": []
+                    }
+                ],
                 "parameters": [
                     {
                         "name": "key",

--- a/tests/unit/test_api_s3_blueprint.py
+++ b/tests/unit/test_api_s3_blueprint.py
@@ -1,7 +1,7 @@
 from flask import Flask
 import pytest
 
-from api.blueprints.drbS3 import s3ObjectLinkFetch
+from api.blueprints.drbS3 import validateToken, s3ObjectLinkFetch
 from api.utils import APIUtils
 
 from werkzeug.datastructures import ImmutableMultiDict 
@@ -13,12 +13,14 @@ class TestS3Blueprint:
             APIUtils,
             normalizeQueryParams=mocker.DEFAULT,
             formatResponseObject=mocker.DEFAULT,
-            generate_presigned_url=mocker.DEFAULT
+            generate_presigned_url=mocker.DEFAULT,
+            validatePassword=mocker.DEFAULT
         )
 
     @pytest.fixture
     def testApp(self):
         flaskApp = Flask('test')
+        flaskApp.config['DB_CLIENT'] = 'testDBClient'
 
         return flaskApp
     
@@ -28,8 +30,20 @@ class TestS3Blueprint:
         mockUtils['formatResponseObject'].return_value = 'testS3Response'
         mockUtils['generate_presigned_url'].return_value = 'https://digital-research-books-beta.nypl.org/work/2263dbf4-51c2-4f6e-b9eb-e1def96b48d4?featured=9401263'
 
+        mockDB = mocker.MagicMock(session=mocker.MagicMock())
+        mockDBClient = mocker.patch('api.blueprints.drbS3.DBClient')
+        mockDBClient.return_value = mockDB
 
-        with testApp.test_request_context('/?key=manifests/met/10935.json'):
+        mockDB.fetchUser.return_value = mocker.MagicMock(
+            user='testUser', password='testPswd', salt='testSalt'
+        )
+
+        mockBase64 = mocker.patch('api.blueprints.drbS3.b64decode')
+        mockBase64.return_value = b'testUser:testPswd'
+
+        mockUtils['validatePassword'].return_value = True
+
+        with testApp.test_request_context('/?key=manifests/met/10935.json', headers={'Authorization': 'Basic testAuth'}):
             testAPIResponse = s3ObjectLinkFetch('drb-files-qa')
 
             assert testAPIResponse == 'testS3Response'
@@ -46,7 +60,20 @@ class TestS3Blueprint:
         mockUtils['formatResponseObject'].return_value = 'testS3Response'
         mockUtils['generate_presigned_url'].return_value = 'https://drb-files-qaFail.s3.amazonaws.com/manifests/met/10935.json?'
 
-        with testApp.test_request_context('/?key=manifests/met/10935.json'):
+        mockDB = mocker.MagicMock(session=mocker.MagicMock())
+        mockDBClient = mocker.patch('api.blueprints.drbS3.DBClient')
+        mockDBClient.return_value = mockDB
+
+        mockDB.fetchUser.return_value = mocker.MagicMock(
+            user='testUser', password='testPswd', salt='testSalt'
+        )
+
+        mockBase64 = mocker.patch('api.blueprints.drbS3.b64decode')
+        mockBase64.return_value = b'testUser:testPswd'
+
+        mockUtils['validatePassword'].return_value = True
+    
+        with testApp.test_request_context('/?key=manifests/met/10935.json', headers={'Authorization': 'Basic testAuth'}):
             testAPIResponse = s3ObjectLinkFetch('drb-files-qaFail')
 
             assert testAPIResponse == 'testS3Response'
@@ -54,3 +81,79 @@ class TestS3Blueprint:
             mockUtils['normalizeQueryParams'].assert_called_once_with(ImmutableMultiDict([('key', 'manifests/met/10935.json')]))
 
             mockUtils['formatResponseObject'].assert_called_once_with(404, 's3ObjectLinkFetch', {'Bucket/Key does not exist': 'https://drb-files-qaFail.s3.amazonaws.com/manifests/met/10935.json?'})
+
+    def test_validateToken_success(self, testApp, mockUtils, mocker):
+        mockFunc = mocker.MagicMock()
+
+        decoratedFunction = validateToken(mockFunc)
+
+        mockDB = mocker.MagicMock(session=mocker.MagicMock())
+        mockDBClient = mocker.patch('api.blueprints.drbS3.DBClient')
+        mockDBClient.return_value = mockDB
+
+        mockDB.fetchUser.return_value = mocker.MagicMock(
+            user='testUser', password='testPswd', salt='testSalt'
+        )
+
+        mockBase64 = mocker.patch('api.blueprints.drbS3.b64decode')
+        mockBase64.return_value = b'testUser:testPswd'
+
+        mockUtils['validatePassword'].return_value = True
+
+        with testApp.test_request_context(
+            '/', headers={'Authorization': 'Basic testAuth'}
+        ):
+            decoratedFunction()
+
+            mockBase64.assert_called_once_with(b'testAuth')
+
+            mockFunc.assert_called_once_with(user='testUser')
+
+    def test_validateToken_error_no_header(self, testApp, mockUtils, mocker):
+        mockFunc = mocker.MagicMock()
+
+        decoratedFunction = validateToken(mockFunc)
+
+        mockUtils['formatResponseObject'].return_value = 'testError'
+
+        with testApp.test_request_context('/'):
+            testResponse = decoratedFunction()
+
+            assert testResponse == 'testError'
+
+            mockUtils['formatResponseObject'].assert_called_once_with(
+                403, 'authResponse',
+                {'message': 'user/password not provided'}
+            )
+
+    def test_validateToken_error_auth(self, testApp, mockUtils, mocker):
+        mockFunc = mocker.MagicMock()
+
+        decoratedFunction = validateToken(mockFunc)
+
+        mockDB = mocker.MagicMock(session=mocker.MagicMock())
+        mockDBClient = mocker.patch('api.blueprints.drbS3.DBClient')
+        mockDBClient.return_value = mockDB
+
+        mockDB.fetchUser.return_value = mocker.MagicMock(
+            user='testUser', password='testPswd', salt='testSalt'
+        )
+
+        mockBase64 = mocker.patch('api.blueprints.drbS3.b64decode')
+        mockBase64.return_value = b'testUser:testPswd'
+
+        mockUtils['validatePassword'].return_value = False
+
+        mockUtils['formatResponseObject'].return_value = 'testError'
+
+        with testApp.test_request_context(
+            '/', headers={'Authorization': 'Basic testAuth'}
+        ):
+            testResponse = decoratedFunction()
+
+            assert testResponse == 'testError'
+
+            mockUtils['formatResponseObject'].assert_called_once_with(
+                401, 'authResponse',
+                {'message': 'invalid user/password'}
+            )


### PR DESCRIPTION
This branch adds a new API and endpoint for the AWS S3 objects in DRB. Right now, there's only endpoint and it returns a unique, presigned link to an S3 object with user authentication based on the psql database. I wonder if I should have the user and password be based on something else besides the database so any feedback on that point specifically would be appreciated.