### PR TITLE
SFR-2114: HathiTrust Fetch Data Files Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## Unreleased version -- v0.13.2
+## Added
 - Added auxiliary functions to build queries for OCLC search endpoints
 - Removing aggregation result print statement
 - Created local.yaml file to setup environment variables when running processes locally
@@ -8,6 +9,9 @@
 - Added functionality for locally generating Counter 5 downloads reports to analytics folder
 - Readded enter and exit functions to API DB client
 - Updated DevelopmentSetUpProcess with database migration method
+
+## Fixed
+- Changed HATHI_DATAFILES outdated link in development, example, and local yaml files 
 
 ## 2024-08-06 -- v0.13.1
 ## Added

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -29,7 +29,7 @@ FILE_ROUTING_KEY: sfrS3Files
 
 # HATHITRUST CONFIGURATION
 # HATHI_API_KEY and HATHI_API_SECRET must be configured as secrets
-HATHI_DATAFILES: https://www.hathitrust.org/filebrowser/download/244651
+HATHI_DATAFILES: https://www.hathitrust.org/files/hathifiles/hathi_file_list.json
 HATHI_API_ROOT: https://babel.hathitrust.org/cgi/htd
 
 # OCLC CONFIGURATION

--- a/config/example.yaml
+++ b/config/example.yaml
@@ -24,7 +24,7 @@ OCLC_QUEUE: xxx
 FILE_QUEUE: xxx
 
 # HATHITRUST CONFIGURATION
-HATHI_DATAFILES: https://www.hathitrust.org/filebrowser/download/244651
+HATHI_DATAFILES: https://www.hathitrust.org/files/hathifiles/hathi_file_list.json
 
 # OCLC CONFIGURATION
 OCLC_API_KEY: xxx

--- a/processes/developmentSetup.py
+++ b/processes/developmentSetup.py
@@ -37,7 +37,6 @@ class DevelopmentSetupProcess(CoreProcess):
         #Allow Database to be trashed when reinitializing local DevelopmentSetUp
         self.initializeDatabase()
 
-
         # Setup ElasticSearch index if necessary
         self.createElasticConnection()
         # Wait for ElasticSearch to be available


### PR DESCRIPTION
This PR was focused on fixing the `fetchHathiSampleData` method which raised an `IOError of Unable to load data files` so the other processes like the `ClusterProcess` don’t ever run in the `DevelopmentSetUpProcess` in the `local.yaml` files. The error came from the `HATHI_DATAFILES` link being outdated and giving a 404 error: [https://www.hathitrust.org/filebrowser/download/244651](). I updated the link to the Hathitrust dataset file in the qa and prod yaml files which includes multiple datasets in it. To adjust the amount of Hathitrust books ingested the conditional break statement at the end of the `DevelopmentSetUpProcess` can be adjusted.