### PR TITLE
SFR-2112/2130: Views Reporting + Requested Business Changes

### DIFF
--- a/analytics/upress_reporting/counter_5_controller.py
+++ b/analytics/upress_reporting/counter_5_controller.py
@@ -38,5 +38,5 @@ class Counter5Controller:
     def _setup_reports(self, publisher, reporting_period):
         return [
             DownloadsReport(publisher, reporting_period)
-            # ViewsReport(publisher, reporting_period)
+            ViewsReport(publisher, reporting_period)
         ]

--- a/analytics/upress_reporting/models/aggregators/aggregator.py
+++ b/analytics/upress_reporting/models/aggregators/aggregator.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+import json
 import boto3
 import os
 
@@ -11,13 +12,13 @@ class Aggregator(ABC):
         self.publisher = publisher
         self.date_range = date_range
         self.s3_client = boto3.client("s3")
-
-    @abstractmethod
-    def pull_interaction_events(self) -> list[InteractionEvent]:
-        return
+        self.referrer_url = os.environ.get("REFERRER_URL", None)
 
     @abstractmethod
     def match_log_info_with_drb_data(self, log_object) -> InteractionEvent | None:
+        '''
+        Match S3 log info to data in DRB dbs.
+        '''
         return
 
     def setup_db_manager(self):
@@ -31,6 +32,22 @@ class Aggregator(ABC):
         self.db_manager.generateEngine()
         self.db_manager.createSession()
 
+    def pull_interaction_events(self, log_path, bucket_name) -> list[InteractionEvent]:
+        '''
+        Loads S3 logs from a given reporting period and parses InteractionEvents 
+        from each log. Use load_batch() and parse_logs_in_batch() to do so.
+        '''
+        events = []
+
+        for date in self.date_range:
+            folder_name = date.strftime("%Y/%m/%d")
+            batch = self.load_batch(log_path, bucket_name,
+                                    folder_name)
+            views_per_day = self.parse_logs_in_batch(batch, bucket_name)
+            events.extend(views_per_day)
+            
+        return events
+
     def load_batch(self, log_path, bucket_name, log_folder):
         prefix = log_path + log_folder + "/"
         paginator = self.s3_client.get_paginator("list_objects_v2")
@@ -38,7 +55,7 @@ class Aggregator(ABC):
             Bucket=bucket_name, Prefix=prefix)
         return page_iterator
 
-    def parse_logs_in_batch(self, batch, bucket_name) -> list:
+    def parse_logs_in_batch(self, batch, bucket_name):
         '''
         Pulls logs from a given S3 batch, then parses each log to see if 
         it contains an InteractionEvent (e.g. view, download, etc).
@@ -47,7 +64,7 @@ class Aggregator(ABC):
 
         for log_file in batch:
             if "Contents" not in log_file:
-                path = self.redact_s3_path(log_file["Prefix"])
+                path = self._redact_s3_path(log_file["Prefix"])
                 raise S3LogParsingError(
                     f"Log files in path {path} do not exist.")
             else:
@@ -66,7 +83,25 @@ class Aggregator(ABC):
 
         return interactions_in_batch
 
-    def redact_s3_path(self, path):
+    def pull_dates_from_edition(self, edition):
+        copyright, publication = None, None
+        for date in edition.dates:
+            if "copyright" in date["type"]:
+                copyright = date["date"]
+            if "publication" in date["type"]:
+                publication = date["date"]
+
+        return (copyright, publication)
+    
+    def load_flags(self, flag_string):
+        try:
+            flags = json.loads(flag_string)
+            return flags if isinstance(flags, dict) else {}
+        except json.decoder.JSONDecodeError as e:
+            raise S3LogParsingError(e.msg)
+        return {}
+
+    def _redact_s3_path(self, path):
         '''
         Used to remove sensitive data from S3 prefix before passing to error message.
         Example input = "logs/123456789/us-east-1/ump-pdf-repository/2024/1/1"
@@ -78,5 +113,10 @@ class Aggregator(ABC):
 
 
 class S3LogParsingError(Exception):
+    def __init__(self, message=None):
+        self.message = message
+
+
+class UnconfiguredEnvironment(Exception):
     def __init__(self, message=None):
         self.message = message

--- a/analytics/upress_reporting/models/aggregators/download_data_aggregator.py
+++ b/analytics/upress_reporting/models/aggregators/download_data_aggregator.py
@@ -1,23 +1,18 @@
-import json
-import boto3
 import os
 import re
 
 from logger import createLog
 from model import Edition, Item, Link
-from models.aggregators.aggregator import Aggregator
+from models.aggregators.aggregator import Aggregator, UnconfiguredEnvironment
 from models.data.interaction_event import InteractionEvent, InteractionType, UsageType
 from model.postgres.item import ITEM_LINKS
-from managers import DBManager
 from model.postgres.record import Record
 from model.postgres.work import Work
 
 # Regexes needed to parse S3 logs
 REQUEST_REGEX = r"REST.GET.OBJECT "
-# File ID includes the file name for the pdf object
 FILE_ID_REGEX = r"REST.GET.OBJECT (.+pdf\s)"
 TIMESTAMP_REGEX = r"\[.+\]"
-REFERRER_REGEX = r"https://drb-qa.nypl.org/"
 
 
 class DownloadDataAggregator(Aggregator):
@@ -33,23 +28,18 @@ class DownloadDataAggregator(Aggregator):
 
         self.logger = createLog("download_data_aggregator")
         self.setup_db_manager()
+        self.set_events()
 
-    def pull_interaction_events(self):
-        '''
-        Returns list of download InteractionEvents in a given reporting period.
-        '''
-        download_events = []
-
-        for date in self.date_range:
-            folder_name = date.strftime("%Y/%m/%d")
-            batch = self.load_batch(self.log_path, self.bucket_name, 
-                                    folder_name)
-            downloads_per_day = self.parse_logs_in_batch(batch, self.bucket_name)
-            download_events.extend(downloads_per_day)
+    def set_events(self):
+        if None in (self.bucket_name, self.log_path, self.referrer_url):
+            error_message = ("One or more necessary environment variables not found:",
+                             "Either DOWNLOAD_BUCKET, DOWNLOAD_LOG_PATH, REFERRER_URL is not set")
+            self.logger.error(error_message)
+            raise UnconfiguredEnvironment(error_message)
         
+        self.events = self.pull_interaction_events(
+            self.log_path, self.bucket_name)
         self.db_manager.closeConnection()
-
-        return download_events
 
     def match_log_info_with_drb_data(self, log_object):
         '''
@@ -57,7 +47,7 @@ class DownloadDataAggregator(Aggregator):
         If so, we parse out the edition title, identifier, and timestamp.
         '''
         matchRequest = re.search(REQUEST_REGEX, log_object)
-        matchReferrer = re.search(REFERRER_REGEX, log_object)
+        matchReferrer = re.search(str(self.referrer_url), log_object)
 
         if matchRequest and matchReferrer and "403 AccessDenied" not in log_object:
             match_time = re.search(TIMESTAMP_REGEX, log_object)
@@ -77,7 +67,7 @@ class DownloadDataAggregator(Aggregator):
                     for edition in self.db_manager.session.query(Edition).filter(
                             Edition.id == item.edition_id):
                         title = edition.title
-                        copyright_year = self._pull_copyright_year(edition)
+                        copyright_year, publication_year = self.pull_dates_from_edition(edition)
 
                         for record in self.db_manager.session.query(Record).filter(
                                 Record.uuid.in_(edition.dcdw_uuids)):
@@ -85,8 +75,6 @@ class DownloadDataAggregator(Aggregator):
                             usage_type = self._determine_usage(record)
                             isbns = [identifier.split(
                                 "|")[0] for identifier in record.identifiers if "isbn" in identifier]
-                            eisbns = [identifier.split(
-                                "|")[0] for identifier in record.identifiers if "eisbn" in identifier]
 
                         for work in self.db_manager.session.query(Work).filter(
                                 Work.id == edition.work_id):
@@ -98,39 +86,23 @@ class DownloadDataAggregator(Aggregator):
             return InteractionEvent(
                 title=title,
                 book_id=book_id,
-                authors=authors,
-                isbns=isbns,
-                eisbns=eisbns,
+                authors="; ".join(authors),
+                isbns=", ".join(isbns),
                 copyright_year=copyright_year,
-                disciplines=disciplines,
-                usage_type=usage_type,
+                publication_year=publication_year,
+                disciplines=", ".join(disciplines),
+                usage_type=usage_type.value,
                 interaction_type=InteractionType.DOWNLOAD,
                 timestamp=match_time.group(0)
             )
-
-    def _pull_copyright_year(self, edition):
-        for date in edition.dates:
-            if "copyright" in date["type"]:
-                return date["date"]
-
-        return None
 
     def _determine_usage(self, record):
         if record.has_part is not None:
             for item in record.has_part:
                 _, uri, _, _, flag_string = tuple(item.split('|'))
                 if "pdf" in uri:
-                    flags = self._load_flags(flag_string)
-                    if (("embed" in flags.keys()) and (flags["embed"] is True)) or (
-                        ("reader" in flags.keys()) and (flags["reader"] is True)):
+                    flags = self.load_flags(flag_string)
+                    if (("embed" in flags) and flags["embed"]) or (
+                            ("reader" in flags) and flags["reader"]):
                         return UsageType.FULL_ACCESS
         return UsageType.LIMITED_ACCESS
-
-    def _load_flags(self, flag_string):
-        try:
-            flags = json.loads(flag_string)
-            return flags if isinstance(flags, dict) else {}
-        except json.decoder.JSONDecodeError:
-            self.logger.error(
-                "Unable to parse nypl_login flags...")
-        return {}

--- a/analytics/upress_reporting/models/aggregators/view_data_aggregator.py
+++ b/analytics/upress_reporting/models/aggregators/view_data_aggregator.py
@@ -1,18 +1,18 @@
-import boto3
 import re
 import os
 
-from analytics.upress_reporting.models.aggregators.aggregator import Aggregator
-from analytics.upress_reporting.models.data.interaction_event import InteractionEvent
 from logger import createLog
-from managers.db import DBManager
+from model.postgres.edition import Edition
+from model.postgres.record import Record
+from model.postgres.work import Work
+from models.aggregators.aggregator import Aggregator, UnconfiguredEnvironment
+from models.data.interaction_event import InteractionEvent, InteractionType, UsageType
+from sqlalchemy import func
 
 # Regexes needed to parse S3 logs
-REQUEST_REGEX = r"REST.GET.OBJECT "
-# File ID includes the file name for the pdf object
-FILE_ID_REGEX = r"REST\.GET\.OBJECT manifests/(.+)/(.+json\s)"
+FILE_ID_REGEX = r"REST.GET.OBJECT manifests/(.*?json)\s"
 TIMESTAMP_REGEX = r"\[.+\]"
-REFERRER_REGEX = r"https://drb-qa.nypl.org/"
+
 
 class ViewDataAggregator(Aggregator):
     def __init__(self, *args):
@@ -21,21 +21,90 @@ class ViewDataAggregator(Aggregator):
         self.log_path = os.environ.get("VIEW_LOG_PATH", None)
 
         self.logger = createLog("view_data_aggregator")
-        self.setup_db_manager() 
-    
-    def pull_interaction_events(self) -> list[InteractionEvent]:
-        '''
-        Returns list of view InteractionEvents in a given reporting period.
-        '''
-        # TODO: potentially move this into general aggregator?
-        view_events = []
+        self.setup_db_manager()
+        self.set_events()
 
-        for date in self.date_range:
-            folder_name = date.strftime("%Y/%m/%d")
-            batch = self.load_batch(self.log_path, self.bucket_name, 
-                                    folder_name)
-            views_per_day = self.parse_logs_in_batch(batch, self.bucket_name)
-            view_events.extend(views_per_day)
+    def set_events(self):
+        if None in (self.bucket_name, self.log_path, self.referrer_url):
+            error_message = (
+                "One or more necessary environment variables not found:",
+                "Either VIEW_BUCKET, VIEW_LOG_PATH, REFERRER_URL is not set",
+            )
+            self.logger.error(error_message)
+            raise UnconfiguredEnvironment(error_message)
 
+        self.events = self.pull_interaction_events(
+            self.log_path, self.bucket_name)
         self.db_manager.closeConnection()
-        return view_events
+
+    def match_log_info_with_drb_data(self, log_object):
+        """
+        Check that the S3 server access log object contains a view request.
+        If so, we parse out the edition title, identifier, and timestamp.
+        """
+        match_file_id = re.search(FILE_ID_REGEX, log_object)
+        match_referrer = re.search(str(self.referrer_url), log_object)
+
+        if match_file_id and match_referrer and "403 AccessDenied" not in log_object:
+            match_time = re.search(TIMESTAMP_REGEX, log_object)
+            # some record identifiers include slashes, so we only want to 
+            # split at first occurrence
+            file_name = match_file_id.group(1).split("/", 1)[1]
+            record_id = file_name.split(".")[0]
+
+            # manifest file name should be the same as one of the record identifiers
+            for record in (
+                self.db_manager.session.query(Record)
+                .filter((Record.source == self.publisher))
+                .filter(func.array_to_string(
+                    Record.identifiers, ",").like("%"+record_id+"%"))):
+                book_id = (record.source_id).split("|")[0]
+                usage_type = self._determine_usage(record)
+                isbns = [
+                    identifier.split("|")[0]
+                    for identifier in record.identifiers
+                    if "isbn" in identifier
+                ]
+
+                for edition in self.db_manager.session.query(Edition).filter(
+                    Edition.dcdw_uuids.contains(f"{{{record.uuid}}}")
+                ):
+                    title = edition.title
+                    copyright_year, publication_year = self.pull_dates_from_edition(
+                        edition)
+
+                    for work in self.db_manager.session.query(Work).filter(
+                        Work.id == edition.work_id
+                    ):
+                        authors = [author["name"] for author in work.authors]
+                        disciplines = [subject["heading"]
+                                       for subject in work.subjects]
+
+                        return InteractionEvent(
+                            title=title,
+                            book_id=book_id,
+                            authors="; ".join(authors),
+                            isbns=", ".join(isbns),
+                            copyright_year=copyright_year,
+                            publication_year=publication_year,
+                            disciplines=", ".join(disciplines),
+                            usage_type=usage_type.value,
+                            interaction_type=InteractionType.VIEW,
+                            timestamp=match_time.group(0)
+                        )
+
+    def _determine_usage(self, record):
+        if record.has_part is not None:
+            for item in record.has_part:
+                _, uri, _, _, flag_string = tuple(item.split("|"))
+                if "manifests" in uri:
+                    flags = self.load_flags(flag_string)
+                    if ("nypl_login" in flags) and flags["nypl_login"]:
+                        return UsageType.LIMITED_ACCESS
+                    if (("embed" in flags) and flags["embed"]) or (
+                        ("reader" in flags) and flags["reader"]
+                    ):
+                        if ("download" in flags) and flags["download"]:
+                            return UsageType.FULL_ACCESS
+
+        return UsageType.VIEW_ONLY_NO_DOWNLOAD_ACCESS

--- a/analytics/upress_reporting/models/data/interaction_event.py
+++ b/analytics/upress_reporting/models/data/interaction_event.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass, fields
+from dataclasses import dataclass
 from enum import Enum
 from typing import Optional
 
@@ -18,11 +18,11 @@ class UsageType(Enum):
 class InteractionEvent():
     title: str
     book_id: int
-    authors: Optional[list[str]]
-    isbns: Optional[list[str]]
-    eisbns: Optional[list[str]]
+    authors: str
+    isbns: str
     copyright_year: Optional[str]
-    disciplines: Optional[list[str]]
-    usage_type: UsageType
+    publication_year: Optional[str]
+    disciplines: Optional[str]
+    usage_type: str
     interaction_type: InteractionType
     timestamp: str

--- a/analytics/upress_reporting/models/reports/counter_5_report.py
+++ b/analytics/upress_reporting/models/reports/counter_5_report.py
@@ -1,3 +1,4 @@
+import calendar
 import pandas
 import re
 import uuid
@@ -20,6 +21,8 @@ class Counter5Report(ABC):
             self.reporting_period = (
                 f"{datetime.now().year}-01-01 to {datetime.now().year}-01-31"
             )
+        self.pandas_date_range = self._parse_reporting_period(
+            self.reporting_period)
 
     @abstractmethod
     def build_header(self) -> dict:
@@ -31,8 +34,65 @@ class Counter5Report(ABC):
 
     def generate_report_id(self):
         return uuid.uuid4()
+    
+    def aggregate_interaction_events(self, events):
+        '''
+        Builds counts for each title in each month in the reporting period.
+        '''
+        # TODO: break up this large method
+        df = pandas.DataFrame(
+            [self._format_dataclass_for_csv(event) for event in events])
+        df.columns = ["Book Title",
+           "Book ID",
+           "Authors",
+           "ISBN(s)",
+           "Copyright Year",
+           "Publication Year",
+           "Disciplines",
+           "Usage Type",
+           "Interaction Type",
+           "Timestamp"]
+        # convert column from str type to Timestamp type for easier grouping
+        df["Timestamp"] = df["Timestamp"].apply(
+            self._reformat_timestamp_data)
 
-    def parse_reporting_period(self, reporting_period, freq='D'):
+        '''
+        Remove all duplicate titles for CSV report. We will populate df_unique's 
+        monthly columns based on df_grouped_by_id_and_month
+        '''
+        df_unique = df.drop_duplicates(subset="Book ID")
+        df_grouped_by_id_and_month = df.groupby(
+            ["Book ID", pandas.Grouper(freq='M', key='Timestamp')])
+        monthly_columns = []
+
+        for keys, group in df_grouped_by_id_and_month:
+            # example key values ->  Keys: ('756467457', Timestamp('2024-04-30 00:00:00'))
+            month, year = keys[1].month, keys[1].year
+            column_name = "{0} {1}".format(calendar.month_name[int(month)], 
+                                           year)
+            f"{month}-{year}"
+            if column_name not in df_unique.columns:
+                monthly_columns.append(column_name)
+                # create a new column for each month in the reporting period
+                df_unique[column_name] = pandas.Series()
+            # populate counts for a given title per month
+            df_unique.loc[df_unique["Book ID"] == keys[0],
+                          column_name] = group["Book ID"].count()
+
+        # delete now-unnecessary data
+        df_unique.drop(columns=["Timestamp", "Interaction Type"], 
+                       axis=1,
+                       inplace=True)
+        # set null values to 0
+        df_unique.loc[:, monthly_columns] = df_unique[monthly_columns].fillna(0)
+        # set reporting period total for each title
+        df_unique.loc[:, "Reporting Period Total"] = df_unique[monthly_columns].sum(
+            axis=1)
+        
+        # return tuple of new columns for CSV labeling
+        return (df_unique.columns.tolist(), df_unique.to_dict(orient="records"))
+    
+    def _parse_reporting_period(self, reporting_period, freq='D'):
         """
         Helper method to transform user input into date_range object.
         Input: String with date range in Y-m-d format (ex. "2024-01-01 to 2024-12-31")
@@ -46,7 +106,7 @@ class Counter5Report(ABC):
             start, end = reporting_period.split(" to ")
             return pandas.date_range(start=start, end=end, freq=freq)
     
-    def format_dataclass_for_csv(self, dataclass_instance: Any) -> List[Any]:
+    def _format_dataclass_for_csv(self, dataclass_instance: Any) -> List[Any]:
         if not is_dataclass(dataclass_instance):
             raise ValueError("Provided instance is not a dataclass.")
         
@@ -54,3 +114,11 @@ class Counter5Report(ABC):
         for field in fields(dataclass_instance):
             csv_row.append(getattr(dataclass_instance, field.name))
         return csv_row
+    
+    def _reformat_timestamp_data(self, date):
+        '''
+        Converts strings to Pandas Timestamp objects.
+        '''
+        string_date = str(date).strip("[]").split(":")[0]
+        return pandas.to_datetime(string_date)
+

--- a/analytics/upress_reporting/models/reports/downloads.py
+++ b/analytics/upress_reporting/models/reports/downloads.py
@@ -5,25 +5,12 @@ from logger import createLog
 from models.aggregators.download_data_aggregator import DownloadDataAggregator
 from models.reports.counter_5_report import Counter5Report
 
-COLUMNS = ["Book Title",
-           "Book ID",
-           "Authors",
-           "ISBN(s)",
-           "eISBN(s)",
-           "Copyright Year",
-           "Disciplines",
-           "Usage Type",
-           "Interaction Type",
-           "Timestamp"]
-
 
 class DownloadsReport(Counter5Report):
     def __init__(self, *args):
         super().__init__(*args)
-        pandas_date_range = self.parse_reporting_period(
-            self.reporting_period)
         self.download_request_parser = DownloadDataAggregator(
-            self.publisher, pandas_date_range)
+            self.publisher, self.pandas_date_range)
         self.logger = createLog("downloads_report")
 
     def build_report(self):
@@ -31,20 +18,25 @@ class DownloadsReport(Counter5Report):
         self.logger.info("Building downloads report...")
 
         header = self.build_header()
-        download_events = self.download_request_parser.pull_interaction_events()
-        columns, final_data = self.aggregate_interaction_events(download_events)
+        download_events = self.download_request_parser.events
 
-        csv_file_name = f"{self.publisher}_downloads_report_{self.created}.csv"
-        with open(csv_file_name, 'w') as csv_file:
-            writer = csv.writer(csv_file)
-            for key, value in header.items():
-                writer.writerow([key, value])
-            writer.writerow([])
-            writer.writerow(columns)
-            for title in final_data:
-                writer.writerow(title.values())
+        if len(download_events) > 0:
+            columns, final_data = self.aggregate_interaction_events(
+                download_events)
+            csv_file_name = f"{self.publisher}_downloads_report_{self.created}.csv"
+            
+            with open(csv_file_name, 'w') as csv_file:
+                writer = csv.writer(csv_file, delimiter="|")
+                for key, value in header.items():
+                    writer.writerow([key, value])
+                writer.writerow([])
+                writer.writerow(columns)
+                for title in final_data:
+                    writer.writerow(title.values())
 
-        self.logger.info("Downloads report generation complete!")
+            self.logger.info("Downloads report generation complete!")
+        else:
+            self.logger.info("No download events found in reporting period!")
 
     def build_header(self):
         return {
@@ -56,65 +48,3 @@ class DownloadsReport(Counter5Report):
             "Created": self.created,
             "Created_By": self.created_by,
         }
-
-    def aggregate_interaction_events(self, events):
-        '''
-        Builds counts for each title in each month in the reporting period.
-        '''
-        # TODO: break up this large method
-        df = pandas.DataFrame(
-            [self.format_dataclass_for_csv(event) for event in events])
-        df.columns = ["Book Title",
-           "Book ID",
-           "Authors",
-           "ISBN(s)",
-           "eISBN(s)",
-           "Copyright Year",
-           "Disciplines",
-           "Usage Type",
-           "Interaction Type",
-           "Timestamp"]
-        # convert column from str type to Timestamp type for easier grouping
-        df["Timestamp"] = df["Timestamp"].apply(
-            self._reformat_timestamp_data)
-
-        '''
-        Remove all duplicate titles for CSV report. We will populate df_unique's 
-        monthly columns based on df_grouped_by_id_and_month
-        '''
-        df_unique = df.drop_duplicates(subset="Book ID")
-        df_grouped_by_id_and_month = df.groupby(
-            ["Book ID", pandas.Grouper(freq='M', key='Timestamp')])
-        monthly_columns = []
-
-        for keys, group in df_grouped_by_id_and_month:
-            # example key values ->  Keys: ('756467457', Timestamp('2024-04-30 00:00:00'))
-            month, year = keys[1].month, keys[1].year
-            column_name = f"{month}-{year}"
-            if column_name not in df_unique.columns:
-                monthly_columns.append(column_name)
-                # create a new column for each month in the reporting period
-                df_unique[column_name] = pandas.Series()
-            # populate counts for a given title per month
-            df_unique.loc[df_unique["Book ID"] == keys[0],
-                          column_name] = group["Book ID"].count()
-
-        # delete now-unnecessary data
-        df_unique.drop(columns=["Timestamp", "Interaction Type"], 
-                       axis=1,
-                       inplace=True)
-        # set null values to 0
-        df_unique.loc[:, monthly_columns] = df_unique[monthly_columns].fillna(0)
-        # set reporting period total for each title
-        df_unique.loc[:, "Reporting Period Total"] = df_unique[monthly_columns].sum(
-            axis=1)
-        
-        # return tuple of new columns for CSV labeling
-        return (df_unique.columns.tolist(), df_unique.to_dict(orient="records"))
-
-    def _reformat_timestamp_data(self, date):
-        '''
-        Converts strings to Pandas Timestamp objects.
-        '''
-        string_date = str(date).strip("[]").split(":")[0]
-        return pandas.to_datetime(string_date)

--- a/analytics/upress_reporting/models/reports/views.py
+++ b/analytics/upress_reporting/models/reports/views.py
@@ -1,14 +1,41 @@
+import csv
+
 from logger import createLog
+from models.aggregators.view_data_aggregator import ViewDataAggregator
 from models.reports.counter_5_report import Counter5Report
 
 
 class ViewsReport(Counter5Report):
     def __init__(self, *args):
         super().__init__(*args)
+        self.view_request_parser = ViewDataAggregator(
+            self.publisher, self.pandas_date_range)
         self.logger = createLog("views_report")
     
     def build_report(self):
-        return
+        # TODO: move to general counter 5 class?
+        self.logger.info("Building views report...")
+
+        header = self.build_header()
+        view_events = self.view_request_parser.events
+
+        if len(view_events) > 0:
+            columns, final_data = self.aggregate_interaction_events(
+                view_events)
+            csv_file_name = f"{self.publisher}_views_report_{self.created}.csv"
+
+            with open(csv_file_name, 'w') as csv_file:
+                writer = csv.writer(csv_file, delimiter="|")
+                for key, value in header.items():
+                    writer.writerow([key, value])
+                writer.writerow([])
+                writer.writerow(columns)
+                for title in final_data:
+                    writer.writerow(title.values())
+
+            self.logger.info("Views report generation complete!")
+        else:
+            self.logger.info("No view events found in reporting period!")
     
     def build_header(self):
         return {
@@ -20,3 +47,4 @@ class ViewsReport(Counter5Report):
             "Created": self.created,
             "Created_By": self.created_by,
         }
+    


### PR DESCRIPTION
### Changes Made
- Added functionality for COUNTER 5 views reporting and [parsing through S3 views logs](https://github.com/NYPL/drb-etl-pipeline/blob/main/analytics/upress_reporting/models/aggregators/view_data_aggregator.py)
- Added `Publication Year` column to all Counter 5 reports
- Convert `Usage Type` (among others) column to user-readable string -- i.e. remove brackets, add commas
- Remove `eISBN` column
- Further [generalized `Aggregator` functionality](https://github.com/NYPL/drb-etl-pipeline/blob/main/analytics/upress_reporting/models/aggregators/aggregator.py) so child classes only have to determine how to match specific log info to info in DRB databases

### Related Stories
- [SFR-2112](https://newyorkpubliclibrary.atlassian.net/browse/SFR-2112)
- [SFR-2130](https://newyorkpubliclibrary.atlassian.net/browse/SFR-2130)