### PR TITLE
SFR-1935_EditionAPIErrorHandling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Updated README and added more information to installation steps
 ## Fixed
 - Resolved the format of fulfill endpoints in UofM manifests
+- Added additional logging to the editions endpoint to debug
 
 ## 2024-03-21 -- v0.13.0
 ## Added

--- a/tests/unit/test_api_edition_blueprint.py
+++ b/tests/unit/test_api_edition_blueprint.py
@@ -25,8 +25,8 @@ class TestEditionBlueprint:
 
     def test_editionFetch_success_noFormat(self, mockUtils, testApp, mocker):
         mockDB = mocker.MagicMock()
-        mockDBClient = mocker.patch('api.blueprints.drbEdition.DBClient')
-        mockDBClient.return_value = mockDB
+        mockDB.__enter__.return_value = mockDB
+        mockDBClient = mocker.patch('api.blueprints.drbEdition.DBClient', return_value=mockDB)
 
         mockUtils['normalizeQueryParams'].return_value = {'showAll': ['true']}
 
@@ -56,8 +56,8 @@ class TestEditionBlueprint:
 
     def test_editionFetch_success_format(self, mockUtils, testApp, mocker):
         mockDB = mocker.MagicMock()
-        mockDBClient = mocker.patch('api.blueprints.drbEdition.DBClient')
-        mockDBClient.return_value = mockDB
+        mockDB.__enter__.return_value = mockDB
+        mockDBClient = mocker.patch('api.blueprints.drbEdition.DBClient', return_value=mockDB)
 
         queryParams = {'showAll': ['true']}
         mockUtils['normalizeQueryParams'].return_value = {'showAll': ['true']}
@@ -98,8 +98,8 @@ class TestEditionBlueprint:
 
     def test_editionFetch_missing(self, mockUtils, testApp, mocker):
         mockDB = mocker.MagicMock()
-        mockDBClient = mocker.patch('api.blueprints.drbEdition.DBClient')
-        mockDBClient.return_value = mockDB
+        mockDB.__enter__.return_value = mockDB
+        mockDBClient = mocker.patch('api.blueprints.drbEdition.DBClient', return_value=mockDB)
 
         mockUtils['normalizeQueryParams'].return_value = {'showAll': ['true']}
         
@@ -119,4 +119,27 @@ class TestEditionBlueprint:
                 404,
                 'singleEdition',
                 {'message': 'Unable to locate edition with id 1'}
+            )
+    
+    def test_editionFetch_error(self, mockUtils, testApp, mocker):
+        mockDB = mocker.MagicMock()
+        mockDB.__enter__.return_value = mockDB
+        mockDBClient = mocker.patch('api.blueprints.drbEdition.DBClient', return_value=mockDB)
+
+        mockUtils['normalizeQueryParams'].return_value = {'showAll': ['true']}
+        
+        mockDB.fetchSingleEdition.side_effect = Exception('Database error')
+
+        mockUtils['formatResponseObject'].return_value = '500response'
+
+        with testApp.test_request_context('/'):
+            testAPIResponse = editionFetch(1)
+
+            assert testAPIResponse == '500response'
+            mockDBClient.assert_called_once_with('testDBClient')
+
+            mockUtils['formatResponseObject'].assert_called_once_with(
+                500,
+                'singleEdition',
+                {'message': 'Unable to fetch edition with id 1'}
             )


### PR DESCRIPTION
# Description
- Currently the response for the /editions endpoint is returning:
```
{"data":{"message":"Encountered fatal database error"},"responseType":"dataError","status":500,"timestamp":"Mon, 01 Apr 2024 16:42:55 GMT"}
```
- This change returns a 500 error if an exception occurs while fetching the addition.  I made some refactors to simplify the code and make it more readable. 
- By logging the error, hopefully we will see the root cause but the [logs](https://one.newrelic.com/logger?account=121334&begin=1718726851596&end=1718726971596&state=96ed1f43-c931-443d-5049-8d8d471c47ed) are not giving us much to work with 

# Testing
`make test`