### PR TITLE
SFR-2121: Adding citation endpoint error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Refactored works and editions APIs and added error handling
 - Generalize data aggregation within analytics folder
 - Updated README release steps
+- Added error handling to citation API
 
 ## 2024-08-06 -- v0.13.1
 ## Added

--- a/api/blueprints/drbCitation.py
+++ b/api/blueprints/drbCitation.py
@@ -17,13 +17,13 @@ def get_citation(uuid):
     response_type = 'citation'
 
     try:
+        citation_formats = request.args.get('format', default='')
+        formats = set(citation_formats.split(','))
+
+        if not formats.issubset(citation_set):
+            return APIUtils.formatResponseObject(400, response_type, { 'message': 'Citation formats are invalid' })
+    
         with DBClient(current_app.config['DB_CLIENT']) as db_client:
-            citation_formats = request.args.get('format')
-            formats = set(citation_formats.split(','))
-
-            if not formats.issubset(citation_set):
-                return APIUtils.formatResponseObject(400, response_type, { 'message': 'Citation formats are invalid' })
-
             work_to_cite = db_client.fetchSingleWork(uuid)
 
             if not work_to_cite:

--- a/api/blueprints/drbCitation.py
+++ b/api/blueprints/drbCitation.py
@@ -9,57 +9,44 @@ logger = createLog(__name__)
 
 citation = Blueprint('citation', __name__, url_prefix='/citation')
 
-citationSet = {'mla', 'apa', 'chicago'}
+citation_set = {'mla', 'apa', 'chicago'}
 
 @citation.route('/<uuid>', methods=['GET'])
-def citationFetch(uuid):
-    logger.info('Fetching Identifier {}'.format(uuid))
+def get_citation(uuid):
+    logger.info(f'Getting citation for work id {uuid}')
+    response_type = 'citation'
 
-    dbClient = DBClient(current_app.config['DB_CLIENT'])
-    dbClient.createSession()
+    try:
+        with DBClient(current_app.config['DB_CLIENT']) as db_client:
+            searchParams = APIUtils.normalizeQueryParams(request.args)
+            logger.debug(searchParams)
 
-    searchParams = APIUtils.normalizeQueryParams(request.args)
-    logger.debug(searchParams)
+            citation_formats = request.args.get('format')
+            formats = set(citation_formats.split(','))
 
-    citeFormats = request.args.get('format') #Default value is None if no arguments set
-    formatList = citeFormats.split(',')
-    formatListSet = set(formatList)
-    logger.debug(formatListSet)
+            if not formats.issubset(citation_set):
+                return APIUtils.formatResponseObject(400, response_type, { 'message': 'Citation formats are invalid' })
 
-    if formatListSet.issubset(citationSet) == False:
-        logger.warning('Page not found')
-        return APIUtils.formatResponseObject(
-                400, 'pageNotFound', {'message': 'Need to specify citation format'}
-            )
+            work_to_cite = db_client.fetchSingleWork(uuid)
 
-    citationWork = dbClient.fetchSingleWork(uuid)
-    
-    outputCitations = {}
+            if not work_to_cite:
+                return APIUtils.formatResponseObject(404, response_type, { 'message': f'No work found with id {uuid}' })
+            
+            output_citations = {}
 
-    for format in formatListSet:
-        logger.info(format)
-        if format == 'mla':
-            newCite = mlaGenerator(citationWork)
-        outputCitations[format] = newCite
+            for format in formats:
+                if format == 'mla':
+                    mla_citation = mla_generator(work_to_cite)
+                    output_citations[format] = mla_citation
 
-    if citationWork:
-        statusCode = 200
-        responseBody = outputCitations
-    else:
-        statusCode = 404
-        responseBody = {
-            'message': f'Unable to locate work with UUID {uuid}'
-        }
+            return APIUtils.formatResponseObject(200, response_type, output_citations)
+    except Exception as e:
+        logger.error(e)
+        return APIUtils.formatResponseObject(500, response_type, { 'message': f'Unable to get citation for work with id {uuid}' })
 
-    logger.info(f'Citation Fetch {statusCode} on /citation/{uuid}')
 
-    dbClient.closeSession()
-
-    return APIUtils.formatResponseObject(
-        statusCode, 'citation', responseBody
-    )
-
-def mlaGenerator(citationWork):
+# TODO: refactor, apply snake_case, and move into a seperate citation utils file
+def mla_generator(citationWork):
     if citationWork:
         # Made title lowercase for consistency when finding this info in the database
         if citationWork.title.lower() == "the bible":

--- a/api/blueprints/drbCitation.py
+++ b/api/blueprints/drbCitation.py
@@ -18,9 +18,6 @@ def get_citation(uuid):
 
     try:
         with DBClient(current_app.config['DB_CLIENT']) as db_client:
-            searchParams = APIUtils.normalizeQueryParams(request.args)
-            logger.debug(searchParams)
-
             citation_formats = request.args.get('format')
             formats = set(citation_formats.split(','))
 

--- a/tests/unit/test_api_citation_blueprint.py
+++ b/tests/unit/test_api_citation_blueprint.py
@@ -2,13 +2,13 @@ from flask import Flask
 import pytest
 from datetime import date
 
-from api.blueprints.drbCitation import citationFetch
+from api.blueprints.drbCitation import get_citation
 from api.utils import APIUtils
 
 
 class TestCitationBlueprint:
     @pytest.fixture
-    def mockUtils(self, mocker):
+    def mock_utils(self, mocker):
         return mocker.patch.multiple(
             APIUtils,
             formatResponseObject=mocker.DEFAULT,
@@ -16,472 +16,479 @@ class TestCitationBlueprint:
         )
 
     @pytest.fixture
-    def testApp(self):
-        flaskApp = Flask('test')
-        flaskApp.config['DB_CLIENT'] = 'testDBClient'
+    def test_app(self):
+        flask_app = Flask('test')
+        flask_app.config['DB_CLIENT'] = 'testDBClient'
 
-        return flaskApp
+        return flask_app
 
 # Tests for when work uuid and format values are set correctly
 
     #* Bible work before 1900 successful test
-    def test_citationFetch_bible_pre1900_success(self, mockUtils, testApp, mocker):
-            mockDB = mocker.MagicMock()
-            mockDBClient = mocker.patch('api.blueprints.drbCitation.DBClient')
-            mockDBClient.return_value = mockDB
+    def test_get_citation_bible_pre1900_success(self, mock_utils, test_app, mocker):
+        mock_db = mocker.MagicMock()
+        mock_db.__enter__.return_value = mock_db
+        mock_db_client = mocker.patch('api.blueprints.drbCitation.DBClient', return_value=mock_db)
 
-            editionMocks = [mocker.MagicMock(publication_date=date(1800, 1, 1), publication_place='testPubPlace')]
+        edition_mocks = [mocker.MagicMock(publication_date=date(1800, 1, 1), publication_place='testPubPlace')]
 
-            mockDB.fetchSingleWork.return_value = mocker.MagicMock(title='The Bible', editions=editionMocks)
-            
-            mockUtils['formatResponseObject'].return_value\
-                = 'citationResponse'
+        mock_db.fetchSingleWork.return_value = mocker.MagicMock(title='The Bible', editions=edition_mocks)
+        
+        mock_utils['formatResponseObject'].return_value\
+            = 'citationResponse'
 
-            with testApp.test_request_context('/?format=mla'):
-                testAPIResponse = citationFetch('testUUID')
+        with test_app.test_request_context('/?format=mla'):
+            test_api_response = get_citation('testUUID')
 
-                assert testAPIResponse == 'citationResponse'
-                mockDBClient.assert_called_once_with('testDBClient')
+            assert test_api_response == 'citationResponse'
+            mock_db_client.assert_called_once_with('testDBClient')
 
-                mockUtils['normalizeQueryParams'].assert_called_once()
+            mock_utils['normalizeQueryParams'].assert_called_once()
 
-                mockUtils['formatResponseObject'].assert_called_once_with(
-                    200, 'citation', {'mla': 'The Bible. Unknown version, testPubPlace, 1800.'}
-                )
+            mock_utils['formatResponseObject'].assert_called_once_with(
+                200, 'citation', {'mla': 'The Bible. Unknown version, testPubPlace, 1800.'}
+            )
 
-    #* Bible work after 1900 successful test
-    def test_citationFetch_bible_post1900_success(self, mockUtils, testApp, mocker):
-            mockDB = mocker.MagicMock()
-            mockDBClient = mocker.patch('api.blueprints.drbCitation.DBClient')
-            mockDBClient.return_value = mockDB
+    def test_get_citation_bible_post1900_success(self, mock_utils, test_app, mocker):
+        mock_db = mocker.MagicMock()
+        mock_db.__enter__.return_value = mock_db
+        mock_db_client = mocker.patch('api.blueprints.drbCitation.DBClient', return_value=mock_db)
 
-            editionMocks = [mocker.MagicMock(publication_date=date(2022, 1, 1), publishers=[{'name': 'NYPL'}])]
+        edition_mocks = [mocker.MagicMock(publication_date=date(2022, 1, 1), publishers=[{'name': 'NYPL'}])]
 
-            mockDB.fetchSingleWork.return_value = mocker.MagicMock(title='The Bible', editions=editionMocks)
-            
-            mockUtils['formatResponseObject'].return_value\
-                = 'citationResponse'
+        mock_db.fetchSingleWork.return_value = mocker.MagicMock(title='The Bible', editions=edition_mocks)
+        
+        mock_utils['formatResponseObject'].return_value\
+            = 'citationResponse'
 
-            with testApp.test_request_context('/?format=mla'):
-                testAPIResponse = citationFetch('testUUID')
+        with test_app.test_request_context('/?format=mla'):
+            test_api_response = get_citation('testUUID')
 
-                assert testAPIResponse == 'citationResponse'
-                mockDBClient.assert_called_once_with('testDBClient')
+            assert test_api_response == 'citationResponse'
+            mock_db_client.assert_called_once_with('testDBClient')
 
-                mockUtils['normalizeQueryParams'].assert_called_once()
+            mock_utils['normalizeQueryParams'].assert_called_once()
 
-                mockUtils['formatResponseObject'].assert_called_once_with(
-                    200, 'citation', {'mla': 'The Bible. Unknown version, NYPL, 2022.'}
-                )
+            mock_utils['formatResponseObject'].assert_called_once_with(
+                200, 'citation', {'mla': 'The Bible. Unknown version, NYPL, 2022.'}
+            )
 
-    #* Government work successful test
-    def test_citationFetch_post1900_gov_success(self, mockUtils, testApp, mocker):
-            mockDB = mocker.MagicMock()
-            mockDBClient = mocker.patch('api.blueprints.drbCitation.DBClient')
-            mockDBClient.return_value = mockDB
+    def test_get_citation_post1900_gov_success(self, mock_utils, test_app, mocker):
+        mock_db = mocker.MagicMock()
+        mock_db.__enter__.return_value = mock_db
+        mock_db_client = mocker.patch('api.blueprints.drbCitation.DBClient', return_value=mock_db)
 
-            editionMocks = [mocker.MagicMock(publication_date=date(2022, 1, 1), publishers=[{'name': 'NYPL'}], \
-                            measurements = [{'type': 'government_document', 'value': '1'}])]
+        edition_mocks = [mocker.MagicMock(publication_date=date(2022, 1, 1), publishers=[{'name': 'NYPL'}], \
+                        measurements = [{'type': 'government_document', 'value': '1'}])]
 
-            mockDB.fetchSingleWork.return_value = mocker.MagicMock(title='State of the Union Address', \
-                                                authors=[{'name': 'United States. Test Agency'}], \
-                                                editions = editionMocks) \
-                                                
-            
-            mockUtils['formatResponseObject'].return_value\
-                = 'citationResponse'
+        mock_db.fetchSingleWork.return_value = mocker.MagicMock(title='State of the Union Address', \
+                                            authors=[{'name': 'United States. Test Agency'}], \
+                                            editions = edition_mocks) \
+                                            
+        
+        mock_utils['formatResponseObject'].return_value\
+            = 'citationResponse'
 
-            with testApp.test_request_context('/?format=mla'):
-                testAPIResponse = citationFetch('testUUID')
+        with test_app.test_request_context('/?format=mla'):
+            test_api_response = get_citation('testUUID')
 
-                assert testAPIResponse == 'citationResponse'
-                mockDBClient.assert_called_once_with('testDBClient')
+            assert test_api_response == 'citationResponse'
+            mock_db_client.assert_called_once_with('testDBClient')
 
-                mockUtils['normalizeQueryParams'].assert_called_once()
+            mock_utils['normalizeQueryParams'].assert_called_once()
 
-                mockUtils['formatResponseObject'].assert_called_once_with(
-                    200, 'citation', {'mla': ' '.join('United States, Test Agency. State of the Union Address. \
-                                    NYPL, 2022.'.split())}
-                )
+            mock_utils['formatResponseObject'].assert_called_once_with(
+                200, 'citation', {'mla': ' '.join('United States, Test Agency. State of the Union Address. \
+                                NYPL, 2022.'.split())}
+            )
 
-    #* Translated work prepared by an editor successful test
-    def test_citationFetch_trans_editor_success(self, mockUtils, testApp, mocker):
-            mockDB = mocker.MagicMock()
-            mockDBClient = mocker.patch('api.blueprints.drbCitation.DBClient')
-            mockDBClient.return_value = mockDB
+    def test_get_citation_trans_editor_success(self, mock_utils, test_app, mocker):
+        mock_db = mocker.MagicMock()
+        mock_db.__enter__.return_value = mock_db
+        mock_db_client = mocker.patch('api.blueprints.drbCitation.DBClient', return_value=mock_db)
 
-            editionMocks = [mocker.MagicMock(publication_date=date(1800, 1, 1), publication_place='testPubPlace', \
-                            measurements = [{'type': 'government_document', 'value': '0'}])]
-
-            mockDB.fetchSingleWork.return_value = mocker.MagicMock(title='testTitle', \
-                                                contributors = [{'roles': 'translator', 'name': 'transLastName, transFirstName'}, \
-                                                {'roles': 'editor', 'name': 'editLastName, editFirstName'}], \
-                                                editions = editionMocks) 
-                                                
-            
-            mockUtils['formatResponseObject'].return_value\
-                = 'citationResponse'
-
-            with testApp.test_request_context('/?format=mla'):
-                testAPIResponse = citationFetch('testUUID')
-
-                assert testAPIResponse == 'citationResponse'
-                mockDBClient.assert_called_once_with('testDBClient')
-
-                mockUtils['normalizeQueryParams'].assert_called_once()
-
-                mockUtils['formatResponseObject'].assert_called_once_with(
-                    200, 'citation', {'mla': ' '.join('testTitle. Translated by transFirstName \
-                                    transLastName, edited by editFirstName editLastName, \
-                                    testPubPlace, 1800.'.split())}
-                )
-
-    #* Translated work not prepared by editor successful test
-    def test_citationFetch_trans_success(self, mockUtils, testApp, mocker):
-        mockDB = mocker.MagicMock()
-        mockDBClient = mocker.patch('api.blueprints.drbCitation.DBClient')
-        mockDBClient.return_value = mockDB
-
-        editionMocks = [mocker.MagicMock(publication_date=date(1800, 1, 1), publication_place='testPubPlace', \
+        edition_mocks = [mocker.MagicMock(publication_date=date(1800, 1, 1), publication_place='testPubPlace', \
                         measurements = [{'type': 'government_document', 'value': '0'}])]
 
-        mockDB.fetchSingleWork.return_value = mocker.MagicMock(title='testTitle', \
+        mock_db.fetchSingleWork.return_value = mocker.MagicMock(title='testTitle', \
+                                            contributors = [{'roles': 'translator', 'name': 'transLastName, transFirstName'}, \
+                                            {'roles': 'editor', 'name': 'editLastName, editFirstName'}], \
+                                            editions = edition_mocks) 
+                                            
+        
+        mock_utils['formatResponseObject'].return_value\
+            = 'citationResponse'
+
+        with test_app.test_request_context('/?format=mla'):
+            test_api_response = get_citation('testUUID')
+
+            assert test_api_response == 'citationResponse'
+            mock_db_client.assert_called_once_with('testDBClient')
+
+            mock_utils['normalizeQueryParams'].assert_called_once()
+
+            mock_utils['formatResponseObject'].assert_called_once_with(
+                200, 'citation', {'mla': ' '.join('testTitle. Translated by transFirstName \
+                                transLastName, edited by editFirstName editLastName, \
+                                testPubPlace, 1800.'.split())}
+            )
+
+    def test_get_citation_trans_success(self, mock_utils, test_app, mocker):
+        mock_db = mocker.MagicMock()
+        mock_db.__enter__.return_value = mock_db
+        mock_db_client = mocker.patch('api.blueprints.drbCitation.DBClient', return_value=mock_db)
+
+        edition_mocks = [mocker.MagicMock(publication_date=date(1800, 1, 1), publication_place='testPubPlace', \
+                        measurements = [{'type': 'government_document', 'value': '0'}])]
+
+        mock_db.fetchSingleWork.return_value = mocker.MagicMock(title='testTitle', \
                                             contributors = [{'roles': 'translator', 'name': 'transLastName, transFirstName'}], \
-                                            editions = editionMocks) 
+                                            editions = edition_mocks) 
                                                 
             
-        mockUtils['formatResponseObject'].return_value\
+        mock_utils['formatResponseObject'].return_value\
                 = 'citationResponse'
 
-        with testApp.test_request_context('/?format=mla'):
-            testAPIResponse = citationFetch('testUUID')
+        with test_app.test_request_context('/?format=mla'):
+            test_api_response = get_citation('testUUID')
 
-            assert testAPIResponse == 'citationResponse'
-            mockDBClient.assert_called_once_with('testDBClient')
+            assert test_api_response == 'citationResponse'
+            mock_db_client.assert_called_once_with('testDBClient')
 
-            mockUtils['normalizeQueryParams'].assert_called_once()
+            mock_utils['normalizeQueryParams'].assert_called_once()
 
-            mockUtils['formatResponseObject'].assert_called_once_with(
+            mock_utils['formatResponseObject'].assert_called_once_with(
                 200, 'citation', {'mla': ' '.join('testTitle. Translated by transFirstName \
                                 transLastName, \
                                 testPubPlace, 1800.'.split())}
                 )
     
-    #* Single edition work successful test
-    def test_citationFetch_single_edit_work_success(self, mockUtils, testApp, mocker):
-        mockDB = mocker.MagicMock()
-        mockDBClient = mocker.patch('api.blueprints.drbCitation.DBClient')
-        mockDBClient.return_value = mockDB
+    def test_get_citation_single_edit_work_success(self, mock_utils, test_app, mocker):
+        mock_db = mocker.MagicMock()
+        mock_db.__enter__.return_value = mock_db
+        mock_db_client = mocker.patch('api.blueprints.drbCitation.DBClient', return_value=mock_db)
 
-        editionMocks = [mocker.MagicMock(publication_date=date(1800, 1, 1), publication_place='testPubPlace', \
+        edition_mocks = [mocker.MagicMock(publication_date=date(1800, 1, 1), publication_place='testPubPlace', \
                         edition_statement = None, measurements = [{'type': 'government_document', 'value': '0'}])]
 
-        mockDB.fetchSingleWork.return_value = mocker.MagicMock(title='testTitle', \
-                                            editions = editionMocks) 
+        mock_db.fetchSingleWork.return_value = mocker.MagicMock(title='testTitle', \
+                                            editions = edition_mocks) 
                                                 
-        mockUtils['formatResponseObject'].return_value\
+        mock_utils['formatResponseObject'].return_value\
                 = 'citationResponse'
 
-        with testApp.test_request_context('/?format=mla'):
-            testAPIResponse = citationFetch('testUUID')
+        with test_app.test_request_context('/?format=mla'):
+            test_api_response = get_citation('testUUID')
 
-            assert testAPIResponse == 'citationResponse'
-            mockDBClient.assert_called_once_with('testDBClient')
+            assert test_api_response == 'citationResponse'
+            mock_db_client.assert_called_once_with('testDBClient')
 
-            mockUtils['normalizeQueryParams'].assert_called_once()
+            mock_utils['normalizeQueryParams'].assert_called_once()
 
-            mockUtils['formatResponseObject'].assert_called_once_with(
+            mock_utils['formatResponseObject'].assert_called_once_with(
                 200, 'citation', {'mla': ' '.join('testTitle. \
                                 testPubPlace, 1800.'.split())}
                 )
 
-    #* Multiple edition work successful test
-    def test_citationFetch_mult_edit_success(self, mockUtils, testApp, mocker):
-        mockDB = mocker.MagicMock()
-        mockDBClient = mocker.patch('api.blueprints.drbCitation.DBClient')
-        mockDBClient.return_value = mockDB
+    def test_get_citation_mult_edit_success(self, mock_utils, test_app, mocker):
+        mock_db = mocker.MagicMock()
+        mock_db.__enter__.return_value = mock_db
+        mock_db_client = mocker.patch('api.blueprints.drbCitation.DBClient', return_value=mock_db)
 
-        editionMocks = [mocker.MagicMock(publication_date=date(2022, 1, 1), publishers=[{'name': 'NYPL'}], \
+        edition_mocks = [mocker.MagicMock(publication_date=date(2022, 1, 1), publishers=[{'name': 'NYPL'}], \
                         edition_statement = '2nd edition.', measurements = [{'type': 'government_document', 'value': '0'}])]
 
-        mockDB.fetchSingleWork.return_value = mocker.MagicMock(title='testTitle', \
-                                            editions = editionMocks)           
+        mock_db.fetchSingleWork.return_value = mocker.MagicMock(title='testTitle', \
+                                            editions = edition_mocks)           
             
-        mockUtils['formatResponseObject'].return_value\
+        mock_utils['formatResponseObject'].return_value\
                 = 'citationResponse'
 
-        with testApp.test_request_context('/?format=mla'):
-            testAPIResponse = citationFetch('testUUID')
+        with test_app.test_request_context('/?format=mla'):
+            test_api_response = get_citation('testUUID')
 
-            assert testAPIResponse == 'citationResponse'
-            mockDBClient.assert_called_once_with('testDBClient')
+            assert test_api_response == 'citationResponse'
+            mock_db_client.assert_called_once_with('testDBClient')
 
-            mockUtils['normalizeQueryParams'].assert_called_once()
+            mock_utils['normalizeQueryParams'].assert_called_once()
 
-            mockUtils['formatResponseObject'].assert_called_once_with(
+            mock_utils['formatResponseObject'].assert_called_once_with(
                 200, 'citation', {'mla': ' '.join('testTitle. 2nd edition., \
                                 NYPL, 2022.'.split())}
                 )
 
-    #* Test 1 for work with one author
-    def test_citationFetch_one_author_work(self, mockUtils, testApp, mocker):
-        mockDB = mocker.MagicMock()
-        mockDBClient = mocker.patch('api.blueprints.drbCitation.DBClient')
-        mockDBClient.return_value = mockDB
+    def test_get_citation_one_author_work(self, mock_utils, test_app, mocker):
+        mock_db = mocker.MagicMock()
+        mock_db.__enter__.return_value = mock_db
+        mock_db_client = mocker.patch('api.blueprints.drbCitation.DBClient', return_value=mock_db)
 
-        editionMocks = [mocker.MagicMock(publication_date=date(1800, 1, 1), publication_place='testPubPlace', \
+        edition_mocks = [mocker.MagicMock(publication_date=date(1800, 1, 1), publication_place='testPubPlace', \
                         measurements = [{'type': 'government_document', 'value': '0'}])]
 
-        mockDB.fetchSingleWork.return_value = mocker.MagicMock(title='testTitle', \
+        mock_db.fetchSingleWork.return_value = mocker.MagicMock(title='testTitle', \
                                             authors = [{'name': 'testLastName, testFirstName'}], \
                                             contributors = [{'roles': 'editor', 'name': 'editLastName, editFirstName'}], \
-                                            editions = editionMocks) 
+                                            editions = edition_mocks) 
                                                 
             
-        mockUtils['formatResponseObject'].return_value\
+        mock_utils['formatResponseObject'].return_value\
                 = 'citationResponse'
 
-        with testApp.test_request_context('/?format=mla'):
-            testAPIResponse = citationFetch('testUUID')
+        with test_app.test_request_context('/?format=mla'):
+            test_api_response = get_citation('testUUID')
 
-            assert testAPIResponse == 'citationResponse'
-            mockDBClient.assert_called_once_with('testDBClient')
+            assert test_api_response == 'citationResponse'
+            mock_db_client.assert_called_once_with('testDBClient')
 
-            mockUtils['normalizeQueryParams'].assert_called_once()
+            mock_utils['normalizeQueryParams'].assert_called_once()
 
-            mockUtils['formatResponseObject'].assert_called_once_with(
+            mock_utils['formatResponseObject'].assert_called_once_with(
                 200, 'citation', {'mla': ' '.join('testLastName, testFirstName. testTitle, \
                                 edited by editFirstName editLastName, \
                                 testPubPlace, 1800.'.split())}
                 )
     
-    #* Test 2 for work with one author
-    def test_citationFetch_one_author_work2(self, mockUtils, testApp, mocker):
-        mockDB = mocker.MagicMock()
-        mockDBClient = mocker.patch('api.blueprints.drbCitation.DBClient')
-        mockDBClient.return_value = mockDB
+    def test_get_citation_one_author_work2(self, mock_utils, test_app, mocker):
+        mock_db = mocker.MagicMock()
+        mock_db.__enter__.return_value = mock_db
+        mock_db_client = mocker.patch('api.blueprints.drbCitation.DBClient', return_value=mock_db)
 
-        editionMocks = [mocker.MagicMock(publication_date=date(2022, 1, 1), publishers=[{'name': 'NYPL'}], \
+        edition_mocks = [mocker.MagicMock(publication_date=date(2022, 1, 1), publishers=[{'name': 'NYPL'}], \
                         edition_statement = None, measurements = [{'type': 'government_document', 'value': '0'}])]
 
-        mockDB.fetchSingleWork.return_value = mocker.MagicMock(title='testTitle', \
+        mock_db.fetchSingleWork.return_value = mocker.MagicMock(title='testTitle', \
                                             authors = [{'name': 'testLastName, testFirstName'}], \
-                                            editions = editionMocks) 
+                                            editions = edition_mocks) 
                                                 
-        mockUtils['formatResponseObject'].return_value\
+        mock_utils['formatResponseObject'].return_value\
                 = 'citationResponse'
 
-        with testApp.test_request_context('/?format=mla'):
-            testAPIResponse = citationFetch('testUUID')
+        with test_app.test_request_context('/?format=mla'):
+            test_api_response = get_citation('testUUID')
 
-            assert testAPIResponse == 'citationResponse'
-            mockDBClient.assert_called_once_with('testDBClient')
+            assert test_api_response == 'citationResponse'
+            mock_db_client.assert_called_once_with('testDBClient')
 
-            mockUtils['normalizeQueryParams'].assert_called_once()
+            mock_utils['normalizeQueryParams'].assert_called_once()
 
-            mockUtils['formatResponseObject'].assert_called_once_with(
+            mock_utils['formatResponseObject'].assert_called_once_with(
                 200, 'citation', {'mla': ' '.join('testLastName, testFirstName. testTitle. \
                                 NYPL, 2022.'.split())}
                 )
-    #* Test for work with corporate author/organization
-    def test_citationFetch_corporate_work(self, mockUtils, testApp, mocker):
-        mockDB = mocker.MagicMock()
-        mockDBClient = mocker.patch('api.blueprints.drbCitation.DBClient')
-        mockDBClient.return_value = mockDB
 
-        editionMocks = [mocker.MagicMock(publication_date=date(2022, 1, 1), publishers=[{'name': 'NYPL'}], \
+    def test_get_citation_corporate_work(self, mock_utils, test_app, mocker):
+        mock_db = mocker.MagicMock()
+        mock_db.__enter__.return_value = mock_db
+        mock_db_client = mocker.patch('api.blueprints.drbCitation.DBClient', return_value=mock_db)
+
+        edition_mocks = [mocker.MagicMock(publication_date=date(2022, 1, 1), publishers=[{'name': 'NYPL'}], \
                         edition_statement = None, measurements = [{'type': 'government_document', 'value': '0'}])]
 
-        mockDB.fetchSingleWork.return_value = mocker.MagicMock(title='testTitle', \
+        mock_db.fetchSingleWork.return_value = mocker.MagicMock(title='testTitle', \
                                             authors = [{'name': 'NYPL'}], \
-                                            editions = editionMocks) 
+                                            editions = edition_mocks) 
                                                 
-        mockUtils['formatResponseObject'].return_value\
+        mock_utils['formatResponseObject'].return_value\
                 = 'citationResponse'
 
-        with testApp.test_request_context('/?format=mla'):
-            testAPIResponse = citationFetch('testUUID')
+        with test_app.test_request_context('/?format=mla'):
+            test_api_response = get_citation('testUUID')
 
-            assert testAPIResponse == 'citationResponse'
-            mockDBClient.assert_called_once_with('testDBClient')
+            assert test_api_response == 'citationResponse'
+            mock_db_client.assert_called_once_with('testDBClient')
 
-            mockUtils['normalizeQueryParams'].assert_called_once()
+            mock_utils['normalizeQueryParams'].assert_called_once()
 
-            mockUtils['formatResponseObject'].assert_called_once_with(
+            mock_utils['formatResponseObject'].assert_called_once_with(
                 200, 'citation', {'mla': ' '.join('testTitle. \
                                 NYPL, 2022.'.split())}
                 )
 
-    #* Test 1 for work with two authors
-    def test_citationFetch__two_authors_work(self, mockUtils, testApp, mocker):
-        mockDB = mocker.MagicMock()
-        mockDBClient = mocker.patch('api.blueprints.drbCitation.DBClient')
-        mockDBClient.return_value = mockDB
+    def test_get_citation__two_authors_work(self, mock_utils, test_app, mocker):
+        mock_db = mocker.MagicMock()
+        mock_db.__enter__.return_value = mock_db
+        mock_db_client = mocker.patch('api.blueprints.drbCitation.DBClient', return_value=mock_db)
 
-        editionMocks = [mocker.MagicMock(publication_date=date(1800, 1, 1), publication_place='testPubPlace', \
+        edition_mocks = [mocker.MagicMock(publication_date=date(1800, 1, 1), publication_place='testPubPlace', \
                         measurements = [{'type': 'government_document', 'value': '0'}])]
 
-        mockDB.fetchSingleWork.return_value = mocker.MagicMock(title='testTitle', \
+        mock_db.fetchSingleWork.return_value = mocker.MagicMock(title='testTitle', \
                                             authors = [{'name': 'testLastName, testFirstName'}, \
                                             {'name': 'testLastName2, testFirstName2'}], \
                                             contributors = [{'roles': 'editor', 'name': 'editLastName, editFirstName'}], \
-                                            editions = editionMocks) 
+                                            editions = edition_mocks) 
                                                 
             
-        mockUtils['formatResponseObject'].return_value\
+        mock_utils['formatResponseObject'].return_value\
                 = 'citationResponse'
 
-        with testApp.test_request_context('/?format=mla'):
-            testAPIResponse = citationFetch('testUUID')
+        with test_app.test_request_context('/?format=mla'):
+            test_api_response = get_citation('testUUID')
 
-            assert testAPIResponse == 'citationResponse'
-            mockDBClient.assert_called_once_with('testDBClient')
+            assert test_api_response == 'citationResponse'
+            mock_db_client.assert_called_once_with('testDBClient')
 
-            mockUtils['normalizeQueryParams'].assert_called_once()
+            mock_utils['normalizeQueryParams'].assert_called_once()
 
-            mockUtils['formatResponseObject'].assert_called_once_with(
+            mock_utils['formatResponseObject'].assert_called_once_with(
                 200, 'citation', {'mla': ' '.join('testLastName, testFirstName, and testFirstName2 testLastName2. \
                                 testTitle, edited by editFirstName editLastName, \
                                 testPubPlace, 1800.'.split())}
                 )
     
-    #* Test 2 for works with two authors
-    def test_citationFetch_two_authors_work2(self, mockUtils, testApp, mocker):
-        mockDB = mocker.MagicMock()
-        mockDBClient = mocker.patch('api.blueprints.drbCitation.DBClient')
-        mockDBClient.return_value = mockDB
+    def test_get_citation_two_authors_work2(self, mock_utils, test_app, mocker):
+        mock_db = mocker.MagicMock()
+        mock_db.__enter__.return_value = mock_db
+        mock_db_client = mocker.patch('api.blueprints.drbCitation.DBClient', return_value=mock_db)
 
-        editionMocks = [mocker.MagicMock(publication_date=date(2022, 1, 1), publishers=[{'name': 'NYPL'}], \
+        edition_mocks = [mocker.MagicMock(publication_date=date(2022, 1, 1), publishers=[{'name': 'NYPL'}], \
                         edition_statement = '2nd edition.', \
                         measurements = [{'type': 'government_document', 'value': '0'}])]
 
-        mockDB.fetchSingleWork.return_value = mocker.MagicMock(title='testTitle', authors = [{'name': 'testLastName, testFirstName'}, \
+        mock_db.fetchSingleWork.return_value = mocker.MagicMock(title='testTitle', authors = [{'name': 'testLastName, testFirstName'}, \
                                             {'name': 'testLastName2, testFirstName2'}], \
-                                            editions = editionMocks)           
+                                            editions = edition_mocks)           
             
-        mockUtils['formatResponseObject'].return_value\
+        mock_utils['formatResponseObject'].return_value\
                 = 'citationResponse'
 
-        with testApp.test_request_context('/?format=mla'):
-            testAPIResponse = citationFetch('testUUID')
+        with test_app.test_request_context('/?format=mla'):
+            test_api_response = get_citation('testUUID')
 
-            assert testAPIResponse == 'citationResponse'
-            mockDBClient.assert_called_once_with('testDBClient')
+            assert test_api_response == 'citationResponse'
+            mock_db_client.assert_called_once_with('testDBClient')
 
-            mockUtils['normalizeQueryParams'].assert_called_once()
+            mock_utils['normalizeQueryParams'].assert_called_once()
 
-            mockUtils['formatResponseObject'].assert_called_once_with(
+            mock_utils['formatResponseObject'].assert_called_once_with(
                 200, 'citation', {'mla': ' '.join('testLastName, testFirstName, and testFirstName2 testLastName2. \
                                 testTitle. 2nd edition., \
                                 NYPL, 2022.'.split())}
                 )
 
-    #* Test 1 for work with three authors
-    def test_citationFetch__three_authors_work(self, mockUtils, testApp, mocker):
-        mockDB = mocker.MagicMock()
-        mockDBClient = mocker.patch('api.blueprints.drbCitation.DBClient')
-        mockDBClient.return_value = mockDB
+    def test_get_citation_three_authors_work(self, mock_utils, test_app, mocker):
+        mock_db = mocker.MagicMock()
+        mock_db.__enter__.return_value = mock_db
+        mock_db_client = mocker.patch('api.blueprints.drbCitation.DBClient', return_value=mock_db)
 
-        editionMocks = [mocker.MagicMock(publication_date=date(1800, 1, 1), publication_place='testPubPlace', \
+        edition_mocks = [mocker.MagicMock(publication_date=date(1800, 1, 1), publication_place='testPubPlace', \
                         measurements = [{'type': 'government_document', 'value': '0'}])]
 
-        mockDB.fetchSingleWork.return_value = mocker.MagicMock(title='testTitle', \
+        mock_db.fetchSingleWork.return_value = mocker.MagicMock(title='testTitle', \
                                             authors = [{'name': 'testLastName, testFirstName'}, \
                                             {'name': 'testLastName2, testFirstName2'}, \
                                             {'name': 'testLastName3, testFirstName3'}], \
                                             contributors = [{'roles': 'editor', 'name': 'editLastName, editFirstName'}], \
-                                            editions = editionMocks) 
+                                            editions = edition_mocks) 
                                                 
             
-        mockUtils['formatResponseObject'].return_value\
+        mock_utils['formatResponseObject'].return_value\
                 = 'citationResponse'
 
-        with testApp.test_request_context('/?format=mla'):
-            testAPIResponse = citationFetch('testUUID')
+        with test_app.test_request_context('/?format=mla'):
+            test_api_response = get_citation('testUUID')
 
-            assert testAPIResponse == 'citationResponse'
-            mockDBClient.assert_called_once_with('testDBClient')
+            assert test_api_response == 'citationResponse'
+            mock_db_client.assert_called_once_with('testDBClient')
 
-            mockUtils['normalizeQueryParams'].assert_called_once()
+            mock_utils['normalizeQueryParams'].assert_called_once()
 
-            mockUtils['formatResponseObject'].assert_called_once_with(
+            mock_utils['formatResponseObject'].assert_called_once_with(
                 200, 'citation', {'mla': ' '.join('testLastName, testFirstName, et al. \
                                 testTitle, edited by editFirstName editLastName, \
                                 testPubPlace, 1800.'.split())}
                 )
     
-    #* Test 2 for works with three authors
-    def test_citationFetch_three_authors_work2(self, mockUtils, testApp, mocker):
-        mockDB = mocker.MagicMock()
-        mockDBClient = mocker.patch('api.blueprints.drbCitation.DBClient')
-        mockDBClient.return_value = mockDB
+    def test_get_citation_three_authors_work2(self, mock_utils, test_app, mocker):
+        mock_db = mocker.MagicMock()
+        mock_db.__enter__.return_value = mock_db
+        mock_db_client = mocker.patch('api.blueprints.drbCitation.DBClient', return_value=mock_db)
 
-        editionMocks = [mocker.MagicMock(publication_date=date(2022, 1, 1), publishers=[{'name': 'NYPL'}], \
+        edition_mocks = [mocker.MagicMock(publication_date=date(2022, 1, 1), publishers=[{'name': 'NYPL'}], \
                         edition_statement = '2nd edition.', \
                         measurements = [{'type': 'government_document', 'value': '0'}])]
 
-        mockDB.fetchSingleWork.return_value = mocker.MagicMock(title='testTitle', authors = [{'name': 'testLastName, testFirstName'}, \
+        mock_db.fetchSingleWork.return_value = mocker.MagicMock(title='testTitle', authors = [{'name': 'testLastName, testFirstName'}, \
                                             {'name': 'testLastName2, testFirstName2'}, \
                                             {'name': 'testLastName3, testFirstName3'}], \
-                                            editions = editionMocks)           
+                                            editions = edition_mocks)           
             
-        mockUtils['formatResponseObject'].return_value\
+        mock_utils['formatResponseObject'].return_value\
                 = 'citationResponse'
 
-        with testApp.test_request_context('/?format=mla'):
-            testAPIResponse = citationFetch('testUUID')
+        with test_app.test_request_context('/?format=mla'):
+            test_api_response = get_citation('testUUID')
 
-            assert testAPIResponse == 'citationResponse'
-            mockDBClient.assert_called_once_with('testDBClient')
+            assert test_api_response == 'citationResponse'
+            mock_db_client.assert_called_once_with('testDBClient')
 
-            mockUtils['normalizeQueryParams'].assert_called_once()
+            mock_utils['normalizeQueryParams'].assert_called_once()
 
-            mockUtils['formatResponseObject'].assert_called_once_with(
+            mock_utils['formatResponseObject'].assert_called_once_with(
                 200, 'citation', {'mla': ' '.join('testLastName, testFirstName, et al. \
                                 testTitle. 2nd edition., \
                                 NYPL, 2022.'.split())}
                 )
 
-    #Test for when the work uuid is not avaliable 
-    def test_citationFetch_fail(self, mockUtils, testApp, mocker):
-        mockDB = mocker.MagicMock()
-        mockDBClient = mocker.patch('api.blueprints.drbCitation.DBClient')
-        mockDBClient.return_value = mockDB
+    def test_get_citation_fail(self, mock_utils, test_app, mocker):
+        mock_db = mocker.MagicMock()
+        mock_db.__enter__.return_value = mock_db
+        mock_db_client = mocker.patch('api.blueprints.drbCitation.DBClient', return_value=mock_db)
 
-        mockDB.fetchSingleWork.return_value = None
+        mock_db.fetchSingleWork.return_value = None
 
-        mockUtils['formatResponseObject'].return_value = '404Response'
+        mock_utils['formatResponseObject'].return_value = '404Response'
 
-        with testApp.test_request_context('testUUID/?format=mla'):
-            testAPIResponse = citationFetch('testUUID')
+        with test_app.test_request_context('testUUID/?format=mla'):
+            test_api_response = get_citation('testUUID')
 
-            assert testAPIResponse == '404Response'
-            mockDBClient.assert_called_once_with('testDBClient')
+            assert test_api_response == '404Response'
+            mock_db_client.assert_called_once_with('testDBClient')
 
-            mockUtils['normalizeQueryParams'].assert_called_once()
-            mockUtils['formatResponseObject'].assert_called_once_with(
+            mock_utils['normalizeQueryParams'].assert_called_once()
+            mock_utils['formatResponseObject'].assert_called_once_with(
                 404,
                 'citation',
-                {'message': 'Unable to locate work with UUID testUUID'}
+                {'message': 'No work found with id testUUID'}
             )
 
-    #Test when request arguments for format are not set
-    def test_citationFetch_fail2(self, mockUtils, testApp, mocker):
-        mockDB = mocker.MagicMock()
-        mockDBClient = mocker.patch('api.blueprints.drbCitation.DBClient')
-        mockDBClient.return_value = mockDB
+    def test_get_citation_fail2(self, mock_utils, test_app, mocker):
+        mock_db = mocker.MagicMock()
+        mock_db.__enter__.return_value = mock_db
+        mock_db_client = mocker.patch('api.blueprints.drbCitation.DBClient', return_value=mock_db)
 
-        mockUtils['formatResponseObject'].return_value = '400Response'
+        mock_utils['formatResponseObject'].return_value = '400Response'
 
-        with testApp.test_request_context('/?format='):
-            testAPIResponse = citationFetch('testUUID')
+        with test_app.test_request_context('/?format='):
+            test_api_response = get_citation('testUUID')
 
-            assert testAPIResponse == '400Response'
-            mockDBClient.assert_called_once_with('testDBClient')
+            assert test_api_response == '400Response'
+            mock_db_client.assert_called_once_with('testDBClient')
 
-            mockUtils['normalizeQueryParams'].assert_called_once()
-            mockUtils['formatResponseObject'].assert_called_once_with(
+            mock_utils['normalizeQueryParams'].assert_called_once()
+            mock_utils['formatResponseObject'].assert_called_once_with(
                 400,
-                'pageNotFound',
-                {'message': 'Need to specify citation format'}
+                'citation',
+                {'message': 'Citation formats are invalid'}
+            )
+
+    def test_get_citation_error(self, mock_utils, test_app, mocker):
+        mock_db = mocker.MagicMock()
+        mock_db.__enter__.return_value = mock_db
+        mock_db_client = mocker.patch('api.blueprints.drbCitation.DBClient', return_value=mock_db)
+        
+        mock_db.fetchSingleEdition.side_effect = Exception('Database error')
+
+        mock_utils['formatResponseObject'].return_value = '500response'
+
+        with test_app.test_request_context('/'):
+            test_api_response = get_citation('testUUID')
+
+            assert test_api_response == '500response'
+            mock_db_client.assert_called_once_with('testDBClient')
+
+            mock_utils['formatResponseObject'].assert_called_once_with(
+                500,
+                'citation',
+                {'message': 'Unable to get citation for work with id testUUID'}
             )

--- a/tests/unit/test_api_citation_blueprint.py
+++ b/tests/unit/test_api_citation_blueprint.py
@@ -22,9 +22,6 @@ class TestCitationBlueprint:
 
         return flask_app
 
-# Tests for when work uuid and format values are set correctly
-
-    #* Bible work before 1900 successful test
     def test_get_citation_bible_pre1900_success(self, mock_utils, test_app, mocker):
         mock_db = mocker.MagicMock()
         mock_db.__enter__.return_value = mock_db
@@ -423,18 +420,41 @@ class TestCitationBlueprint:
                 {'message': 'No work found with id testUUID'}
             )
 
-    def test_get_citation_fail2(self, mock_utils, test_app, mocker):
-        mock_db = mocker.MagicMock()
-        mock_db.__enter__.return_value = mock_db
-        mock_db_client = mocker.patch('api.blueprints.drbCitation.DBClient', return_value=mock_db)
-
+    def test_get_citation_empty_format(self, mock_utils, test_app):
         mock_utils['formatResponseObject'].return_value = '400Response'
 
         with test_app.test_request_context('/?format='):
             test_api_response = get_citation('testUUID')
 
             assert test_api_response == '400Response'
-            mock_db_client.assert_called_once_with('testDBClient')
+
+            mock_utils['formatResponseObject'].assert_called_once_with(
+                400,
+                'citation',
+                {'message': 'Citation formats are invalid'}
+            )
+
+    def test_get_citation_missing_format(self, mock_utils, test_app):
+        mock_utils['formatResponseObject'].return_value = '400response'
+
+        with test_app.test_request_context('/'):
+            test_api_response = get_citation('testUUID')
+
+            assert test_api_response == '400response'
+
+            mock_utils['formatResponseObject'].assert_called_once_with(
+                400,
+                'citation',
+                {'message': 'Citation formats are invalid'}
+            )
+
+    def test_get_citation_unknown_format(self, mock_utils, test_app):
+        mock_utils['formatResponseObject'].return_value = '400response'
+
+        with test_app.test_request_context('/?format=test'):
+            test_api_response = get_citation('testUUID')
+
+            assert test_api_response == '400response'
 
             mock_utils['formatResponseObject'].assert_called_once_with(
                 400,
@@ -451,7 +471,7 @@ class TestCitationBlueprint:
 
         mock_utils['formatResponseObject'].return_value = '500response'
 
-        with test_app.test_request_context('/'):
+        with test_app.test_request_context('/?format=mla'):
             test_api_response = get_citation('testUUID')
 
             assert test_api_response == '500response'

--- a/tests/unit/test_api_citation_blueprint.py
+++ b/tests/unit/test_api_citation_blueprint.py
@@ -43,8 +43,6 @@ class TestCitationBlueprint:
             assert test_api_response == 'citationResponse'
             mock_db_client.assert_called_once_with('testDBClient')
 
-            mock_utils['normalizeQueryParams'].assert_called_once()
-
             mock_utils['formatResponseObject'].assert_called_once_with(
                 200, 'citation', {'mla': 'The Bible. Unknown version, testPubPlace, 1800.'}
             )
@@ -66,8 +64,6 @@ class TestCitationBlueprint:
 
             assert test_api_response == 'citationResponse'
             mock_db_client.assert_called_once_with('testDBClient')
-
-            mock_utils['normalizeQueryParams'].assert_called_once()
 
             mock_utils['formatResponseObject'].assert_called_once_with(
                 200, 'citation', {'mla': 'The Bible. Unknown version, NYPL, 2022.'}
@@ -94,8 +90,6 @@ class TestCitationBlueprint:
 
             assert test_api_response == 'citationResponse'
             mock_db_client.assert_called_once_with('testDBClient')
-
-            mock_utils['normalizeQueryParams'].assert_called_once()
 
             mock_utils['formatResponseObject'].assert_called_once_with(
                 200, 'citation', {'mla': ' '.join('United States, Test Agency. State of the Union Address. \
@@ -125,8 +119,6 @@ class TestCitationBlueprint:
             assert test_api_response == 'citationResponse'
             mock_db_client.assert_called_once_with('testDBClient')
 
-            mock_utils['normalizeQueryParams'].assert_called_once()
-
             mock_utils['formatResponseObject'].assert_called_once_with(
                 200, 'citation', {'mla': ' '.join('testTitle. Translated by transFirstName \
                                 transLastName, edited by editFirstName editLastName, \
@@ -155,8 +147,6 @@ class TestCitationBlueprint:
             assert test_api_response == 'citationResponse'
             mock_db_client.assert_called_once_with('testDBClient')
 
-            mock_utils['normalizeQueryParams'].assert_called_once()
-
             mock_utils['formatResponseObject'].assert_called_once_with(
                 200, 'citation', {'mla': ' '.join('testTitle. Translated by transFirstName \
                                 transLastName, \
@@ -183,8 +173,6 @@ class TestCitationBlueprint:
             assert test_api_response == 'citationResponse'
             mock_db_client.assert_called_once_with('testDBClient')
 
-            mock_utils['normalizeQueryParams'].assert_called_once()
-
             mock_utils['formatResponseObject'].assert_called_once_with(
                 200, 'citation', {'mla': ' '.join('testTitle. \
                                 testPubPlace, 1800.'.split())}
@@ -209,8 +197,6 @@ class TestCitationBlueprint:
 
             assert test_api_response == 'citationResponse'
             mock_db_client.assert_called_once_with('testDBClient')
-
-            mock_utils['normalizeQueryParams'].assert_called_once()
 
             mock_utils['formatResponseObject'].assert_called_once_with(
                 200, 'citation', {'mla': ' '.join('testTitle. 2nd edition., \
@@ -240,8 +226,6 @@ class TestCitationBlueprint:
             assert test_api_response == 'citationResponse'
             mock_db_client.assert_called_once_with('testDBClient')
 
-            mock_utils['normalizeQueryParams'].assert_called_once()
-
             mock_utils['formatResponseObject'].assert_called_once_with(
                 200, 'citation', {'mla': ' '.join('testLastName, testFirstName. testTitle, \
                                 edited by editFirstName editLastName, \
@@ -269,8 +253,6 @@ class TestCitationBlueprint:
             assert test_api_response == 'citationResponse'
             mock_db_client.assert_called_once_with('testDBClient')
 
-            mock_utils['normalizeQueryParams'].assert_called_once()
-
             mock_utils['formatResponseObject'].assert_called_once_with(
                 200, 'citation', {'mla': ' '.join('testLastName, testFirstName. testTitle. \
                                 NYPL, 2022.'.split())}
@@ -297,14 +279,12 @@ class TestCitationBlueprint:
             assert test_api_response == 'citationResponse'
             mock_db_client.assert_called_once_with('testDBClient')
 
-            mock_utils['normalizeQueryParams'].assert_called_once()
-
             mock_utils['formatResponseObject'].assert_called_once_with(
                 200, 'citation', {'mla': ' '.join('testTitle. \
                                 NYPL, 2022.'.split())}
                 )
 
-    def test_get_citation__two_authors_work(self, mock_utils, test_app, mocker):
+    def test_get_citation_two_authors_work(self, mock_utils, test_app, mocker):
         mock_db = mocker.MagicMock()
         mock_db.__enter__.return_value = mock_db
         mock_db_client = mocker.patch('api.blueprints.drbCitation.DBClient', return_value=mock_db)
@@ -327,8 +307,6 @@ class TestCitationBlueprint:
 
             assert test_api_response == 'citationResponse'
             mock_db_client.assert_called_once_with('testDBClient')
-
-            mock_utils['normalizeQueryParams'].assert_called_once()
 
             mock_utils['formatResponseObject'].assert_called_once_with(
                 200, 'citation', {'mla': ' '.join('testLastName, testFirstName, and testFirstName2 testLastName2. \
@@ -357,8 +335,6 @@ class TestCitationBlueprint:
 
             assert test_api_response == 'citationResponse'
             mock_db_client.assert_called_once_with('testDBClient')
-
-            mock_utils['normalizeQueryParams'].assert_called_once()
 
             mock_utils['formatResponseObject'].assert_called_once_with(
                 200, 'citation', {'mla': ' '.join('testLastName, testFirstName, and testFirstName2 testLastName2. \
@@ -391,8 +367,6 @@ class TestCitationBlueprint:
             assert test_api_response == 'citationResponse'
             mock_db_client.assert_called_once_with('testDBClient')
 
-            mock_utils['normalizeQueryParams'].assert_called_once()
-
             mock_utils['formatResponseObject'].assert_called_once_with(
                 200, 'citation', {'mla': ' '.join('testLastName, testFirstName, et al. \
                                 testTitle, edited by editFirstName editLastName, \
@@ -422,8 +396,6 @@ class TestCitationBlueprint:
             assert test_api_response == 'citationResponse'
             mock_db_client.assert_called_once_with('testDBClient')
 
-            mock_utils['normalizeQueryParams'].assert_called_once()
-
             mock_utils['formatResponseObject'].assert_called_once_with(
                 200, 'citation', {'mla': ' '.join('testLastName, testFirstName, et al. \
                                 testTitle. 2nd edition., \
@@ -445,7 +417,6 @@ class TestCitationBlueprint:
             assert test_api_response == '404Response'
             mock_db_client.assert_called_once_with('testDBClient')
 
-            mock_utils['normalizeQueryParams'].assert_called_once()
             mock_utils['formatResponseObject'].assert_called_once_with(
                 404,
                 'citation',
@@ -465,7 +436,6 @@ class TestCitationBlueprint:
             assert test_api_response == '400Response'
             mock_db_client.assert_called_once_with('testDBClient')
 
-            mock_utils['normalizeQueryParams'].assert_called_once()
             mock_utils['formatResponseObject'].assert_called_once_with(
                 400,
                 'citation',


### PR DESCRIPTION
## Description
- Added error handling to the citation endpoint
- Added a TODO to refactor the util functions and move them out into a separate file

## Testing
`make test`