### PR TITLE
SFR-1935 Add editionID validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Deprecated datetime.utcnow() method
 - Added new field (publisher_project_source) to the records and items data models
 - Ran database migration to add publisher_project_source field to records and items tables
+- Added editionID validation to editions API
 ## Fixed
 - Resolved the format of fulfill endpoints in UofM manifests
 - Added additional logging to the editions endpoint to debug

--- a/api/blueprints/drbEdition.py
+++ b/api/blueprints/drbEdition.py
@@ -22,6 +22,9 @@ def editionFetch(editionID):
                 or current_app.config['READER_VERSION']
             filteredFormats = APIUtils.formatFilters(terms)
 
+            if not isValidEditionID(editionID):
+                return APIUtils.formatResponseObject(400, RESPONSE_TYPE, { 'message': 'Edition id {} is invalid'.format(editionID) })
+
             edition = dbClient.fetchSingleEdition(editionID)
 
             if not edition:
@@ -39,3 +42,7 @@ def editionFetch(editionID):
     except Exception as e: 
         logger.error(e)
         return APIUtils.formatResponseObject(500, RESPONSE_TYPE, { 'message': 'Unable to fetch edition with id {}'.format(editionID) })
+
+
+def isValidEditionID(editionID) -> bool:
+    return isinstance(editionID, int) or (isinstance(editionID, str) and editionID.isdigit())

--- a/tests/unit/test_api_edition_blueprint.py
+++ b/tests/unit/test_api_edition_blueprint.py
@@ -143,3 +143,17 @@ class TestEditionBlueprint:
                 'singleEdition',
                 {'message': 'Unable to fetch edition with id 1'}
             )
+
+    def test_editionFetch_invalid_id_error(self, mockUtils, testApp, mocker):
+        mockDB = mocker.MagicMock()
+        mockDB.__enter__.return_value = mockDB
+        mocker.patch('api.blueprints.drbEdition.DBClient', return_value=mockDB)
+
+        with testApp.test_request_context('/'):
+            editionFetch('e2d0e0aa-aa72-42a0-88fb-1aeadbec2f67')
+
+            mockUtils['formatResponseObject'].assert_called_once_with(
+                400,
+                'singleEdition',
+                {'message': 'Edition id e2d0e0aa-aa72-42a0-88fb-1aeadbec2f67 is invalid'}
+            )


### PR DESCRIPTION
## Description
- After adding better error handling, the logs now show that the editionID that was being passed in was a string and not an integer
- This change ensures the path param editionID is a valid integer before querying the database. If not, it returns a 400 response back to the client

## Testing
`make test`