### PR TITLE
SFR-2065: Adding more logging to proxy API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Ran database migration to add publisher_project_source field to records and items tables
 - Filled out publisher_project_source field for UofM books
 - Added editionID validation to editions API
+- Added more logging to proxy API
 ## Fixed
 - Resolved the format of fulfill endpoints in UofM manifests
 - Added additional logging to the editions endpoint to debug

--- a/api/blueprints/drbUtils.py
+++ b/api/blueprints/drbUtils.py
@@ -81,7 +81,7 @@ def getProxyResponse():
                     urlParts.scheme, urlParts.netloc, cleanUrl
                 )
         else:
-            logger.warn(f'Unable to proxy clean URL {cleanUrl}')
+            logger.warn(f'Unable to proxy clean url {cleanUrl}')
             cleanUrl = proxyUrl
             break
 

--- a/api/blueprints/drbUtils.py
+++ b/api/blueprints/drbUtils.py
@@ -60,7 +60,7 @@ def getProxyResponse():
     cleanUrl = unquote_plus(proxyUrl)
     urlParts = urlparse(cleanUrl)
 
-    logger.info(f'Received request to proxy url: {proxyUrl}')
+    logger.info(f'Received {request.method} request to proxy url: {proxyUrl}')
 
     while True:
         headResp = requests.head(

--- a/api/blueprints/drbUtils.py
+++ b/api/blueprints/drbUtils.py
@@ -13,6 +13,12 @@ logger = createLog(__name__)
 
 
 utils = Blueprint('utils', __name__, url_prefix='/utils')
+EXCLUDED_HEADERS = [
+    'content-encoding', 'content-length', 'transfer-encoding',
+    'x-frame-options', 'referrer-policy', 'access-control-allow-origin',
+    'connection', 'keep-alive', 'public', 'proxy-authenticate',
+    'upgrade'
+]
 
 
 @utils.route('/languages', methods=['GET'])
@@ -51,10 +57,10 @@ def totalCounts():
 @cross_origin(origins=os.environ.get('API_PROXY_CORS_ALLOWED', '*'))
 def getProxyResponse():
     proxyUrl = request.args.get('proxy_url')
-
     cleanUrl = unquote_plus(proxyUrl)
-
     urlParts = urlparse(cleanUrl)
+
+    logger.info(f'Received request to proxy url: {proxyUrl}')
 
     while True:
         headResp = requests.head(
@@ -62,11 +68,12 @@ def getProxyResponse():
         )
 
         statusCode = headResp.status_code
-        print(statusCode, cleanUrl)
+        
+        logger.info(f'HEAD response from {cleanUrl} returned status code {statusCode}')
+
         if statusCode in [200, 204]:
             break
         elif statusCode in [301, 302, 303, 307, 308]:
-            print(headResp.headers)
             cleanUrl = headResp.headers['Location']
 
             if cleanUrl[0] == '/':
@@ -74,7 +81,7 @@ def getProxyResponse():
                     urlParts.scheme, urlParts.netloc, cleanUrl
                 )
         else:
-            logger.warn('Unable to proxy URL {}'.format(cleanUrl))
+            logger.warn(f'Unable to proxy clean URL {cleanUrl}')
             cleanUrl = proxyUrl
             break
 
@@ -88,17 +95,11 @@ def getProxyResponse():
         allow_redirects=False
     )
 
-    excludedHeaders = [
-        'content-encoding', 'content-length', 'transfer-encoding',
-        'x-frame-options', 'referrer-policy', 'access-control-allow-origin',
-        'connection', 'keep-alive', 'public', 'proxy-authenticate',
-        'upgrade'
-    ]
-
     headers = [
         (k, v) for (k, v) in resp.headers.items()
-        if k.lower() not in excludedHeaders
+        if k.lower() not in EXCLUDED_HEADERS
     ]
 
-    proxyResp = Response(resp.content, resp.status_code, headers)
-    return proxyResp
+    logger.info(f'Returning {request.method} response from {cleanUrl} with status code {resp.status_code}')
+
+    return Response(resp.content, resp.status_code, headers)


### PR DESCRIPTION
## Description
- Adding more logging to understand why proxying through S3 PDFs fails
- When we retrieve metadata about the S3 url it returns 403
- When we retrieve metadata about the cleaned S3 url it returns 400 and the cleaning process malforms the tokens
- @jackiequach had a great callout and we should just not proxy to S3. 

## Testing
`make test`