### PR TITLE
SFR-1966_FulfillURLUofM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## unreleased version -- v0.13.1
 ## Added
 - New script to parse download requests from S3 log files for UMP books 
-- New script to update current UofM manifests with fulfill endpoints
+- New script to update current UofM manifests with fulfill urls to replace pdf/epub urls
 ## Fixed
 
 ## 2024-03-21 -- v0.13.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## unreleased version -- v0.13.1
 ## Added
 - New script to parse download requests from S3 log files for UMP books 
-- New script to update all UofM manifests with fulfill endpoints
+- New script to update current UofM manifests with fulfill endpoints
 ## Fixed
 
 ## 2024-03-21 -- v0.13.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## unreleased version -- v0.13.1
 ## Added
 - New script to parse download requests from S3 log files for UMP books 
-- New script to update current UofM manifests with fulfill urls to replace pdf/epub urls
+- New script to update current UofM manifests with fulfill endpoints to replace pdf/epub urls
 ## Fixed
 
 ## 2024-03-21 -- v0.13.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased version -- v0.13.1
 ## Added
 - New script to parse download requests from S3 log files for UMP books 
+- New script to update all UofM manifests with fulfill endpoints
 ## Fixed
 
 ## 2024-03-21 -- v0.13.0

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -15,3 +15,4 @@ from .countCABooks import main as countCA
 from .nyplLoginFlags import main as nyplFlags
 from .deleteUMPManifestLinks import main as deleteUMPManifests
 from .parseDownloadRequests import main as parseDownloads
+from .fulfillURLManifest import main as fulfillManifest

--- a/scripts/fulfillURLManifest.py
+++ b/scripts/fulfillURLManifest.py
@@ -1,0 +1,110 @@
+import boto3
+import json
+import os
+import logging
+from botocore.exceptions import ClientError
+from model import Link
+from managers import DBManager, s3
+
+s3_client = boto3.client("s3")
+
+bucketName = 'drb-files-qa'
+
+# class fulfillURLManifest():
+
+#     def __init__(self):
+
+#         # Connect to database
+#         self.generateEngine()
+#         self.createSession()
+
+#         # S3 Configuration
+#         self.s3Bucket = bucketName
+#         self.createS3Client()
+
+def main():
+
+    '''Replacing pdf/epub links in with fulfill urls in manifest JSON files'''
+
+    batches = load_batch()
+    for batch in batches:
+        for c in batch['Contents']:
+            currKey = c['Key']
+            metadataObject = s3_client.get_object(Bucket= bucketName, Key= f'{currKey}')
+            update_batch(metadataObject, bucketName, currKey)
+    
+
+def update_batch(metadataObject, bucketName, currKey):
+
+    dbManager = DBManager(
+        user=os.environ.get('POSTGRES_USER', None),
+        pswd=os.environ.get('POSTGRES_PSWD', None),
+        host=os.environ.get('POSTGRES_HOST', None),
+        port=os.environ.get('POSTGRES_PORT', None),
+        db=os.environ.get('POSTGRES_NAME', None)
+    )
+
+    dbManager.generateEngine()
+
+    dbManager.createSession()
+
+    metadataJSON = json.loads(metadataObject['Body'].read().decode("utf-8"))
+    
+    metadataJSON = linkFulfill(metadataJSON, dbManager)
+    metadataJSON = readingOrderFulfill(metadataJSON, dbManager)
+    metadataJSON = resourceFulfill(metadataJSON, dbManager)
+    metadataJSON = tocFulfill(metadataJSON, dbManager)
+
+    fulfillManifest = json.dumps(metadataJSON, ensure_ascii = False, indent = 6)
+
+    try:
+        return s3_client.put_object(Bucket=bucketName, Key='manifests/UofM/0472030132.json', \
+                            Body=fulfillManifest, ACL= 'public-read', \
+                            ContentType = 'application/json'
+            )
+    except ClientError as e:
+        logging.error(e)
+
+def linkFulfill(metadataJSON, dbManager):
+    for i in metadataJSON['links']:
+        if i['type'] == 'application/pdf' or i['type'] == 'application/epub+zip' \
+            or i['type'] == 'application/epub+xml':
+                for link in dbManager.session.query(Link) \
+                    .filter(Link.url == i['href'].replace('https://', '')):
+                        i['href'] = f'http://127.0.0.1:5050/fulfill/{link.id}'
+                        return metadataJSON
+                
+def readingOrderFulfill(metadataJSON, dbManager):
+    for i in metadataJSON['readingOrder']:
+        if i['type'] == 'application/pdf' or i['type'] == 'application/epub+zip' \
+            or i['type'] == 'application/epub+xml':
+                for link in dbManager.session.query(Link) \
+                    .filter(Link.url == i['href'].replace('https://', '')):
+                        i['href'] = f'http://127.0.0.1:5050/fulfill/{link.id}'
+                        return metadataJSON
+
+def resourceFulfill(metadataJSON, dbManager):
+    for i in metadataJSON['resources']:
+        if i['type'] == 'application/pdf' or i['type'] == 'application/epub+zip' \
+            or i['type'] == 'application/epub+xml':
+                for link in dbManager.session.query(Link) \
+                    .filter(Link.url == i['href'].replace('https://', '')):
+                        i['href'] = f'http://127.0.0.1:5050/fulfill/{link.id}'
+                        return metadataJSON
+
+def tocFulfill(metadataJSON, dbManager): 
+    for i in metadataJSON['toc']:
+        if 'pdf' in i['href'] \
+            or 'epub' in i['href']:
+                for link in dbManager.session.query(Link) \
+                    .filter(Link.url == i['href'].replace('https://', '')):
+                        i['href'] = f'http://127.0.0.1:5050/fulfill/{link.id}'
+                        return metadataJSON
+
+def load_batch():
+
+    '''# Loading batches of JSON records using a paginator until there are no more batches'''
+
+    paginator = s3_client.get_paginator('list_objects_v2')
+    page_iterator = paginator.paginate(Bucket= bucketName, Prefix= 'manifests/UofM/')
+    return page_iterator

--- a/scripts/fulfillURLManifest.py
+++ b/scripts/fulfillURLManifest.py
@@ -58,7 +58,7 @@ def update_batch(metadataObject, bucketName, currKey):
     fulfillManifest = json.dumps(metadataJSON, ensure_ascii = False, indent = 6)
 
     try:
-        return s3_client.put_object(Bucket=bucketName, Key='manifests/UofM/0472030132.json', \
+        return s3_client.put_object(Bucket=bucketName, Key=currKey, \
                             Body=fulfillManifest, ACL= 'public-read', \
                             ContentType = 'application/json'
             )


### PR DESCRIPTION
This PR focuses on updating the UofM manifests with fulfill endpoints to replace the pdf and epub links within the manifest JSON file. All the UofM files will be affected for now even though a few are now Public Domain since reverting this change can be done at a later time once this ticket is resolved. Also, the commented out class definition at the top of the script has to do with one question I have. The question is if the S3Manger method, `putObjectInBucket`, should be utilized instead of the regular `s3_client.put_object` method since the S3Manger method is used when we currently put manifests in a S3 bucket like in the UofM process.