### PR TITLE
SFR-1866_Bardo&HathiConfigUpdate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ New /fulfill endpoint with ability to check for NYPL login in Bearer authorizati
 - New APIUtils method to generate a presigned url for S3 actions
 ## Fixed
 - NYPL records not being added due to SQLAlchemy error
+- Bardo CCE API and Hathi DataFiles URL updated
 
 ## 2023-09-05 version -- v0.12.3
 ## Removed

--- a/config/production.yaml
+++ b/config/production.yaml
@@ -32,7 +32,7 @@ FILE_ROUTING_KEY: sfrS3Files
 
 # HATHITRUST CONFIGURATION
 # HATHI_API_KEY and HATHI_API_SECRET must be configured as secrets
-HATHI_DATAFILES: https://www.hathitrust.org/filebrowser/download/244651
+HATHI_DATAFILES: https://www.hathitrust.org/files/hathifiles/hathi_file_list.json
 HATHI_API_ROOT: https://babel.hathitrust.org/cgi/htd
 
 # OCLC CONFIGURATION
@@ -62,7 +62,7 @@ NYPL_API_CLIENT_TOKEN_URL: https://isso.nypl.org/oauth/token
 GITHUB_API_ROOT: https://api.github.com/graphql
 
 # Bardo CCE API URL
-BARDO_CCE_API: http://sfr-bardo-copyright-development.us-east-1.elasticbeanstalk.com/search
+BARDO_CCE_API: http://sfr-c-ecsal-14v3injrieoy5-258691445.us-east-1.elb.amazonaws.com/search/
 
 # Project MUSE MARC endpoint
 MUSE_MARC_URL: https://about.muse.jhu.edu/lib/metadata?format=marc&content=book&include=oa&filename=open_access_books&no_auth=1

--- a/config/qa.yaml
+++ b/config/qa.yaml
@@ -32,7 +32,7 @@ FILE_ROUTING_KEY: sfrS3Files
 
 # HATHITRUST CONFIGURATION
 # HATHI_API_KEY and HATHI_API_SECRET must be configured as secrets
-HATHI_DATAFILES: https://www.hathitrust.org/filebrowser/download/244651
+HATHI_DATAFILES: https://www.hathitrust.org/files/hathifiles/hathi_file_list.json
 HATHI_API_ROOT: https://babel.hathitrust.org/cgi/htd
 
 # OCLC CONFIGURATION
@@ -62,7 +62,7 @@ NYPL_API_CLIENT_TOKEN_URL: https://isso.nypl.org/oauth/token
 GITHUB_API_ROOT: https://api.github.com/graphql
 
 # Bardo CCE API URL
-BARDO_CCE_API: http://sfr-bardo-copyright-development.us-east-1.elasticbeanstalk.com/search
+BARDO_CCE_API: http://sfr-c-ecsal-14v3injrieoy5-258691445.us-east-1.elb.amazonaws.com/search/
 
 # Project MUSE MARC endpoint
 MUSE_MARC_URL: https://about.muse.jhu.edu/lib/metadata?format=marc&content=book&include=oa&filename=open_access_books&no_auth=1


### PR DESCRIPTION
This PR updates the Bardo CCE API and Hathi Data Files URLS in the production and qa config. The Bardo CCE API URL was outdated so local running of the NYPL Process was unsuccessful and worked soon after updating this url.