### PR TITLE
NO-REF: Fix to readd API db client enter/exit functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Created local.yaml file to setup environment variables when running processes locally
 - Implemented OCLC other editions call
 - Added functionality for locally generating Counter 5 downloads reports to analytics folder
+- Readded enter and exit functions to API DB client
 
 ## 2024-08-06 -- v0.13.1
 ## Added

--- a/api/db.py
+++ b/api/db.py
@@ -18,6 +18,13 @@ class DBClient():
     def closeSession(self):
         self.session.close()
 
+    def __enter__(self):
+        self.createSession()
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_tb):
+        self.closeSession()
+
     def fetchSearchedWorks(self, ids):
         uuids = [i[0] for i in ids]
         editionIds = list(set(APIUtils.flatten([i[1] for i in ids])))

--- a/managers/db.py
+++ b/managers/db.py
@@ -35,15 +35,6 @@ class DBManager:
         except Exception as e:
             raise e
 
-
-    def __enter__(self):
-        self.generateEngine()
-        self.createSession()
-        return self
-
-    def __exit__(self, exc_type, exc_value, exc_tb):
-        self.closeConnection()
-
     def initializeDatabase(self):
         if not inspect(self.engine).has_table('works'):
             Base.metadata.create_all(self.engine)


### PR DESCRIPTION
## Description
- The API db client's enter and exit function were deleted as part of https://github.com/NYPL/drb-etl-pipeline/pull/321
- This change readds them but removes the enter and exit function from the db manager

## Testing
`make test`