### PR TITLE
SFR-1967_FulfillFutureLAManifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - New script to parse download requests from S3 log files for UMP books 
 - New script to update current UofM manifests with fulfill endpoints to replace pdf/epub urls
 - Updated README with appendix and additions to avaliable processes
-- New process to add fulfill endpoints to Limited Access manifests after the ClusterProcess has finished running
+- New process to add fulfill urls to Limited Access manifests and update fulfill_limited_access flags to True
 ## Fixed
 
 ## 2024-03-21 -- v0.13.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - New script to parse download requests from S3 log files for UMP books 
 - New script to update current UofM manifests with fulfill endpoints to replace pdf/epub urls
 - Updated README with appendix and additions to avaliable processes
+- New process to add fulfill endpoints to Limited Access manifests after the ClusterProcess has run
 ## Fixed
 
 ## 2024-03-21 -- v0.13.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## Added
 - New script to parse download requests from S3 log files for UMP books 
 - New script to update current UofM manifests with fulfill endpoints to replace pdf/epub urls
+- Updated README with appendix and additions to avaliable processes
 ## Fixed
 
 ## 2024-03-21 -- v0.13.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - New script to parse download requests from S3 log files for UMP books 
 - New script to update current UofM manifests with fulfill endpoints to replace pdf/epub urls
 - Updated README with appendix and additions to avaliable processes
-- New process to add fulfill endpoints to Limited Access manifests after the ClusterProcess has run
+- New process to add fulfill endpoints to Limited Access manifests after the ClusterProcess has finished running
 ## Fixed
 
 ## 2024-03-21 -- v0.13.0

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The docker compose file uses the sample-compose.yaml file in the `config` direct
 
 To run the processes individually the command should be in this format: `python main.py --process APIProcess`.
 
-The currently available processes are:
+The currently available processes (with the exception of the UofSC and ChicagoISAC processes) are:
 
 - `DevelopmentSetupProcess` Initialize a testing/development database
 - `APIProcess` run the DRB API
@@ -90,8 +90,19 @@ The currently available processes are:
 - `NYPLProcess` Fetch files from the NYPL catalog (specifically Bib records) and import them
 - `GutenbergProcess` Fetch updated files from Project Gutenberg and import them
 - `MUSEProcess` Fetch open access books from Project MUSE and import them
-- `DOABProcess` Fetch open access books from the Directory of Open Access Books
+- `METProcess` Fetch open access books from The MET Watson Digital Collections and import them
+- `DOABProcess` Fetch open access books from the Directory of Open Access Books and import them
+- `LOCProcess` Fetch open access and digitized books from the Library of Congress and import them
+- `UofMProcess` Fetch open access books from the Univerity of Michigan and import them
 - `CoverProcess` Fetch covers for edition records
+
+#### Appendix Link Flags (All flags are booleans)
+- `reader` Added to 'application/webpub+json' links to indicate if a book will have a Read Online function on the frontend
+- `embed` Indicates if a book will be using a third party web reader like Hathitrust's web reader on the frontend
+- `download` Added to pdf/epub links to indicate if a book is downloadable on the frontend
+- `catalog` Indicates if a book is a part of a catalog which may not be readable online, but can be accessed with other means like requesting online 
+- `nypl_login` Indicates if a book is a requestable book on the frontend for NYPL patrons
+- `fulfill_limited_access` Indicates if a Limited Access book has been encrypted and can be read by NYPL patrons
 
 #### Building and running a process in Docker
 

--- a/config/production.yaml
+++ b/config/production.yaml
@@ -57,6 +57,10 @@ NYPL_LOCATIONS_BY_CODE: https://nypl-core-objects-mapping-qa.s3.amazonaws.com/by
 # API_CLIENT_ID and API_CLIENT_SECRET must be configured in secrets file
 NYPL_API_CLIENT_TOKEN_URL: https://isso.nypl.org/oauth/token
 
+# DRB API Credentials
+DRB_API_HOST: '0.0.0.0'
+DRB_API_PORT: '80'
+
 # GITHUB API Credentials
 # GITHUB_API_KEY must be configured in secrets file
 GITHUB_API_ROOT: https://api.github.com/graphql

--- a/config/production.yaml
+++ b/config/production.yaml
@@ -58,7 +58,7 @@ NYPL_LOCATIONS_BY_CODE: https://nypl-core-objects-mapping-qa.s3.amazonaws.com/by
 NYPL_API_CLIENT_TOKEN_URL: https://isso.nypl.org/oauth/token
 
 # DRB API Credentials
-DRB_API_HOST: '0.0.0.0'
+DRB_API_HOST: 'digital-research-books-beta.nypl.org'
 DRB_API_PORT: '80'
 
 # GITHUB API Credentials

--- a/config/qa.yaml
+++ b/config/qa.yaml
@@ -58,7 +58,7 @@ NYPL_LOCATIONS_BY_CODE: https://nypl-core-objects-mapping-qa.s3.amazonaws.com/by
 NYPL_API_CLIENT_TOKEN_URL: https://isso.nypl.org/oauth/token
 
 # DRB API Credentials
-DRB_API_HOST: '0.0.0.0'
+DRB_API_HOST: 'drb-qa.nypl.org'
 DRB_API_PORT: '80'
 
 # GITHUB API Credentials

--- a/config/qa.yaml
+++ b/config/qa.yaml
@@ -57,6 +57,10 @@ NYPL_LOCATIONS_BY_CODE: https://nypl-core-objects-mapping-qa.s3.amazonaws.com/by
 # API_CLIENT_ID and API_CLIENT_SECRET must be configured in secrets file
 NYPL_API_CLIENT_TOKEN_URL: https://isso.nypl.org/oauth/token
 
+# DRB API Credentials
+DRB_API_HOST: '0.0.0.0'
+DRB_API_PORT: '80'
+
 # GITHUB API Credentials
 # GITHUB_API_KEY must be configured in secrets file
 GITHUB_API_ROOT: https://api.github.com/graphql

--- a/config/sample-compose.yaml
+++ b/config/sample-compose.yaml
@@ -62,6 +62,11 @@ NYPL_API_CLIENT_PUBLIC_KEY: |
   EQIDAQAB
   -----END PUBLIC KEY-----
 
+  # DRB API Credentials
+  
+DRB_API_HOST: '0.0.0.0'
+DRB_API_PORT: '5050'
+
 # Bardo CCE API URL
 BARDO_CCE_API: http://sfr-bardo-copyright-development.us-east-1.elasticbeanstalk.com/search
 

--- a/config/sample-compose.yaml
+++ b/config/sample-compose.yaml
@@ -64,7 +64,7 @@ NYPL_API_CLIENT_PUBLIC_KEY: |
 
   # DRB API Credentials
   
-DRB_API_HOST: '0.0.0.0'
+DRB_API_HOST: drb_local_webapp
 DRB_API_PORT: '5050'
 
 # Bardo CCE API URL

--- a/managers/s3.py
+++ b/managers/s3.py
@@ -94,6 +94,14 @@ class S3Manager:
             )
         except ClientError:
             raise S3Error('Unable to get object from s3')
+        
+    def load_batches(self, objKey, bucket):
+
+        '''# Loading batches of data using a paginator until there are no more batches'''
+
+        paginator = self.s3Client.get_paginator('list_objects_v2')
+        page_iterator = paginator.paginate(Bucket=bucket, Prefix=objKey)
+        return page_iterator
 
     @staticmethod
     def getmd5HashOfObject(obj):

--- a/processes/UofM.py
+++ b/processes/UofM.py
@@ -45,7 +45,7 @@ class UofMProcess(CoreProcess):
             UofMRec = UofMMapping(record)
             UofMRec.applyMapping()
             self.addHasPartMapping(record, UofMRec.record)
-            #self.storePDFManifest(UofMRec.record)
+            self.storePDFManifest(UofMRec.record)
             self.addDCDWToUpdateList(UofMRec)
             
         except (MappingError, HTTPError, ConnectionError, IndexError, TypeError) as e:
@@ -90,7 +90,7 @@ class UofMProcess(CoreProcess):
                     urlPDFObject,
                     'UofM',
                     'application/pdf',
-                    '{"catalog": false, "download": true, "reader": false, "embed": false}'
+                    '{"catalog": false, "download": true, "reader": false, "embed": false, "nypl_login": true}'
                 ])
                 record.has_part.append(linkString)
 
@@ -101,7 +101,6 @@ class UofMProcess(CoreProcess):
                     logger.info(UofMError("Object doesn't exist"))
         
 
-            
     def storePDFManifest(self, record):
         for link in record.has_part:
             itemNo, uri, source, mediaType, flags = link.split('|')
@@ -124,7 +123,7 @@ class UofMProcess(CoreProcess):
                     manifestURI,
                     source,
                     'application/webpub+json',
-                    '{"catalog": false, "download": false, "reader": true, "embed": false}'
+                    '{"catalog": false, "download": false, "reader": true, "embed": false, "fulfill_limited_access": false}'
                 ])
 
                 record.has_part.insert(0, linkString)

--- a/processes/__init__.py
+++ b/processes/__init__.py
@@ -18,3 +18,4 @@ from .chicagoISAC import ChicagoISACProcess
 from .UofSC import UofSCProcess
 from .loc import LOCProcess
 from .UofM import UofMProcess
+from .addFulfillManifest import FulfillProcess

--- a/processes/addFulfillManifest.py
+++ b/processes/addFulfillManifest.py
@@ -1,23 +1,15 @@
 import json
 import os
-import boto3
 import copy
 import logging
-from requests.exceptions import HTTPError, ConnectionError
 from botocore.exceptions import ClientError
 
 from .core import CoreProcess
-from urllib.error import HTTPError
-from managers import WebpubManifest
 from datetime import datetime, timedelta, timezone
-from managers import DBManager
 from model import Link
 from logger import createLog
 
 logger = createLog(__name__)
-
-s3_client = boto3.client("s3")
-bucketName = 'drb-files-qa'
 
 class FulfillProcess(CoreProcess):
 
@@ -33,51 +25,42 @@ class FulfillProcess(CoreProcess):
 
         # S3 Configuration
         self.s3Bucket = os.environ['FILE_BUCKET']
+        self.host = os.environ['DRB_API_HOST']
+        self.port = os.environ['DRB_API_PORT']
+        self.objKey = 'manifests/UofM/'
         self.createS3Client()
 
     def runProcess(self):
         if self.process == 'daily':
             startTimeStamp = datetime.now(timezone.utc) - timedelta(days=1)
-            self.updateManifest(startTimeStamp)
+            self.getManifests(startTimeStamp)
         elif self.process == 'complete':
-            self.updateManifest()
+            self.getManifests()
         elif self.process == 'custom':
             timeStamp = self.ingestPeriod
             startTimeStamp = datetime.strptime(timeStamp, '%Y-%m-%dT%H:%M:%S')
-            self.updateManifest(startTimeStamp)
+            self.getManifests(startTimeStamp)
 
-    def updateManifest(self, startTimeStamp=None):
+    def getManifests(self, startTimeStamp=None):
 
         '''Load batch of LA works from past 24 hours'''
 
-        batches = self.load_batch()
-        for batch in batches:
-            for c in batch['Contents']:
-                if c["LastModified"] > startTimeStamp.replace(tzinfo=timezone.utc):
-                    currKey = c['Key']
-                    metadataObject = self.getObjectFromBucket(currKey, self.s3Bucket)
-                    self.update_batch(metadataObject, self.s3Bucket, currKey)
+        batches = self.load_batches(self.objKey, self.s3Bucket)
+        filtered_batches = batches.search(f"Contents[?to_string(LastModified) > '\"{startTimeStamp}\"'].Key")
+        for batch in filtered_batches:
+            currKey = batch['Key']
+            metadataObject = self.getObjectFromBucket(currKey, self.s3Bucket)
+            self.update_manifest(metadataObject, self.s3Bucket, currKey)
 
-    def update_batch(self, metadataObject, bucketName, currKey):
-        dbManager = DBManager(
-        user=os.environ.get('POSTGRES_USER', None),
-        pswd=os.environ.get('POSTGRES_PSWD', None),
-        host=os.environ.get('POSTGRES_HOST', None),
-        port=os.environ.get('POSTGRES_PORT', None),
-        db=os.environ.get('POSTGRES_NAME', None)
-    )
-
-        dbManager.generateEngine()
-
-        dbManager.createSession()
+    def update_manifest(self, metadataObject, bucketName, currKey):
 
         metadataJSON = json.loads(metadataObject['Body'].read().decode("utf-8"))
         metadataJSONCopy = copy.deepcopy(metadataJSON)
         
-        metadataJSON = self.linkFulfill(metadataJSON, dbManager)
-        metadataJSON = self.readingOrderFulfill(metadataJSON, dbManager)
-        metadataJSON = self.resourceFulfill(metadataJSON, dbManager)
-        metadataJSON = self.tocFulfill(metadataJSON, dbManager)
+        metadataJSON = self.linkFulfill(self, metadataJSON)
+        metadataJSON = self.readingOrderFulfill(self, metadataJSON)
+        metadataJSON = self.resourceFulfill(self, metadataJSON)
+        metadataJSON = self.tocFulfill(self, metadataJSON)
 
         if metadataJSON != metadataJSONCopy:
             try:
@@ -88,53 +71,51 @@ class FulfillProcess(CoreProcess):
             except ClientError as e:
                 logging.error(e)
         
-        dbManager.closeConnection()
+        self.closeConnection()
 
-    def linkFulfill(self, metadataJSON, dbManager):
-        for i in metadataJSON['links']:
-            i['href'] = self.fulfillReplace(i, dbManager)
+    def linkFulfill(self, metadataJSON):
+        for link in metadataJSON['links']:
+            link['href'] = self.fulfillReplace(self, link)
 
         return metadataJSON
             
-    def readingOrderFulfill(self, metadataJSON, dbManager):
-        for i in metadataJSON['readingOrder']:
-            i['href'] = self.fulfillReplace(i, dbManager)
+    def readingOrderFulfill(self, metadataJSON):
+        for readOrder in metadataJSON['readingOrder']:
+            readOrder['href'] = self.fulfillReplace(self, readOrder)
 
         return metadataJSON
 
-    def resourceFulfill(self, metadataJSON, dbManager):
-        for i in metadataJSON['resources']:
-            i['href'] = self.fulfillReplace(i, dbManager)
+    def resourceFulfill(self, metadataJSON):
+        for resource in metadataJSON['resources']:
+            resource['href'] = self.fulfillReplace(self, resource)
 
         return metadataJSON
 
-    def tocFulfill(self, metadataJSON, dbManager): 
-        for i in metadataJSON['toc']:
-            if 'pdf' in i['href'] \
-                or 'epub' in i['href']:
-                    for link in dbManager.session.query(Link) \
-                        .filter(Link.url == i['href'].replace('https://', '')):
-                            i['href'] = f'http://127.0.0.1:5050/fulfill/{link.id}'
+    def tocFulfill(self, metadataJSON): 
+
+        '''
+        THe toc dictionary has no "type" key like the previous dictionaries 
+        therefore the 'href' key is evaluated instead
+        '''
+
+        for toc in metadataJSON['toc']:
+            if 'pdf' in toc['href'] \
+                or 'epub' in toc['href']:
+                    for link in self.session.query(Link) \
+                        .filter(Link.url == toc['href'].replace('https://', '')):
+                            toc['href'] = f'http://{self.host}:{os.environ[self.port]}/fulfill/{link.id}'
                             link.flags['fulfill_limited_access'] = True
         return metadataJSON
 
     @staticmethod
-    def fulfillReplace(metadata, dbManager):
+    def fulfillReplace(self, metadata):
         if metadata['type'] == 'application/pdf' or metadata['type'] == 'application/epub+zip' \
             or metadata['type'] == 'application/epub+xml':
-                for link in dbManager.session.query(Link) \
+                for link in self.session.query(Link) \
                     .filter(Link.url == metadata['href'].replace('https://', '')):
-                        metadata['href'] = f'http://127.0.0.1:5050/fulfill/{link.id}'
+                        metadata['href'] = f'http://{self.host}:{os.environ[self.port]}/fulfill/{link.id}'
                         link.flags['fulfill_limited_access'] = True
         return metadata['href']
-
-    def load_batch(self):
-
-        '''# Loading batches of JSON records using a paginator until there are no more batches'''
-
-        paginator = s3_client.get_paginator('list_objects_v2')
-        page_iterator = paginator.paginate(Bucket= bucketName, Prefix= 'manifests/UofM/')
-        return page_iterator
 
 class FulfillError(Exception):
     pass

--- a/processes/addFulfillManifest.py
+++ b/processes/addFulfillManifest.py
@@ -1,0 +1,138 @@
+import json
+import os
+import boto3
+import copy
+import logging
+from requests.exceptions import HTTPError, ConnectionError
+from botocore.exceptions import ClientError
+
+from .core import CoreProcess
+from urllib.error import HTTPError
+from managers import WebpubManifest
+from datetime import datetime, timedelta, timezone
+from managers import DBManager
+from model import Link
+from logger import createLog
+
+logger = createLog(__name__)
+
+s3_client = boto3.client("s3")
+bucketName = 'drb-files-qa'
+
+class FulfillProcess(CoreProcess):
+
+    def __init__(self, *args):
+        super(FulfillProcess, self).__init__(*args[:4])
+
+        self.fullImport = self.process == 'complete' 
+        self.startTimestamp = None
+
+        # Connect to database
+        self.generateEngine()
+        self.createSession()
+
+        # S3 Configuration
+        self.s3Bucket = os.environ['FILE_BUCKET']
+        self.createS3Client()
+
+    def runProcess(self):
+        if self.process == 'daily':
+            startTimeStamp = datetime.now(timezone.utc) - timedelta(days=1)
+            self.updateManifest(startTimeStamp)
+        elif self.process == 'complete':
+            self.updateManifest()
+        elif self.process == 'custom':
+            timeStamp = self.ingestPeriod
+            startTimeStamp = datetime.strptime(timeStamp, '%Y-%m-%dT%H:%M:%S')
+            self.updateManifest(startTimeStamp)
+
+    def updateManifest(self, startTimeStamp=None):
+
+        '''Load batch of LA works from past 24 hours'''
+
+        batches = self.load_batch()
+        for batch in batches:
+            for c in batch['Contents']:
+                if c["LastModified"] > startTimeStamp.replace(tzinfo=timezone.utc):
+                    currKey = c['Key']
+                    metadataObject = self.getObjectFromBucket(currKey, self.s3Bucket)
+                    self.update_batch(metadataObject, self.s3Bucket, currKey)
+
+    def update_batch(self, metadataObject, bucketName, currKey):
+        dbManager = DBManager(
+        user=os.environ.get('POSTGRES_USER', None),
+        pswd=os.environ.get('POSTGRES_PSWD', None),
+        host=os.environ.get('POSTGRES_HOST', None),
+        port=os.environ.get('POSTGRES_PORT', None),
+        db=os.environ.get('POSTGRES_NAME', None)
+    )
+
+        dbManager.generateEngine()
+
+        dbManager.createSession()
+
+        metadataJSON = json.loads(metadataObject['Body'].read().decode("utf-8"))
+        metadataJSONCopy = copy.deepcopy(metadataJSON)
+        
+        metadataJSON = self.linkFulfill(metadataJSON, dbManager)
+        metadataJSON = self.readingOrderFulfill(metadataJSON, dbManager)
+        metadataJSON = self.resourceFulfill(metadataJSON, dbManager)
+        metadataJSON = self.tocFulfill(metadataJSON, dbManager)
+
+        if metadataJSON != metadataJSONCopy:
+            try:
+                fulfillManifest = json.dumps(metadataJSON, ensure_ascii = False)
+                return self.putObjectInBucket(
+                    fulfillManifest, currKey, bucketName
+                )
+            except ClientError as e:
+                logging.error(e)
+
+    def linkFulfill(self, metadataJSON, dbManager):
+        for i in metadataJSON['links']:
+            i['href'] = self.fulfillReplace(i, dbManager)
+
+        return metadataJSON
+            
+    def readingOrderFulfill(self, metadataJSON, dbManager):
+        for i in metadataJSON['readingOrder']:
+            i['href'] = self.fulfillReplace(i, dbManager)
+
+        return metadataJSON
+
+    def resourceFulfill(self, metadataJSON, dbManager):
+        for i in metadataJSON['resources']:
+            i['href'] = self.fulfillReplace(i, dbManager)
+
+        return metadataJSON
+
+    def tocFulfill(self, metadataJSON, dbManager): 
+        for i in metadataJSON['toc']:
+            if 'pdf' in i['href'] \
+                or 'epub' in i['href']:
+                    for link in dbManager.session.query(Link) \
+                        .filter(Link.url == i['href'].replace('https://', '')):
+                            i['href'] = f'http://127.0.0.1:5050/fulfill/{link.id}'
+                            link.flags['fulfill_limited_access'] = True
+        return metadataJSON
+
+    @staticmethod
+    def fulfillReplace(metadata, dbManager):
+        if metadata['type'] == 'application/pdf' or metadata['type'] == 'application/epub+zip' \
+            or metadata['type'] == 'application/epub+xml':
+                for link in dbManager.session.query(Link) \
+                    .filter(Link.url == metadata['href'].replace('https://', '')):
+                        metadata['href'] = f'http://127.0.0.1:5050/fulfill/{link.id}'
+                        link.flags['fulfill_limited_access'] = True
+        return metadata['href']
+
+    def load_batch(self):
+
+        '''# Loading batches of JSON records using a paginator until there are no more batches'''
+
+        paginator = s3_client.get_paginator('list_objects_v2')
+        page_iterator = paginator.paginate(Bucket= bucketName, Prefix= 'manifests/UofM/')
+        return page_iterator
+
+class FulfillError(Exception):
+    pass

--- a/processes/addFulfillManifest.py
+++ b/processes/addFulfillManifest.py
@@ -87,6 +87,8 @@ class FulfillProcess(CoreProcess):
                 )
             except ClientError as e:
                 logging.error(e)
+        
+        dbManager.closeConnection()
 
     def linkFulfill(self, metadataJSON, dbManager):
         for i in metadataJSON['links']:

--- a/processes/addFulfillManifest.py
+++ b/processes/addFulfillManifest.py
@@ -46,21 +46,37 @@ class FulfillProcess(CoreProcess):
         '''Load batch of LA works based on startTimeStamp'''
 
         batches = self.load_batches(self.prefix, self.s3Bucket)
-        filtered_batches = batches.search(f"Contents[?to_string(LastModified) > '\"{startTimeStamp}\"'].Key")
-        for batch in filtered_batches:
-            currKey = batch['Key']
-            metadataObject = self.getObjectFromBucket(currKey, self.s3Bucket)
-            self.update_manifest(metadataObject, self.s3Bucket, currKey)
+        if startTimeStamp:
+            filtered_batches = batches.search(f"Contents[?to_string(LastModified) > '\"{startTimeStamp}\"'].Key")
+            for batch in filtered_batches:
+                for c in batch['Contents']:
+                    currKey = c['Key']
+                    metadataObject = self.getObjectFromBucket(currKey, self.s3Bucket)
+                    self.update_manifest(metadataObject, self.s3Bucket, currKey)
+        else:
+            for batch in batches:
+                for c in batch['Contents']:
+                    currKey = c['Key']
+                    metadataObject = self.getObjectFromBucket(currKey, self.s3Bucket)
+                    self.update_manifest(metadataObject, self.s3Bucket, currKey)
 
     def update_manifest(self, metadataObject, bucketName, currKey):
 
         metadataJSON = json.loads(metadataObject['Body'].read().decode("utf-8"))
         metadataJSONCopy = copy.deepcopy(metadataJSON)
         
-        metadataJSON = self.linkFulfill(metadataJSON)
-        metadataJSON = self.readingOrderFulfill(metadataJSON)
-        metadataJSON = self.resourceFulfill(metadataJSON)
-        metadataJSON = self.tocFulfill(metadataJSON)
+        counter = 0
+    
+        metadataJSON, counter = self.linkFulfill(metadataJSON, counter)
+        metadataJSON, counter = self.readingOrderFulfill(metadataJSON, counter)
+        metadataJSON, counter = self.resourceFulfill(metadataJSON, counter)
+        metadataJSON, counter = self.tocFulfill(metadataJSON, counter)
+
+        if counter >= 4: 
+            for link in metadataJSON['links']:
+                self.fulfillFlagUpdate(link)
+
+        self.closeConnection()
 
         if metadataJSON != metadataJSONCopy:
             try:
@@ -70,31 +86,32 @@ class FulfillProcess(CoreProcess):
                 )
             except ClientError as e:
                 logging.error(e)
-        
-        self.closeConnection()
 
     def linkFulfill(self, metadataJSON):
         for link in metadataJSON['links']:
-            link['href'] = self.fulfillReplace(self, link)
+            fulfillLink, counter = self.fulfillReplace(link, counter)
+            link['href'] = fulfillLink
 
-        return metadataJSON
+        return (metadataJSON, counter)
             
     def readingOrderFulfill(self, metadataJSON):
         for readOrder in metadataJSON['readingOrder']:
-            readOrder['href'] = self.fulfillReplace(self, readOrder)
+            fulfillLink, counter = self.fulfillReplace(readOrder, counter)
+            readOrder['href'] = fulfillLink
 
-        return metadataJSON
+        return (metadataJSON, counter)
 
     def resourceFulfill(self, metadataJSON):
         for resource in metadataJSON['resources']:
-            resource['href'] = self.fulfillReplace(self, resource)
+            fulfillLink, counter = self.fulfillReplace(resource, counter)
+            resource['href'] = fulfillLink
 
-        return metadataJSON
+        return (metadataJSON, counter)
 
     def tocFulfill(self, metadataJSON): 
 
         '''
-        THe toc dictionary has no "type" key like the previous dictionaries 
+        The toc dictionary has no "type" key like the previous dictionaries 
         therefore the 'href' key is evaluated instead
         '''
 
@@ -103,18 +120,33 @@ class FulfillProcess(CoreProcess):
                 or 'epub' in toc['href']:
                     for link in self.session.query(Link) \
                         .filter(Link.url == toc['href'].replace('https://', '')):
-                            toc['href'] = f'{self.host}:{self.port}/fulfill/{link.id}'
-                            link.flags['fulfill_limited_access'] = True
-        return metadataJSON
+                            counter += 1
+                            toc['href'] = f'http://{self.host}:{self.port}/fulfill/{link.id}'
+
+        return (metadataJSON, counter)
 
     def fulfillReplace(self, metadata):
         if metadata['type'] == 'application/pdf' or metadata['type'] == 'application/epub+zip' \
             or metadata['type'] == 'application/epub+xml':
                 for link in self.session.query(Link) \
                     .filter(Link.url == metadata['href'].replace('https://', '')):
-                        metadata['href'] = f'{self.host}:{self.port}/fulfill/{link.id}'
-                        link.flags['fulfill_limited_access'] = True
-        return metadata['href']
+                        counter += 1            
+                        metadata['href'] = f'http://{self.host}:{self.port}/fulfill/{link.id}'
+
+        return (metadata['href'], counter)
+    
+    def fulfillFlagUpdate(self, metadata):
+        if metadata['type'] == 'application/webpub+json':
+            for link in self.session.query(Link) \
+                .filter(Link.url == metadata['href'].replace('https://', '')):   
+                        print(link)
+                        print(link.flags)
+                        if 'fulfill_limited_access' in link.flags.keys():
+                            if link.flags['fulfill_limited_access'] == False:
+                                newLinkFlag = dict(link.flags)
+                                newLinkFlag['fulfill_limited_access'] = True
+                                link.flags = newLinkFlag
+                                self.commitChanges()
 
 class FulfillError(Exception):
     pass

--- a/scripts/fulfillURLManifest.py
+++ b/scripts/fulfillURLManifest.py
@@ -2,7 +2,7 @@ import boto3
 import json
 import os
 import logging
-
+import os 
 
 import copy 
 from botocore.exceptions import ClientError
@@ -13,11 +13,14 @@ s3_client = boto3.client("s3")
 
 bucketName = 'drb-files-qa'
 
+host = os.environ['DRB_API_HOST']
+port = os.environ['DRB_API_PORT']
+
 def main():
 
     '''Replacing pdf/epub links in with fulfill urls in manifest JSON files'''
 
-    batches = load_batch()
+    batches = load_batches()
     for batch in batches:
         for c in batch['Contents']:
             currKey = c['Key']
@@ -80,7 +83,7 @@ def tocFulfill(metadataJSON, dbManager):
             or 'epub' in i['href']:
                 for link in dbManager.session.query(Link) \
                     .filter(Link.url == i['href'].replace('https://', '')):
-                        i['href'] = f'http://127.0.0.1:5050/fulfill/{link.id}'
+                        i['href'] = f'http://{host}:{port}/fulfill/{link.id}'
     return metadataJSON
 
 def fulfillReplace(metadata, dbManager):
@@ -88,10 +91,10 @@ def fulfillReplace(metadata, dbManager):
         or metadata['type'] == 'application/epub+xml':
             for link in dbManager.session.query(Link) \
                 .filter(Link.url == metadata['href'].replace('https://', '')):
-                    metadata['href'] = f'http://127.0.0.1:5050/fulfill/{link.id}'
+                    metadata['href'] = f'http://{host}:{port}/fulfill/{link.id}'
     return metadata['href']
 
-def load_batch():
+def load_batches():
 
     '''# Loading batches of JSON records using a paginator until there are no more batches'''
 

--- a/tests/unit/test_fulfillManifest_process.py
+++ b/tests/unit/test_fulfillManifest_process.py
@@ -1,0 +1,58 @@
+import pytest
+
+from mappings.core import MappingError
+from processes.addFulfillManifest import FulfillProcess
+from tests.helper import TestHelpers
+
+class TestUofMProcess:
+    @classmethod
+    def setup_class(cls):
+        TestHelpers.setEnvVars()
+
+    @classmethod
+    def teardown_class(cls):
+        TestHelpers.clearEnvVars()
+
+    @pytest.fixture
+    def testProcess(self, mocker):
+        class TestFulfill(FulfillProcess):
+            def __init__(self):
+                self.s3Bucket = 'test_aws_bucket'
+                self.s3Client = mocker.MagicMock(s3Client='testS3Client')
+                self.session = mocker.MagicMock(session='testSession')
+                self.records = mocker.MagicMock(record='testRecord')
+                self.batchSize = mocker.MagicMock(batchSize='testBatchSize')
+                self.host = mocker.MagicMock(host='testHost')
+                self.port = mocker.MagicMock(port='testPort')
+                self.prefix = 'testPrefix'
+                self.objKey = mocker.MagicMock(objKey='testKey')
+                self.process = 'complete'
+        
+        return TestFulfill()
+
+    def test_runProcess(self, testProcess, mocker):
+        runMocks = mocker.patch.multiple(
+            FulfillProcess,
+            getManifests=mocker.DEFAULT,
+        )
+
+        testProcess.runProcess()
+
+        runMocks['getManifests'].assert_called_once()
+
+
+    def test_getManifests_success(self, testProcess, mocker):
+        processMocks = mocker.patch.multiple(FulfillProcess,
+            load_batches=mocker.DEFAULT,
+            getObjectFromBucket=mocker.DEFAULT,
+            update_manifest=mocker.DEFAULT
+        )
+
+        mockPrefix = mocker.MagicMock(prefix='testPrefix')
+        mockTimeStamp = mocker.MagicMock(timeStamp='testTimeStamp')
+        
+        testProcess.getManifests(mockTimeStamp)
+
+
+        processMocks['load_batches'].assert_called_once_with('testPrefix','test_aws_bucket')
+        


### PR DESCRIPTION
This PR focuses on adding fulfill endpoints to future LA manifests after they have been ingested and clustered. A new flag called fulfill_limited_access has been added to prevent these LA works to be Read Online on the frontend before the process  addFulfillManifest is run. 