### PR TITLE
Sfr-2054_PubSourceFieldMigration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - New process to add fulfill urls to Limited Access manifests and update fulfill_limited_access flags to True
 - Updated README and added more information to installation steps
 - Deprecated datetime.utcnow() method
+- Added new column (contract_source) to the records and item tables
 ## Fixed
 - Resolved the format of fulfill endpoints in UofM manifests
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - New process to add fulfill urls to Limited Access manifests and update fulfill_limited_access flags to True
 - Updated README and added more information to installation steps
 - Deprecated datetime.utcnow() method
-- Added new column (contract_source) to the records and item tables
+- Added new field (publisher_project_source) to the records and item tables
 ## Fixed
 - Resolved the format of fulfill endpoints in UofM manifests
 

--- a/migrations/versions/54e57fb2e1c6_add_contract_source_to_records_and_items.py
+++ b/migrations/versions/54e57fb2e1c6_add_contract_source_to_records_and_items.py
@@ -1,4 +1,4 @@
-"""add contract source to records and items
+"""add publisher_project_source field to records and items
 
 Revision ID: 54e57fb2e1c6
 Revises: e46b30dd3ff5
@@ -17,10 +17,10 @@ depends_on = None
 
 
 def upgrade():
-    op.add_column('records', sa.Column('contract_source', sa.ARRAY, index=True))
-    op.add_column('items', sa.Column('contract_source', sa.ARRAY, index=True))
+    op.add_column('records', sa.Column('publisher_project_source', sa.ARRAY(sa.Unicode), index=True))
+    op.add_column('items', sa.Column('publisher_project_source', sa.ARRAY(sa.Unicode), index=True))
 
 
 def downgrade():
-    op.drop_column('records', 'contract_source')
-    op.drop_column('items', 'contract_source')
+    op.drop_column('records', 'publisher_project_source')
+    op.drop_column('items', 'publisher_project_source')

--- a/migrations/versions/54e57fb2e1c6_add_contract_source_to_records_and_items.py
+++ b/migrations/versions/54e57fb2e1c6_add_contract_source_to_records_and_items.py
@@ -17,8 +17,8 @@ depends_on = None
 
 
 def upgrade():
-    op.add_column('records', sa.Column('publisher_project_source', sa.ARRAY(sa.Unicode), index=True))
-    op.add_column('items', sa.Column('publisher_project_source', sa.ARRAY(sa.Unicode), index=True))
+    op.add_column('records', sa.Column('publisher_project_source', sa.Unicode, index=True))
+    op.add_column('items', sa.Column('publisher_project_source', sa.Unicode, index=True))
 
 
 def downgrade():

--- a/migrations/versions/54e57fb2e1c6_add_contract_source_to_records_and_items.py
+++ b/migrations/versions/54e57fb2e1c6_add_contract_source_to_records_and_items.py
@@ -1,0 +1,26 @@
+"""add contract source to records and items
+
+Revision ID: 54e57fb2e1c6
+Revises: e46b30dd3ff5
+Create Date: 2024-06-26 15:04:24.092549
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '54e57fb2e1c6'
+down_revision = 'e46b30dd3ff5'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('records', sa.Column('contract_source', sa.ARRAY, index=True))
+    op.add_column('items', sa.Column('contract_source', sa.ARRAY, index=True))
+
+
+def downgrade():
+    op.drop_column('records', 'contract_source')
+    op.drop_column('items', 'contract_source')

--- a/model/postgres/item.py
+++ b/model/postgres/item.py
@@ -24,7 +24,7 @@ class Item(Base, Core):
 
     id = Column(Integer, primary_key=True)
     source = Column(Unicode, nullable=False, index=True)
-    publisher_project_source = Column(ARRAY(Unicode, dimensions=1), index=True)
+    publisher_project_source = Column(Unicode, index=True)
     content_type = Column(Unicode)
     contributors = Column(JSONB)
     modified = Column(DateTime)

--- a/model/postgres/item.py
+++ b/model/postgres/item.py
@@ -24,6 +24,7 @@ class Item(Base, Core):
 
     id = Column(Integer, primary_key=True)
     source = Column(Unicode, nullable=False, index=True)
+    contract_source = Column(ARRAY(Unicode, dimensions=1), index=True)
     content_type = Column(Unicode)
     contributors = Column(JSONB)
     modified = Column(DateTime)
@@ -44,6 +45,6 @@ class Item(Base, Core):
 
     def __dir__(self):
         return [
-            'source', 'content_type', 'contributors', 'modified', 'drm',
+            'source', 'contract_source', 'content_type', 'contributors', 'modified', 'drm',
             'measurements'
         ]

--- a/model/postgres/item.py
+++ b/model/postgres/item.py
@@ -24,7 +24,7 @@ class Item(Base, Core):
 
     id = Column(Integer, primary_key=True)
     source = Column(Unicode, nullable=False, index=True)
-    contract_source = Column(ARRAY(Unicode, dimensions=1), index=True)
+    publisher_project_source = Column(ARRAY(Unicode, dimensions=1), index=True)
     content_type = Column(Unicode)
     contributors = Column(JSONB)
     modified = Column(DateTime)

--- a/model/postgres/item.py
+++ b/model/postgres/item.py
@@ -45,6 +45,6 @@ class Item(Base, Core):
 
     def __dir__(self):
         return [
-            'source', 'contract_source', 'content_type', 'contributors', 'modified', 'drm',
+            'source', 'publisher_project_source', 'content_type', 'contributors', 'modified', 'drm',
             'measurements'
         ]

--- a/model/postgres/record.py
+++ b/model/postgres/record.py
@@ -50,7 +50,7 @@ class Record(Base, Core):
         )
     
     def __dir__(self):
-        return ['uuid', 'frbr_status', 'cluster_status', 'source', 'contract_source', 'source_id',
+        return ['uuid', 'frbr_status', 'cluster_status', 'source', 'publisher_project_source', 'source_id',
             'title', 'alternative', 'medium', 'is_part_of', 'subjects', 'authors',
             'contributors', 'languages', 'dates', 'rights', 'identifiers',
             'date_submitted', 'requires', 'spatial', 'publisher', 'has_version',

--- a/model/postgres/record.py
+++ b/model/postgres/record.py
@@ -18,7 +18,7 @@ class Record(Base, Core):
     )
     cluster_status = Column(Boolean, default=False, nullable=False, index=True)
     source = Column(Unicode, index=True) # dc:source, Non-Repeating
-    publisher_project_source = Column(ARRAY(Unicode, dimensions=1), index=True) # dc:publisherProjectSource, Non-Repeating
+    publisher_project_source = Column(Unicode, index=True) # dc:publisherProjectSource, Non-Repeating
     source_id = Column(Unicode, index=True) # dc:identifier, Non-Repeating
     title = Column(Unicode) # dc:title, Non-Repeating
     alternative = Column(ARRAY(Unicode, dimensions=1)) # dc:alternative, Repeating

--- a/model/postgres/record.py
+++ b/model/postgres/record.py
@@ -18,7 +18,7 @@ class Record(Base, Core):
     )
     cluster_status = Column(Boolean, default=False, nullable=False, index=True)
     source = Column(Unicode, index=True) # dc:source, Non-Repeating
-    contract_source = Column(ARRAY(Unicode, dimensions=1), index=True) # dc:contractSource, Non-Repeating
+    publisher_project_source = Column(ARRAY(Unicode, dimensions=1), index=True) # dc:publisherProjectSource, Non-Repeating
     source_id = Column(Unicode, index=True) # dc:identifier, Non-Repeating
     title = Column(Unicode) # dc:title, Non-Repeating
     alternative = Column(ARRAY(Unicode, dimensions=1)) # dc:alternative, Repeating

--- a/model/postgres/record.py
+++ b/model/postgres/record.py
@@ -18,6 +18,7 @@ class Record(Base, Core):
     )
     cluster_status = Column(Boolean, default=False, nullable=False, index=True)
     source = Column(Unicode, index=True) # dc:source, Non-Repeating
+    contract_source = Column(ARRAY(Unicode, dimensions=1), index=True) # dc:contractSource, Non-Repeating
     source_id = Column(Unicode, index=True) # dc:identifier, Non-Repeating
     title = Column(Unicode) # dc:title, Non-Repeating
     alternative = Column(ARRAY(Unicode, dimensions=1)) # dc:alternative, Repeating
@@ -49,7 +50,7 @@ class Record(Base, Core):
         )
     
     def __dir__(self):
-        return ['uuid', 'frbr_status', 'cluster_status', 'source', 'source_id',
+        return ['uuid', 'frbr_status', 'cluster_status', 'source', 'contract_source', 'source_id',
             'title', 'alternative', 'medium', 'is_part_of', 'subjects', 'authors',
             'contributors', 'languages', 'dates', 'rights', 'identifiers',
             'date_submitted', 'requires', 'spatial', 'publisher', 'has_version',


### PR DESCRIPTION
This PR so far focuses on adding a new column named publisher_project_source to the record and items PSQL tables since both tables have a source field already so it makes sense to have both source type fields in these tables. 