### PR TITLE
SFR-2066: Upgrade RabbitMQ Docker image to 3.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Implement call to Worldcat to retrieve OCLC number
 - Refactor OCLC Catalog Manager
 - Added make integration command
+- Upgrade RabbitMQ Docker image to 3.13
 
 ## Fixed
 - Resolved the format of fulfill endpoints in UofM manifests

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
 
   rabbitmq:
     container_name: drb_local_mq
-    image: rabbitmq:3.10
+    image: rabbitmq:3.13
     ports:
       - 5672:5672
     volumes:


### PR DESCRIPTION
## Description
- Upgrading RabbitMQ Docker image to latest release https://www.rabbitmq.com/release-information

## Testing
`docker compose up`

<img width="988" alt="Screenshot 2024-07-30 at 3 23 26 PM" src="https://github.com/user-attachments/assets/9f2f73e1-795b-4144-ac22-b53c09336e28">
