### PR TITLE
SFR-2069_RenameDockerAPIName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ## Fixed
 - Resolved the format of fulfill endpoints in UofM manifests
 - Added additional logging to the editions endpoint to debug
+- Renamed Docker API container name to drb_local_api
 
 ## 2024-03-21 -- v0.13.0
 ## Added

--- a/config/sample-compose.yaml
+++ b/config/sample-compose.yaml
@@ -64,7 +64,7 @@ NYPL_API_CLIENT_PUBLIC_KEY: |
 
   # DRB API Credentials
   
-DRB_API_HOST: drb_local_webapp
+DRB_API_HOST: drb_local_api
 DRB_API_PORT: '5050'
 
 # Bardo CCE API URL

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
       - drb_local_rsdata:/data
 
   webapp:
-    container_name: drb_local_webapp
+    container_name: drb_local_api
     depends_on:
       - database
       - elasticsearch


### PR DESCRIPTION
This PR changes the name of the DRB API container from drb_local_webapp to drb_local_api since the previous name was a misnomer and could confuse new developers of what the container actually represents.