### PR TITLE
SFR-1891_DeleteUMPManifestLinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Change default development port to 5050 due to macOS Monterey and higher occupying port 5000 by default
 - Added new University of Michigan process and mapping for ingestion
 - New directory for test JSON files that will be ingested
+- New script to delete UMP Manifest links from links table
 ## Fixed
 - NYPL records not being added due to SQLAlchemy error
 - Bardo CCE API and Hathi DataFiles URL updated

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -13,3 +13,4 @@ from .ingestS3Metadata import main as ingestS3
 from .updatePubLocationAndLinks import main as updateLocationAndLinks
 from .countCABooks import main as countCA
 from .nyplLoginFlags import main as nyplFlags
+from .deleteUMPManifestLinks import main as deleteUMPManifests

--- a/scripts/deleteUMPManifestLinks.py
+++ b/scripts/deleteUMPManifestLinks.py
@@ -1,0 +1,35 @@
+import os
+
+from model import Link, Item
+from model.postgres.item import ITEM_LINKS
+from managers import DBManager
+
+def main():
+    
+    '''Deleting UMP Manifest Links from links table'''
+
+    dbManager = DBManager(
+        user= os.environ.get('POSTGRES_USER', None),
+        pswd= os.environ.get('POSTGRES_PSWD', None),
+        host= os.environ.get('POSTGRES_HOST', None),
+        port= os.environ.get('POSTGRES_PORT', None),
+        db= os.environ.get('POSTGRES_NAME', None)
+    )
+
+    dbManager.generateEngine()
+
+    dbManager.createSession()
+
+
+    for item in dbManager.session.query(Item) \
+        .filter(Item.source == 'UofM'):
+        for link in dbManager.session.query(Link) \
+            .join(ITEM_LINKS) \
+            .filter(ITEM_LINKS.c.item_id == item.id) \
+            .filter(Link.media_type == 'application/webpub+json'):   
+                dbManager.session.delete(link)
+
+    dbManager.commitChanges()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This PR adds a new script to delete UMP manifest links from the links table that should not have been created at this time. One question is if the UofM manifest directory in the S3 manifest bucket should be deleted as well?