### PR TITLE
HOTFIX_FixFulfillURLManifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - New process to add fulfill urls to Limited Access manifests and update fulfill_limited_access flags to True
 - Updated README and added more information to installation steps
 ## Fixed
+- Resolved the format of fulfill endpoints in UofM manifests
 
 ## 2024-03-21 -- v0.13.0
 ## Added

--- a/config/production.yaml
+++ b/config/production.yaml
@@ -58,7 +58,7 @@ NYPL_LOCATIONS_BY_CODE: https://nypl-core-objects-mapping-qa.s3.amazonaws.com/by
 NYPL_API_CLIENT_TOKEN_URL: https://isso.nypl.org/oauth/token
 
 # DRB API Credentials
-DRB_API_HOST: 'digital-research-books-beta.nypl.org'
+DRB_API_HOST: 'drb-api-production.nypl.org'
 DRB_API_PORT: '80'
 
 # GITHUB API Credentials

--- a/config/qa.yaml
+++ b/config/qa.yaml
@@ -58,7 +58,7 @@ NYPL_LOCATIONS_BY_CODE: https://nypl-core-objects-mapping-qa.s3.amazonaws.com/by
 NYPL_API_CLIENT_TOKEN_URL: https://isso.nypl.org/oauth/token
 
 # DRB API Credentials
-DRB_API_HOST: 'drb-qa.nypl.org'
+DRB_API_HOST: 'drb-api-qa.nypl.org'
 DRB_API_PORT: '80'
 
 # GITHUB API Credentials

--- a/processes/__init__.py
+++ b/processes/__init__.py
@@ -18,4 +18,4 @@ from .chicagoISAC import ChicagoISACProcess
 from .UofSC import UofSCProcess
 from .loc import LOCProcess
 from .UofM import UofMProcess
-from .addFulfillManifest import FulfillProcess
+from .fulfillURLManifest import FulfillProcess

--- a/processes/fulfillURLManifest.py
+++ b/processes/fulfillURLManifest.py
@@ -26,7 +26,6 @@ class FulfillProcess(CoreProcess):
         # S3 Configuration
         self.s3Bucket = os.environ['FILE_BUCKET']
         self.host = os.environ['DRB_API_HOST']
-        self.port = os.environ['DRB_API_PORT']
         self.prefix = 'manifests/UofM/'
         self.createS3Client()
 
@@ -121,7 +120,7 @@ class FulfillProcess(CoreProcess):
                     for link in self.session.query(Link) \
                         .filter(Link.url == toc['href'].replace('https://', '')):
                             counter += 1
-                            toc['href'] = f'http://{self.host}:{self.port}/fulfill/{link.id}'
+                            toc['href'] = f'https://{self.host}/fulfill/{link.id}'
 
         return (metadataJSON, counter)
 
@@ -131,7 +130,7 @@ class FulfillProcess(CoreProcess):
                 for link in self.session.query(Link) \
                     .filter(Link.url == metadata['href'].replace('https://', '')):
                         counter += 1            
-                        metadata['href'] = f'http://{self.host}:{self.port}/fulfill/{link.id}'
+                        metadata['href'] = f'https://{self.host}/fulfill/{link.id}'
 
         return (metadata['href'], counter)
     

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -15,4 +15,4 @@ from .countCABooks import main as countCA
 from .nyplLoginFlags import main as nyplFlags
 from .deleteUMPManifestLinks import main as deleteUMPManifests
 from .parseDownloadRequests import main as parseDownloads
-from .fulfillURLManifest import main as fulfillManifest
+from .addFulfillManifest import main as fulfillManifest

--- a/scripts/addFulfillManifest.py
+++ b/scripts/addFulfillManifest.py
@@ -14,7 +14,6 @@ s3_client = boto3.client("s3")
 bucketName = 'drb-files-qa'
 
 host = os.environ['DRB_API_HOST']
-port = os.environ['DRB_API_PORT']
 
 def main():
 
@@ -101,7 +100,7 @@ def tocFulfill(metadataJSON, counter, dbManager):
                 for link in dbManager.session.query(Link) \
                     .filter(Link.url == toc['href'].replace('https://', '')):
                         counter += 1
-                        toc['href'] = f'http://{host}:{port}/fulfill/{link.id}'
+                        toc['href'] = f'https://{host}/fulfill/{link.id}'
 
     return (metadataJSON, counter)
 
@@ -112,7 +111,7 @@ def fulfillReplace(metadata, counter, dbManager):
             for link in dbManager.session.query(Link) \
                 .filter(Link.url == metadata['href'].replace('https://', '')):          
                     counter += 1            
-                    metadata['href'] = f'http://{host}:{port}/fulfill/{link.id}'
+                    metadata['href'] = f'https://{host}/fulfill/{link.id}'
 
     return (metadata['href'], counter)
 

--- a/tests/unit/test_fulfillManifest_process.py
+++ b/tests/unit/test_fulfillManifest_process.py
@@ -1,7 +1,7 @@
 import pytest
 
 from mappings.core import MappingError
-from processes.addFulfillManifest import FulfillProcess
+from processes.fulfillURLManifest import FulfillProcess
 from tests.helper import TestHelpers
 
 class TestUofMProcess:


### PR DESCRIPTION
This hotfix intends to fix the typos found in the original format of the fulfill endpoints in the UofM manifests. The structure of it now works as intended with an example that was used by the web reader on the front end. The example was this: `https://drb-api-qa.nypl.org/fulfill/9350262`