### PR TITLE
HOTFIX_FixFormatFilter500Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Bardo CCE API and Hathi DataFiles URL updated
 - Deleted Tugboat configuration as Tugboat is no longer used and no longer builds
 - Adjusted sorting for item source and media type priority
-- Removed item media type priority to fix 500 error with search endpoint for filtering by format
+- Removed item media type sorting to fix 500 error with search endpoint for filtering by format
 
 ## 2023-09-05 version -- v0.12.3
 ## Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Bardo CCE API and Hathi DataFiles URL updated
 - Deleted Tugboat configuration as Tugboat is no longer used and no longer builds
 - Adjusted sorting for item source and media type priority
-- Removed item media type sorting to fix 500 error with search endpoint for filtering by format
+- Fixed 500 error with search endpoint for filtering by format by adjusting item sorting
 
 ## 2023-09-05 version -- v0.12.3
 ## Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Bardo CCE API and Hathi DataFiles URL updated
 - Deleted Tugboat configuration as Tugboat is no longer used and no longer builds
 - Adjusted sorting for item source and media type priority
+- Removed item media type priority to fix 500 error with search endpoint for filtering by format
 
 ## 2023-09-05 version -- v0.12.3
 ## Removed

--- a/api/utils.py
+++ b/api/utils.py
@@ -366,7 +366,7 @@ class APIUtils():
             editionDict['items'].append(itemDict)
 
         editionDict['items']\
-            .sort(key=lambda x: (cls.SOURCE_PRIORITY[x['source']], cls.sortByMediaType(x['links'][0])))
+            .sort(key=lambda x: (cls.SOURCE_PRIORITY[x['source']]))
 
         if records is not None:
             itemsByLink = {}

--- a/api/utils.py
+++ b/api/utils.py
@@ -365,9 +365,22 @@ class APIUtils():
 
             editionDict['items'].append(itemDict)
 
-        editionDict['items']\
-            .sort(key=lambda x: (cls.SOURCE_PRIORITY[x['source']]))
+        emptyListFlag = False
+        
+        #This for loop is meant to check if a empty links array exists in a item dictionary
+            #If one exists, then sorting by source priority and empty/non-empty priority occurs
+            #Otherwise, sorting by source and link media type occurs
+        for itemDict in editionDict['items']:
+            if itemDict['links'] == []:
+                editionDict['items']\
+                    .sort(key=lambda x: (cls.SOURCE_PRIORITY[x['source']], x['links'] == []))
+                emptyListFlag = True
+                break
 
+        if emptyListFlag == False:
+            editionDict['items']\
+                .sort(key=lambda x: (cls.SOURCE_PRIORITY[x['source']], cls.sortByMediaType(x['links'][0])))
+            
         if records is not None:
             itemsByLink = {}
             for item in editionDict['items']:
@@ -400,8 +413,8 @@ class APIUtils():
             'application/html+catalog': 6
         }
 
-        return scores.get(link['mediaType'], 7)
-
+        return scores.get(link['mediaType'], 7)   
+     
     @classmethod
     def formatRecord(cls, record, itemsByLink):
         outRecord = {

--- a/tests/unit/test_api_utils.py
+++ b/tests/unit/test_api_utils.py
@@ -129,7 +129,7 @@ class TestAPIUtils:
             physical_location={'name': 'test'},
             source='hathitrust'
         )
-
+    
     @pytest.fixture
     def testWebpubItem(self, MockDBObject, testWebpubLink):
         return MockDBObject(
@@ -145,6 +145,16 @@ class TestAPIUtils:
         return MockDBObject(
             id='it3',
             links=[testPDFLink],
+            rights=[],
+            physical_location={},
+            source='gutenberg'
+        )
+    
+    @pytest.fixture
+    def testEmptyItem(self, MockDBObject):
+        return MockDBObject(
+            id='it4',
+            links=[],
             rights=[],
             physical_location={},
             source='gutenberg'
@@ -510,6 +520,38 @@ class TestAPIUtils:
         assert formattedEdition['items'][1]['links'][0]['mediaType'] ==\
             'application/epub+xml'
 
+    def test_formatEdition_v2_reader_flag(self, testEdition, testWebpubItem, testPDFItem):
+        testEdition.items.append(testPDFItem)
+        testEdition.items.append(testWebpubItem)
+
+
+        formattedEdition = APIUtils.formatEdition(testEdition, reader='v2')
+
+        assert len(formattedEdition['items']) == 3
+        assert formattedEdition['items'][0]['item_id'] == 'it2'
+        assert formattedEdition['items'][0]['links'][0]['mediaType'] ==\
+            'application/webpub+json'
+        assert formattedEdition['items'][1]['links'][0]['mediaType'] ==\
+            'application/pdf'
+        assert formattedEdition['items'][2]['links'][0]['flags']['reader'] is\
+            False
+        
+    def test_formatEdition_v2_reader_flag_2(self, testEdition, testWebpubItem, testPDFItem, testEmptyItem):
+        testEdition.items.append(testEmptyItem)
+        testEdition.items.append(testWebpubItem)
+
+
+        formattedEdition = APIUtils.formatEdition(testEdition, reader='v2')
+
+        assert len(formattedEdition['items']) == 3
+        assert formattedEdition['items'][0]['item_id'] == 'it2'
+        assert formattedEdition['items'][0]['links'][0]['mediaType'] ==\
+            'application/webpub+json'
+        assert formattedEdition['items'][1]['links'] ==\
+            []
+        assert formattedEdition['items'][2]['links'][0]['flags']['reader'] is\
+            False
+    
     def test_formatRecord(self, testRecord, mocker):
         testLinkItems = {
             'url1': {'item_id': 1, 'url': 'url1'},

--- a/tests/unit/test_api_utils.py
+++ b/tests/unit/test_api_utils.py
@@ -510,21 +510,6 @@ class TestAPIUtils:
         assert formattedEdition['items'][1]['links'][0]['mediaType'] ==\
             'application/epub+xml'
 
-    def test_formatEdition_v2_reader_flag(self, testEdition, testWebpubItem, testPDFItem):
-        testEdition.items.append(testPDFItem)
-        testEdition.items.append(testWebpubItem)
-
-        formattedEdition = APIUtils.formatEdition(testEdition, reader='v2')
-
-        assert len(formattedEdition['items']) == 3
-        assert formattedEdition['items'][0]['item_id'] == 'it2'
-        assert formattedEdition['items'][0]['links'][0]['mediaType'] ==\
-            'application/webpub+json'
-        assert formattedEdition['items'][1]['links'][0]['mediaType'] ==\
-            'application/pdf'
-        assert formattedEdition['items'][2]['links'][0]['flags']['reader'] is\
-            False
-
     def test_formatRecord(self, testRecord, mocker):
         testLinkItems = {
             'url1': {'item_id': 1, 'url': 'url1'},


### PR DESCRIPTION
This hotfix intends to fix the 500 error that started to occur in the DRB API after using the search endpoint and using the format filter. The error came in after adding the items media type sorting code line which led to a index error due to some items having an empty link list. Removing this line might revert some changes to the frontend with item sorting but the links are properly sorted now due to the change to the sortByMediaType method in APIUtils from a previous hotfix change [https://github.com/NYPL/drb-etl-pipeline/pull/294](url)