### PR TITLE
SFR-2122: Adding collection GET API error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Added local S3 docker container via localstack
 - Added error handling to citation API
 - Implemented Counter 5 reporting for view counts
+- Added error handling to GET collection endpoints
 
 ## Fixed
 - Changed HATHI_DATAFILES outdated link in development, example, and local yaml files


### PR DESCRIPTION
## Description
- Adding error handling to the collection endpoints that are called from the frontend

## Testing
`make test`