### PR TITLE
SFR-2079: Integration test make command

### DIFF
--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -1,4 +1,4 @@
-name: ETL Pipeline Tests (Pull Request)
+name: ETL Pipeline Pull Request Checks
 
 on:
   pull_request:
@@ -35,6 +35,9 @@ jobs:
           python -m pip install --upgrade pip wheel
           pip install -r dev-requirements.txt
           pip install -r requirements.txt
-      - name: Run test suite
+      - name: Run unit tests
         run: |
-          make test
+          make unit
+      - name: Run integration tests
+        run: |
+          make integration

--- a/.github/workflows/tests-unit.yaml
+++ b/.github/workflows/tests-unit.yaml
@@ -1,4 +1,4 @@
-name: ETL Pipeline Pull Request Checks
+name: ETL Pipeline Tests (Pull Request)
 
 on:
   pull_request:
@@ -38,6 +38,3 @@ jobs:
       - name: Run unit tests
         run: |
           make unit
-      - name: Run integration tests
-        run: |
-          make integration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - Added more logging to proxy API
 - Implement call to Worldcat to retrieve OCLC number
 - Refactor OCLC Catalog Manager
-- Added integration test step in Github Actions
+- Added make integration command
 
 ## Fixed
 - Resolved the format of fulfill endpoints in UofM manifests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Added more logging to proxy API
 - Implement call to Worldcat to retrieve OCLC number
 - Refactor OCLC Catalog Manager
+- Added integration test step in Github Actions
 
 ## Fixed
 - Resolved the format of fulfill endpoints in UofM manifests

--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,14 @@ compose_command = docker-compose --file $(compose_file)
 help:
 	@echo "make help"
 
-test: 
+unit: 
 	python -m pytest --cov-report term-missing --cov=. tests/unit
 
 allure-test:
 	python -m pytest --alluredir=./allure-results ./tests/unit
+
+integration: 
+	python -m pytest tests/integration
 
 up:
 	$(compose_command) up -d

--- a/README.md
+++ b/README.md
@@ -123,6 +123,12 @@ This will place an image `drb-etl-pipeline:latest` in your local docker instance
 
 When running a Docker image locally that interacts with other resources running on `localhost` it is necessary to supply a special URL to access them. Due to this it is generally helpful to define a unique `config` file for local docker testing. You may not wish to commit this file to git as it may contain secrets.
 
+### Testing
+
+To run the unit tests, run `make unit`.
+
+To run the integration tests, run `make integration`.
+
 ### Managing secrets
 
 To keep sensitive settings out of git, some secrets configuration must be done to run the cluster. To set up for running on your local machine, copy the `config/example.yaml` file and provide the necessary configuration (ask a colleague if you need some of the keys required there). Then provide the name of this file as the `--environment` argument when you run scripts.


### PR DESCRIPTION
## Description
- Adds integration test make command

## Testing
`make unit; make integration`


## TODO
- We will tackle integration tests and CI in a later phase of tech debt but not as part of the OCLC work. 