### PR TITLE
NO-REF: Remove index from adding new column migration

### DIFF
--- a/migrations/versions/54e57fb2e1c6_add_contract_source_to_records_and_items.py
+++ b/migrations/versions/54e57fb2e1c6_add_contract_source_to_records_and_items.py
@@ -17,8 +17,8 @@ depends_on = None
 
 
 def upgrade():
-    op.add_column('records', sa.Column('publisher_project_source', sa.Unicode, index=True))
-    op.add_column('items', sa.Column('publisher_project_source', sa.Unicode, index=True))
+    op.add_column('records', sa.Column('publisher_project_source', sa.Unicode))
+    op.add_column('items', sa.Column('publisher_project_source', sa.Unicode))
 
 
 def downgrade():


### PR DESCRIPTION
This PR removes the index from the migration to add the publisher_project_source field to the records and items table due to deadblocks occurring during database migration in the production environment.