### PR TITLE
HOTFIX_SourcePriorityUofM

### DIFF
--- a/api/utils.py
+++ b/api/utils.py
@@ -40,10 +40,11 @@ class APIUtils():
         'muse': 4,
         'met': 5,
         'isac': 6,
-        'UofSC': 7,
-        'hathitrust': 8,
-        'oclc': 9,
-        'nypl': 10
+        'UofM': 7,
+        'UofSC': 8,
+        'hathitrust': 9,
+        'oclc': 10,
+        'nypl': 11
     }
 
     @staticmethod


### PR DESCRIPTION
This hotfix focuses on updating the source priority to include University of Michigan because a KeyError occurred when trying to search up a UofM book on the QA site.