### PR TITLE
SFR-1877: rewrite URLs as fulfillment URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Added
 New /fulfill endpoint with ability to check for NYPL login in Bearer authorization header
 Fulfill endpoint returns pre-signed URLs for objects in private buckets when user is logged in
+JSON from all endpoints (search, OPDS search, etc) includes fulfill URL when object requires NYPL login
 
 ## unreleased version -- v0.12.4
 ## Added

--- a/api/blueprints/drbEdition.py
+++ b/api/blueprints/drbEdition.py
@@ -27,13 +27,13 @@ def editionFetch(editionID):
 
     filteredFormats = APIUtils.formatFilters(terms)
 
-    edition = dbClient.fetchSingleEdition(editionID) 
+    edition = dbClient.fetchSingleEdition(editionID)
     if edition:
         statusCode = 200
         records = dbClient.fetchRecordsByUUID(edition.dcdw_uuids)
 
         responseBody = APIUtils.formatEditionOutput(
-            edition, records=records, dbClient=dbClient, showAll=showAll, formats=filteredFormats, reader=readerVersion
+            edition, request=request, records=records, dbClient=dbClient, showAll=showAll, formats=filteredFormats, reader=readerVersion
         )
     else:
         statusCode = 404

--- a/api/blueprints/drbLink.py
+++ b/api/blueprints/drbLink.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, current_app
+from flask import Blueprint, current_app, request
 from ..db import DBClient
 from ..utils import APIUtils
 from logger import createLog
@@ -18,7 +18,7 @@ def linkFetch(linkID):
 
     if link:
         statusCode = 200
-        responseObject = APIUtils.formatLinkOutput(link)
+        responseObject = APIUtils.formatLinkOutput(link, request=request)
     else:
         statusCode = 404
         responseObject = {'message': 'Unable to locate link #{}'.format(linkID)}

--- a/api/blueprints/drbSearch.py
+++ b/api/blueprints/drbSearch.py
@@ -77,7 +77,7 @@ def standardQuery():
     dataBlock = {
         'totalWorks': searchResult.hits.total.value,
         'works': APIUtils.formatWorkOutput(
-            works, results, dbClient=dbClient, formats=filteredFormats, reader=readerVersion
+            works, results, request=request, dbClient=dbClient, formats=filteredFormats, reader=readerVersion
         ),
         'paging': paging,
         'facets': facets

--- a/api/blueprints/drbWork.py
+++ b/api/blueprints/drbWork.py
@@ -20,7 +20,7 @@ def workFetch(uuid):
     terms = {}
     for param in ['filter']:
         terms[param] = APIUtils.extractParamPairs(param, searchParams)
-    
+
     showAll = searchParams.get('showAll', ['true'])[0].lower() != 'false'
     readerVersion = searchParams.get('readerVersion', [None])[0]\
         or current_app.config['READER_VERSION']
@@ -30,8 +30,8 @@ def workFetch(uuid):
     work = dbClient.fetchSingleWork(uuid)
     if work:
         statusCode = 200
-        responseBody = APIUtils.formatWorkOutput(work, None, showAll=showAll, dbClient=dbClient, formats=filteredFormats, reader=readerVersion)
-        
+        responseBody = APIUtils.formatWorkOutput(work, None, showAll=showAll, request=request, dbClient=dbClient, formats=filteredFormats, reader=readerVersion)
+
     else:
         statusCode = 404
         responseBody = {

--- a/api/blueprints/drbWork.py
+++ b/api/blueprints/drbWork.py
@@ -30,7 +30,9 @@ def workFetch(uuid):
     work = dbClient.fetchSingleWork(uuid)
     if work:
         statusCode = 200
-        responseBody = APIUtils.formatWorkOutput(work, None, showAll=showAll, request=request, dbClient=dbClient, formats=filteredFormats, reader=readerVersion)
+        responseBody = APIUtils.formatWorkOutput(work, None, showAll=showAll,
+            request=request, dbClient=dbClient, formats=filteredFormats, reader=readerVersion
+        )
 
     else:
         statusCode = 404

--- a/api/utils.py
+++ b/api/utils.py
@@ -336,6 +336,9 @@ class APIUtils():
                     'flags': flags
                 })
 
+            # Replace item links with fulfillment links where necessary
+            itemDict['links'] = list(map(APIUtils.replacePrivateLinkUrl, itemDict['links']))
+
             itemDict['links'].sort(key=cls.sortByMediaType)
 
             itemDict['rights'] = [
@@ -445,6 +448,9 @@ class APIUtils():
         linkDict['work'] = dict(link.items[0].edition.work)
         linkDict['work']['editions'] = [linkEdition]
         linkDict['work']['editions'][0]['items'] = [linkItem]
+
+        # Amend link to include /fulfill link if appropriate
+        linkDict = APIUtils.replacePrivateLinkUrl(linkDict)
 
         return linkDict
 
@@ -570,3 +576,15 @@ class APIUtils():
             {'Bucket': bucketName,'Key': objectKey},
             timeValid
         )
+
+    @staticmethod
+    def replacePrivateLinkUrl(link):
+        """
+        Given a link object, return a link object with the url replaced if
+        the link has flags indicating it should be fulfilled via /fulfill
+        """
+        if link['flags'].get("edd") or not link['flags'].get("nypl_login"):
+            return link
+        else:
+            link['url'] = "<environment>/fulfill/" + str(link['link_id'])
+        return link

--- a/api/utils.py
+++ b/api/utils.py
@@ -239,16 +239,14 @@ class APIUtils():
         editionWorkAuthors = edition.work.authors
         editionInCollection = cls.checkEditionInCollection(None, edition, dbClient)
 
-            # Replace item links with fulfillment links where necessary
-
-        #edition['links'] = list(map(APIUtils.replacePrivateLinkUrl, edition['links'], repeat(request)))
-
         formattedEdition = cls.formatEdition(
             edition, editionWorkTitle, editionWorkAuthors, editionInCollection, records, formats, showAll=showAll, reader=reader
         )
 
-        for instance in formattedEdition['instances']:
+        if formattedEdition.get("instances"):
+            for instance in formattedEdition['instances']:
                 for item in instance['items']:
+                    # Map over item links and patch with pre-signed URL where necessary
                     item['links']= list(map(APIUtils.replacePrivateLinkUrl, item['links'], repeat(request)))
 
         return formattedEdition
@@ -559,7 +557,8 @@ class APIUtils():
     def getPresignedUrlFromObjectUrl(s3Client, url):
         """
         Given the URL of an S3 resource, generate a presigned Amazon S3 URL
-        that can be used to access that resource.
+        that can be used to access that resource. This function assumes S3
+        URLs in the "virtual hosted bucket" style, not deprecated path style.
 
         :param s3_client: A Boto3 Amazon S3 client
         :param url: The URL of the desired resource

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -1,5 +1,16 @@
 import os
+from flask import Request
 
+# Because many Blueprint tests rely on checking to see if specific arguments were
+# passed to output processing functions, and these output processing functions now
+# require a request object to determine the host, this class provides an object that
+# will compare "true" to any instantiated Flask request object, for contexts where a
+# valid request object must be passed in but none of its content or attributes matter.
+class AnyFlaskRequest:
+    def __eq__(self, __value: object) -> bool:
+        if isinstance(__value, Request):  # any Flask request will compare true
+            return True
+        return False
 
 class TestHelpers:
     ENV_VARS = {

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -1,16 +1,4 @@
 import os
-from flask import Request
-
-# Because many Blueprint tests rely on checking to see if specific arguments were
-# passed to output processing functions, and these output processing functions now
-# require a request object to determine the host, this class provides an object that
-# will compare "true" to any instantiated Flask request object, for contexts where a
-# valid request object must be passed in but none of its content or attributes matter.
-class AnyFlaskRequest:
-    def __eq__(self, __value: object) -> bool:
-        if isinstance(__value, Request):  # any Flask request will compare true
-            return True
-        return False
 
 class TestHelpers:
     ENV_VARS = {

--- a/tests/unit/test_api_edition_blueprint.py
+++ b/tests/unit/test_api_edition_blueprint.py
@@ -1,9 +1,8 @@
-from flask import Flask
+from flask import Flask, request
 import pytest
 
 from api.blueprints.drbEdition import editionFetch
 from api.utils import APIUtils
-from tests.helper import AnyFlaskRequest
 
 class TestEditionBlueprint:
     @pytest.fixture
@@ -15,7 +14,7 @@ class TestEditionBlueprint:
             formatResponseObject=mocker.DEFAULT,
             formatEditionOutput=mocker.DEFAULT
         )
-    
+
     @pytest.fixture
     def testApp(self):
         flaskApp = Flask('test')
@@ -28,7 +27,6 @@ class TestEditionBlueprint:
         mockDB = mocker.MagicMock()
         mockDBClient = mocker.patch('api.blueprints.drbEdition.DBClient')
         mockDBClient.return_value = mockDB
-        someFlaskRequest = AnyFlaskRequest()
 
         mockUtils['normalizeQueryParams'].return_value = {'showAll': ['true']}
 
@@ -50,7 +48,7 @@ class TestEditionBlueprint:
             mockUtils['normalizeQueryParams'].assert_called_once()
             mockUtils['formatEditionOutput'].assert_called_once_with(
                 mockEdition, records='testRecords', dbClient=mockDB, showAll=True, formats=[],
-                reader='test', request=someFlaskRequest
+                reader='test', request=request
             )
             mockUtils['formatResponseObject'].assert_called_once_with(
                 200, 'singleEdition', 'testEdition'
@@ -60,7 +58,6 @@ class TestEditionBlueprint:
         mockDB = mocker.MagicMock()
         mockDBClient = mocker.patch('api.blueprints.drbEdition.DBClient')
         mockDBClient.return_value = mockDB
-        someFlaskRequest = AnyFlaskRequest()
 
         queryParams = {'showAll': ['true']}
         mockUtils['normalizeQueryParams'].return_value = {'showAll': ['true']}
@@ -90,7 +87,7 @@ class TestEditionBlueprint:
             ])
             mockUtils['formatEditionOutput'].assert_called_once_with(
                 mockEdition, records='testRecords', showAll=True,
-                dbClient=mockDB,request=someFlaskRequest,
+                dbClient=mockDB,request=request,
                 formats=['application/html+edd', 'application/x.html+edd'], reader='test'
             )
             mockUtils['formatResponseObject'].assert_called_once_with(

--- a/tests/unit/test_api_edition_blueprint.py
+++ b/tests/unit/test_api_edition_blueprint.py
@@ -1,9 +1,9 @@
-from flask import Flask
+from flask import Flask, Request
 import pytest
 
 from api.blueprints.drbEdition import editionFetch
 from api.utils import APIUtils
-
+from tests.helper import AnyFlaskRequest
 
 class TestEditionBlueprint:
     @pytest.fixture
@@ -28,6 +28,7 @@ class TestEditionBlueprint:
         mockDB = mocker.MagicMock()
         mockDBClient = mocker.patch('api.blueprints.drbEdition.DBClient')
         mockDBClient.return_value = mockDB
+        someFlaskRequest = AnyFlaskRequest()
 
         mockUtils['normalizeQueryParams'].return_value = {'showAll': ['true']}
 
@@ -48,7 +49,8 @@ class TestEditionBlueprint:
 
             mockUtils['normalizeQueryParams'].assert_called_once()
             mockUtils['formatEditionOutput'].assert_called_once_with(
-                mockEdition, records='testRecords', dbClient=mockDB, showAll=True, formats=[], reader='test'
+                mockEdition, records='testRecords', dbClient=mockDB, showAll=True, formats=[],
+                reader='test', request=someFlaskRequest
             )
             mockUtils['formatResponseObject'].assert_called_once_with(
                 200, 'singleEdition', 'testEdition'
@@ -58,6 +60,7 @@ class TestEditionBlueprint:
         mockDB = mocker.MagicMock()
         mockDBClient = mocker.patch('api.blueprints.drbEdition.DBClient')
         mockDBClient.return_value = mockDB
+        someFlaskRequest = AnyFlaskRequest()
 
         queryParams = {'showAll': ['true']}
         mockUtils['normalizeQueryParams'].return_value = {'showAll': ['true']}
@@ -86,8 +89,9 @@ class TestEditionBlueprint:
                 mocker.call('filter', queryParams)
             ])
             mockUtils['formatEditionOutput'].assert_called_once_with(
-                mockEdition, records='testRecords', showAll=True, dbClient=mockDB, 
-                                    formats=['application/html+edd', 'application/x.html+edd'], reader='test'
+                mockEdition, records='testRecords', showAll=True,
+                dbClient=mockDB,request=someFlaskRequest,
+                formats=['application/html+edd', 'application/x.html+edd'], reader='test'
             )
             mockUtils['formatResponseObject'].assert_called_once_with(
                 200, 'singleEdition', 'testEdition'

--- a/tests/unit/test_api_edition_blueprint.py
+++ b/tests/unit/test_api_edition_blueprint.py
@@ -1,4 +1,4 @@
-from flask import Flask, Request
+from flask import Flask
 import pytest
 
 from api.blueprints.drbEdition import editionFetch

--- a/tests/unit/test_api_link_blueprint.py
+++ b/tests/unit/test_api_link_blueprint.py
@@ -1,9 +1,8 @@
-from flask import Flask
+from flask import Flask, request
 import pytest
 
 from api.blueprints.drbLink import linkFetch
 from api.utils import APIUtils
-from tests.helper import AnyFlaskRequest
 
 class TestLinkBlueprint:
     @pytest.fixture
@@ -25,7 +24,6 @@ class TestLinkBlueprint:
         mockDB = mocker.MagicMock()
         mockDBClient = mocker.patch('api.blueprints.drbLink.DBClient')
         mockDBClient.return_value = mockDB
-        someFlaskRequest = AnyFlaskRequest()
 
         mockDB.fetchSingleLink.return_value = 'dbLinkRecord'
 
@@ -38,7 +36,7 @@ class TestLinkBlueprint:
             assert testAPIResponse == 'singleLinkResponse'
             mockDBClient.assert_called_once_with('testDBClient')
 
-            mockUtils['formatLinkOutput'].assert_called_once_with('dbLinkRecord', request=someFlaskRequest)
+            mockUtils['formatLinkOutput'].assert_called_once_with('dbLinkRecord', request=request)
             mockUtils['formatResponseObject'].assert_called_once_with(
                 200, 'singleLink', 'testLink'
             )

--- a/tests/unit/test_api_link_blueprint.py
+++ b/tests/unit/test_api_link_blueprint.py
@@ -1,8 +1,9 @@
-from flask import Flask
+from flask import Flask, Request
 import pytest
 
 from api.blueprints.drbLink import linkFetch
 from api.utils import APIUtils
+from tests.helper import AnyFlaskRequest
 
 class TestLinkBlueprint:
     @pytest.fixture
@@ -24,6 +25,7 @@ class TestLinkBlueprint:
         mockDB = mocker.MagicMock()
         mockDBClient = mocker.patch('api.blueprints.drbLink.DBClient')
         mockDBClient.return_value = mockDB
+        someFlaskRequest = AnyFlaskRequest()
 
         mockDB.fetchSingleLink.return_value = 'dbLinkRecord'
 
@@ -36,7 +38,7 @@ class TestLinkBlueprint:
             assert testAPIResponse == 'singleLinkResponse'
             mockDBClient.assert_called_once_with('testDBClient')
 
-            mockUtils['formatLinkOutput'].assert_called_once_with('dbLinkRecord')
+            mockUtils['formatLinkOutput'].assert_called_once_with('dbLinkRecord', request=someFlaskRequest)
             mockUtils['formatResponseObject'].assert_called_once_with(
                 200, 'singleLink', 'testLink'
             )

--- a/tests/unit/test_api_link_blueprint.py
+++ b/tests/unit/test_api_link_blueprint.py
@@ -1,4 +1,4 @@
-from flask import Flask, Request
+from flask import Flask
 import pytest
 
 from api.blueprints.drbLink import linkFetch

--- a/tests/unit/test_api_search_blueprint.py
+++ b/tests/unit/test_api_search_blueprint.py
@@ -1,10 +1,9 @@
-from flask import Flask
+from flask import Flask, request
 import pytest
 
 from api.blueprints.drbSearch import standardQuery
 from api.utils import APIUtils
 from api.elastic import ElasticClientError
-from tests.helper import AnyFlaskRequest
 
 class TestSearchBlueprint:
     @pytest.fixture
@@ -100,8 +99,6 @@ class TestSearchBlueprint:
 
         mockUtils['formatResponseObject'].return_value = 'mockAPIResponse'
 
-        someFlaskRequest = AnyFlaskRequest()
-
         with testApp.test_request_context('/?testing=true'):
             testAPIResponse = standardQuery()
 
@@ -142,7 +139,7 @@ class TestSearchBlueprint:
                 dbClient=mockDB,
                 formats=['text/html'],
                 reader='test',
-                request=someFlaskRequest
+                request=request
             )
 
             mockUtils['formatResponseObject'].assert_called_once_with(

--- a/tests/unit/test_api_search_blueprint.py
+++ b/tests/unit/test_api_search_blueprint.py
@@ -4,7 +4,7 @@ import pytest
 from api.blueprints.drbSearch import standardQuery
 from api.utils import APIUtils
 from api.elastic import ElasticClientError
-
+from tests.helper import AnyFlaskRequest
 
 class TestSearchBlueprint:
     @pytest.fixture
@@ -100,6 +100,8 @@ class TestSearchBlueprint:
 
         mockUtils['formatResponseObject'].return_value = 'mockAPIResponse'
 
+        someFlaskRequest = AnyFlaskRequest()
+
         with testApp.test_request_context('/?testing=true'):
             testAPIResponse = standardQuery()
 
@@ -139,7 +141,8 @@ class TestSearchBlueprint:
                 testResultIds,
                 dbClient=mockDB,
                 formats=['text/html'],
-                reader='test'
+                reader='test',
+                request=someFlaskRequest
             )
 
             mockUtils['formatResponseObject'].assert_called_once_with(

--- a/tests/unit/test_api_work_blueprint.py
+++ b/tests/unit/test_api_work_blueprint.py
@@ -3,6 +3,7 @@ import pytest
 
 from api.blueprints.drbWork import workFetch
 from api.utils import APIUtils
+from tests.helper import AnyFlaskRequest
 
 
 class TestWorkBlueprint:
@@ -36,6 +37,8 @@ class TestWorkBlueprint:
         mockUtils['formatWorkOutput'].return_value = 'testWork'
         mockUtils['formatResponseObject'].return_value = 'singleWorkResponse'
 
+        someFlaskRequest = AnyFlaskRequest()
+
         with testApp.test_request_context('/?showAll=true'):
             testAPIResponse = workFetch('testUUID')
 
@@ -44,7 +47,8 @@ class TestWorkBlueprint:
 
             mockUtils['normalizeQueryParams'].assert_called_once
             mockUtils['formatWorkOutput'].assert_called_once_with(
-                'dbWorkRecord', None, showAll=True, dbClient=mockDB, formats=[], reader='test'
+                'dbWorkRecord', None, showAll=True, dbClient=mockDB, formats=[],
+                reader='test', request=someFlaskRequest
             )
             mockUtils['formatResponseObject'].assert_called_once_with(
                 200, 'singleWork', 'testWork'
@@ -67,6 +71,8 @@ class TestWorkBlueprint:
         mockUtils['formatWorkOutput'].return_value = 'testWork'
         mockUtils['formatResponseObject'].return_value = 'singleWorkResponse'
 
+        someFlaskRequest = AnyFlaskRequest()
+
         with testApp.test_request_context('/?showAll=true'):
             testAPIResponse = workFetch('testUUID')
 
@@ -78,7 +84,8 @@ class TestWorkBlueprint:
                 mocker.call('filter', queryParams)
             ])
             mockUtils['formatWorkOutput'].assert_called_once_with(
-                'dbWorkRecord', None, showAll=True, dbClient=mockDB, formats=['application/html+edd', 'application/x.html+edd'], reader='test'
+                'dbWorkRecord', None, showAll=True, dbClient=mockDB, formats=['application/html+edd',
+                'application/x.html+edd'], reader='test', request=someFlaskRequest
             )
             mockUtils['formatResponseObject'].assert_called_once_with(
                 200, 'singleWork', 'testWork'
@@ -96,6 +103,8 @@ class TestWorkBlueprint:
         mockUtils['formatWorkOutput'].return_value = 'testWork'
         mockUtils['formatResponseObject'].return_value = 'singleWorkResponse'
 
+        someFlaskRequest = AnyFlaskRequest()
+
         with testApp.test_request_context('/?showAll=false'):
             testAPIResponse = workFetch('testUUID')
 
@@ -104,7 +113,8 @@ class TestWorkBlueprint:
 
             mockUtils['normalizeQueryParams'].assert_called_once
             mockUtils['formatWorkOutput'].assert_called_once_with(
-                'dbWorkRecord', None, showAll=False, dbClient=mockDB, formats=[], reader='test'
+                'dbWorkRecord', None, showAll=False, dbClient=mockDB, formats=[], reader='test',
+                request=someFlaskRequest
             )
             mockUtils['formatResponseObject'].assert_called_once_with(
                 200, 'singleWork', 'testWork'

--- a/tests/unit/test_api_work_blueprint.py
+++ b/tests/unit/test_api_work_blueprint.py
@@ -1,9 +1,8 @@
-from flask import Flask
+from flask import Flask, request
 import pytest
 
 from api.blueprints.drbWork import workFetch
 from api.utils import APIUtils
-from tests.helper import AnyFlaskRequest
 
 
 class TestWorkBlueprint:
@@ -37,8 +36,6 @@ class TestWorkBlueprint:
         mockUtils['formatWorkOutput'].return_value = 'testWork'
         mockUtils['formatResponseObject'].return_value = 'singleWorkResponse'
 
-        someFlaskRequest = AnyFlaskRequest()
-
         with testApp.test_request_context('/?showAll=true'):
             testAPIResponse = workFetch('testUUID')
 
@@ -48,7 +45,7 @@ class TestWorkBlueprint:
             mockUtils['normalizeQueryParams'].assert_called_once
             mockUtils['formatWorkOutput'].assert_called_once_with(
                 'dbWorkRecord', None, showAll=True, dbClient=mockDB, formats=[],
-                reader='test', request=someFlaskRequest
+                reader='test', request=request
             )
             mockUtils['formatResponseObject'].assert_called_once_with(
                 200, 'singleWork', 'testWork'
@@ -71,8 +68,6 @@ class TestWorkBlueprint:
         mockUtils['formatWorkOutput'].return_value = 'testWork'
         mockUtils['formatResponseObject'].return_value = 'singleWorkResponse'
 
-        someFlaskRequest = AnyFlaskRequest()
-
         with testApp.test_request_context('/?showAll=true'):
             testAPIResponse = workFetch('testUUID')
 
@@ -85,7 +80,7 @@ class TestWorkBlueprint:
             ])
             mockUtils['formatWorkOutput'].assert_called_once_with(
                 'dbWorkRecord', None, showAll=True, dbClient=mockDB, formats=['application/html+edd',
-                'application/x.html+edd'], reader='test', request=someFlaskRequest
+                'application/x.html+edd'], reader='test', request=request
             )
             mockUtils['formatResponseObject'].assert_called_once_with(
                 200, 'singleWork', 'testWork'
@@ -103,8 +98,6 @@ class TestWorkBlueprint:
         mockUtils['formatWorkOutput'].return_value = 'testWork'
         mockUtils['formatResponseObject'].return_value = 'singleWorkResponse'
 
-        someFlaskRequest = AnyFlaskRequest()
-
         with testApp.test_request_context('/?showAll=false'):
             testAPIResponse = workFetch('testUUID')
 
@@ -114,7 +107,7 @@ class TestWorkBlueprint:
             mockUtils['normalizeQueryParams'].assert_called_once
             mockUtils['formatWorkOutput'].assert_called_once_with(
                 'dbWorkRecord', None, showAll=False, dbClient=mockDB, formats=[], reader='test',
-                request=someFlaskRequest
+                request=request
             )
             mockUtils['formatResponseObject'].assert_called_once_with(
                 200, 'singleWork', 'testWork'


### PR DESCRIPTION
## Description
This pull request rewrites the URLs of links for objects that are not EDD links and also nypl_login required. This should cover items within the scope of Limited Access. 

Other options (like rewriting the links in the database and referring to a third, new column of S3 urls) were considered, but none of them seemed like they would work without heavily rewriting some of the code related to FRBRized output.

As it stands, almost all of the work is done at the "Format..." level for each hierarchy where links are part of the JSON formatted output. While this makes the change fairly superficial and it must be implemented in many places, it is hopefully transparent enough that this link overwriting can be easily found and modified and/or removed later if needed.

## Motivation and Context
The link URLs in the database represent private s3 URLs. If the s3 URLs are sent as part of the JSON, there won't be any way for users (or the front end) to retrieve the contents of the URLs. The fulfill endpoint already contains the logic needed to generate a fulfill URL that points to the private item bucket via a time-gated URL that requires user authentication; however, the private URLs to s3 must be rewritten with these fulfillment URLs before the API output is returned.