### PR TITLE
NO-REF: Refactor OCLC Catalog Manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Added editionID validation to editions API
 - Updated README with steps on retrieving local-compose.yaml file and credentials
 - Added more logging to proxy API
+- Refactor OCLC Catalog Manager
 ## Fixed
 - Resolved the format of fulfill endpoints in UofM manifests
 - Added additional logging to the editions endpoint to debug

--- a/managers/oclcCatalog.py
+++ b/managers/oclcCatalog.py
@@ -4,15 +4,14 @@ from requests.exceptions import Timeout, ConnectionError
 
 class OCLCCatalogManager:
     CATALOG_URL = 'http://www.worldcat.org/webservices/catalog/content/{}?wskey={}'
-    def __init__(self, oclcNo):
-        self.oclcNo = oclcNo
+    def __init__(self):
         self.oclcKey = os.environ['OCLC_API_KEY']
         self.attempts = 0
 
-    def queryCatalog(self):
+    def queryCatalog(self, oclcNo):
         classifyResp = None
         self.attempts += 1
-        catalogQuery = self.CATALOG_URL.format(self.oclcNo, self.oclcKey)
+        catalogQuery = self.CATALOG_URL.format(oclcNo, self.oclcKey)
         if self.attempts > 3: 
             return classifyResp
 
@@ -20,7 +19,7 @@ class OCLCCatalogManager:
             classifyResp = requests.get(catalogQuery, timeout=3)
         except (Timeout, ConnectionError):
             print('Failed to query URL {}'.format(catalogQuery))
-            return self.queryCatalog()
+            return self.queryCatalog(oclcNo)
 
         if classifyResp.status_code != 200:
             print('OCLC Catalog Request failed with status {}'.format(
@@ -29,4 +28,3 @@ class OCLCCatalogManager:
             return None
     
         return classifyResp.text
-        

--- a/processes/oclcCatalog.py
+++ b/processes/oclcCatalog.py
@@ -60,8 +60,9 @@ class CatalogProcess(CoreProcess):
 
     def processCatalogQuery(self, msgBody):
         message = json.loads(msgBody)
-        catalogManager = OCLCCatalogManager(message['oclcNo'])
-        catalogXML = catalogManager.queryCatalog()
+        oclcNo = message['oclcNo']
+        catalogManager = OCLCCatalogManager()
+        catalogXML = catalogManager.queryCatalog(oclcNo)
         if catalogXML:
             self.parseCatalogRecord(catalogXML, message['owiNo'])
 

--- a/tests/unit/test_oclcCatalog_manager.py
+++ b/tests/unit/test_oclcCatalog_manager.py
@@ -9,10 +9,9 @@ class TestOCLCCatalogManager:
     def testInstance(self, mocker):
         mocker.patch.dict('os.environ', {'OCLC_API_KEY': 'test_api_key'})
 
-        return OCLCCatalogManager(1)
+        return OCLCCatalogManager()
 
     def test_initializer(self, testInstance):
-        assert testInstance.oclcNo == 1
         assert testInstance.oclcKey == 'test_api_key'
         assert testInstance.attempts == 0
 
@@ -24,7 +23,7 @@ class TestOCLCCatalogManager:
         mockResponse.status_code = 200
         mockResponse.text = 'testClassifyRecord'
 
-        testResponse = testInstance.queryCatalog()
+        testResponse = testInstance.queryCatalog(1)
 
         assert testResponse == 'testClassifyRecord'
         mockRequest.get.assert_called_once_with(
@@ -40,7 +39,7 @@ class TestOCLCCatalogManager:
         mockResponse.status_code = 500
         mockResponse.text = 'testClassifyRecord'
 
-        testResponse = testInstance.queryCatalog()
+        testResponse = testInstance.queryCatalog(1)
 
         assert testResponse == None
         mockRequest.get.assert_called_once_with(
@@ -56,7 +55,7 @@ class TestOCLCCatalogManager:
         mockResponse.status_code = 200
         mockResponse.text = 'testClassifyRecord'
 
-        testResponse = testInstance.queryCatalog()
+        testResponse = testInstance.queryCatalog(1)
 
         assert testResponse == 'testClassifyRecord'
         mockRequest.get.assert_has_calls(
@@ -71,7 +70,7 @@ class TestOCLCCatalogManager:
         mockResponse.status_code = 200
         mockResponse.text = 'testClassifyRecord'
 
-        testResponse = testInstance.queryCatalog()
+        testResponse = testInstance.queryCatalog(1)
 
         assert testResponse == None
         mockRequest.get.assert_has_calls(

--- a/tests/unit/test_oclcCatalog_process.py
+++ b/tests/unit/test_oclcCatalog_process.py
@@ -69,8 +69,8 @@ class TestOCLCCatalogProcess:
 
         testInstance.processCatalogQuery('{"oclcNo": 1, "owiNo": 1}')
 
-        mockOCLC.assert_called_once_with(1)
-        mockManager.queryCatalog.assert_called_once()
+        mockOCLC.assert_called_once()
+        mockManager.queryCatalog.assert_called_once_with(1)
         mockParser.assert_called_once_with('testXML', 1)
 
     def test_processCatalogQuery_no_record_found(self, testInstance, mocker):
@@ -82,8 +82,8 @@ class TestOCLCCatalogProcess:
 
         testInstance.processCatalogQuery('{"oclcNo": "badID"}')
 
-        mockOCLC.assert_called_once_with('badID')
-        mockManager.queryCatalog.assert_called_once()
+        mockOCLC.assert_called_once()
+        mockManager.queryCatalog.assert_called_once_with('badID')
         mockParser.assert_not_called()
 
     def test_parseCatalogRecord_success(self, testInstance, mocker):


### PR DESCRIPTION
## Description
- This simple refactor passes the oclc no as a param to query the catalog rather than a param to instantiate the manager class

## Testing
`make test`