### PR TITLE
SFR-2120: Adding search API error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Added local S3 docker container via localstack
 - Added error handling to citation API
 - Implemented Counter 5 reporting for view counts
+- Added error handling to search API
 
 ## Fixed
 - Changed HATHI_DATAFILES outdated link in development, example, and local yaml files


### PR DESCRIPTION
## Description
- The search API had some decent error handling but some incorrect HTTP response codes
- Refactored and moved to camel case
- Added outer error handling

## Testing
`make test`