### PR TITLE
SFR-2133: Adding UUID validation to APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Added error handling to GET collection endpoints
 - Added error handling for utils API
 - Added error handling to search API
+- Added uuid API validation
 
 ## Fixed
 - Changed HATHI_DATAFILES outdated link in development, example, and local yaml files 

--- a/api/blueprints/drbCitation.py
+++ b/api/blueprints/drbCitation.py
@@ -1,7 +1,7 @@
-from socket import if_nametoindex
 from flask import Blueprint, request, current_app
 from ..db import DBClient
 from ..utils import APIUtils
+from ..validation_utils import is_valid_uuid
 from logger import createLog
 from datetime import date
 
@@ -15,6 +15,9 @@ citation_set = {'mla', 'apa', 'chicago'}
 def get_citation(uuid):
     logger.info(f'Getting citation for work id {uuid}')
     response_type = 'citation'
+
+    if not is_valid_uuid(uuid):
+        return APIUtils.formatResponseObject(400, response_type, { 'message': f'Work id {uuid} is invalid' })
 
     try:
         citation_formats = request.args.get('format', default='')

--- a/api/blueprints/drbCollection.py
+++ b/api/blueprints/drbCollection.py
@@ -10,6 +10,7 @@ from ..db import DBClient
 from ..elastic import ElasticClient
 from ..opdsUtils import OPDSUtils
 from ..utils import APIUtils
+from ..validation_utils import is_valid_uuid
 from ..opds2 import Feed, Publication
 from logger import createLog
 from model import Work, Edition
@@ -261,6 +262,9 @@ def collectionUpdate(uuid, user=None):
 def get_collection(uuid):
     logger.info(f'Getting collection with id {uuid}')
     response_type = 'fetchCollection'
+
+    if not is_valid_uuid(uuid):
+        return APIUtils.formatResponseObject(400, response_type, { 'message': f'Collection id {uuid} is invalid' })
 
     try:
         db_client = DBClient(current_app.config['DB_CLIENT'])

--- a/api/validation_utils.py
+++ b/api/validation_utils.py
@@ -1,2 +1,13 @@
+import uuid
+
+
 def is_valid_numeric_id(id) -> bool:
     return isinstance(id, int) or (isinstance(id, str) and id.isdigit())
+
+
+def is_valid_uuid(id, version=4) -> bool:
+    try:
+        uuid.UUID(str(id), version=version)
+        return True
+    except ValueError:
+        return False

--- a/tests/unit/test_api_citation_blueprint.py
+++ b/tests/unit/test_api_citation_blueprint.py
@@ -35,7 +35,7 @@ class TestCitationBlueprint:
             = 'citationResponse'
 
         with test_app.test_request_context('/?format=mla'):
-            test_api_response = get_citation('testUUID')
+            test_api_response = get_citation('a8512b02-779b-45c6-95a3-56f90831be46')
 
             assert test_api_response == 'citationResponse'
             mock_db_client.assert_called_once_with('testDBClient')
@@ -57,7 +57,7 @@ class TestCitationBlueprint:
             = 'citationResponse'
 
         with test_app.test_request_context('/?format=mla'):
-            test_api_response = get_citation('testUUID')
+            test_api_response = get_citation('a8512b02-779b-45c6-95a3-56f90831be46')
 
             assert test_api_response == 'citationResponse'
             mock_db_client.assert_called_once_with('testDBClient')
@@ -83,7 +83,7 @@ class TestCitationBlueprint:
             = 'citationResponse'
 
         with test_app.test_request_context('/?format=mla'):
-            test_api_response = get_citation('testUUID')
+            test_api_response = get_citation('a8512b02-779b-45c6-95a3-56f90831be46')
 
             assert test_api_response == 'citationResponse'
             mock_db_client.assert_called_once_with('testDBClient')
@@ -111,7 +111,7 @@ class TestCitationBlueprint:
             = 'citationResponse'
 
         with test_app.test_request_context('/?format=mla'):
-            test_api_response = get_citation('testUUID')
+            test_api_response = get_citation('a8512b02-779b-45c6-95a3-56f90831be46')
 
             assert test_api_response == 'citationResponse'
             mock_db_client.assert_called_once_with('testDBClient')
@@ -139,7 +139,7 @@ class TestCitationBlueprint:
                 = 'citationResponse'
 
         with test_app.test_request_context('/?format=mla'):
-            test_api_response = get_citation('testUUID')
+            test_api_response = get_citation('a8512b02-779b-45c6-95a3-56f90831be46')
 
             assert test_api_response == 'citationResponse'
             mock_db_client.assert_called_once_with('testDBClient')
@@ -165,7 +165,7 @@ class TestCitationBlueprint:
                 = 'citationResponse'
 
         with test_app.test_request_context('/?format=mla'):
-            test_api_response = get_citation('testUUID')
+            test_api_response = get_citation('a8512b02-779b-45c6-95a3-56f90831be46')
 
             assert test_api_response == 'citationResponse'
             mock_db_client.assert_called_once_with('testDBClient')
@@ -190,7 +190,7 @@ class TestCitationBlueprint:
                 = 'citationResponse'
 
         with test_app.test_request_context('/?format=mla'):
-            test_api_response = get_citation('testUUID')
+            test_api_response = get_citation('a8512b02-779b-45c6-95a3-56f90831be46')
 
             assert test_api_response == 'citationResponse'
             mock_db_client.assert_called_once_with('testDBClient')
@@ -218,7 +218,7 @@ class TestCitationBlueprint:
                 = 'citationResponse'
 
         with test_app.test_request_context('/?format=mla'):
-            test_api_response = get_citation('testUUID')
+            test_api_response = get_citation('a8512b02-779b-45c6-95a3-56f90831be46')
 
             assert test_api_response == 'citationResponse'
             mock_db_client.assert_called_once_with('testDBClient')
@@ -245,7 +245,7 @@ class TestCitationBlueprint:
                 = 'citationResponse'
 
         with test_app.test_request_context('/?format=mla'):
-            test_api_response = get_citation('testUUID')
+            test_api_response = get_citation('a8512b02-779b-45c6-95a3-56f90831be46')
 
             assert test_api_response == 'citationResponse'
             mock_db_client.assert_called_once_with('testDBClient')
@@ -271,7 +271,7 @@ class TestCitationBlueprint:
                 = 'citationResponse'
 
         with test_app.test_request_context('/?format=mla'):
-            test_api_response = get_citation('testUUID')
+            test_api_response = get_citation('a8512b02-779b-45c6-95a3-56f90831be46')
 
             assert test_api_response == 'citationResponse'
             mock_db_client.assert_called_once_with('testDBClient')
@@ -300,7 +300,7 @@ class TestCitationBlueprint:
                 = 'citationResponse'
 
         with test_app.test_request_context('/?format=mla'):
-            test_api_response = get_citation('testUUID')
+            test_api_response = get_citation('a8512b02-779b-45c6-95a3-56f90831be46')
 
             assert test_api_response == 'citationResponse'
             mock_db_client.assert_called_once_with('testDBClient')
@@ -328,7 +328,7 @@ class TestCitationBlueprint:
                 = 'citationResponse'
 
         with test_app.test_request_context('/?format=mla'):
-            test_api_response = get_citation('testUUID')
+            test_api_response = get_citation('a8512b02-779b-45c6-95a3-56f90831be46')
 
             assert test_api_response == 'citationResponse'
             mock_db_client.assert_called_once_with('testDBClient')
@@ -359,7 +359,7 @@ class TestCitationBlueprint:
                 = 'citationResponse'
 
         with test_app.test_request_context('/?format=mla'):
-            test_api_response = get_citation('testUUID')
+            test_api_response = get_citation('a8512b02-779b-45c6-95a3-56f90831be46')
 
             assert test_api_response == 'citationResponse'
             mock_db_client.assert_called_once_with('testDBClient')
@@ -388,7 +388,7 @@ class TestCitationBlueprint:
                 = 'citationResponse'
 
         with test_app.test_request_context('/?format=mla'):
-            test_api_response = get_citation('testUUID')
+            test_api_response = get_citation('a8512b02-779b-45c6-95a3-56f90831be46')
 
             assert test_api_response == 'citationResponse'
             mock_db_client.assert_called_once_with('testDBClient')
@@ -408,8 +408,8 @@ class TestCitationBlueprint:
 
         mock_utils['formatResponseObject'].return_value = '404Response'
 
-        with test_app.test_request_context('testUUID/?format=mla'):
-            test_api_response = get_citation('testUUID')
+        with test_app.test_request_context('a8512b02-779b-45c6-95a3-56f90831be46/?format=mla'):
+            test_api_response = get_citation('a8512b02-779b-45c6-95a3-56f90831be46')
 
             assert test_api_response == '404Response'
             mock_db_client.assert_called_once_with('testDBClient')
@@ -417,14 +417,14 @@ class TestCitationBlueprint:
             mock_utils['formatResponseObject'].assert_called_once_with(
                 404,
                 'citation',
-                {'message': 'No work found with id testUUID'}
+                {'message': 'No work found with id a8512b02-779b-45c6-95a3-56f90831be46'}
             )
 
     def test_get_citation_empty_format(self, mock_utils, test_app):
         mock_utils['formatResponseObject'].return_value = '400Response'
 
         with test_app.test_request_context('/?format='):
-            test_api_response = get_citation('testUUID')
+            test_api_response = get_citation('a8512b02-779b-45c6-95a3-56f90831be46')
 
             assert test_api_response == '400Response'
 
@@ -438,7 +438,7 @@ class TestCitationBlueprint:
         mock_utils['formatResponseObject'].return_value = '400response'
 
         with test_app.test_request_context('/'):
-            test_api_response = get_citation('testUUID')
+            test_api_response = get_citation('a8512b02-779b-45c6-95a3-56f90831be46')
 
             assert test_api_response == '400response'
 
@@ -452,7 +452,7 @@ class TestCitationBlueprint:
         mock_utils['formatResponseObject'].return_value = '400response'
 
         with test_app.test_request_context('/?format=test'):
-            test_api_response = get_citation('testUUID')
+            test_api_response = get_citation('a8512b02-779b-45c6-95a3-56f90831be46')
 
             assert test_api_response == '400response'
 
@@ -472,7 +472,7 @@ class TestCitationBlueprint:
         mock_utils['formatResponseObject'].return_value = '500response'
 
         with test_app.test_request_context('/?format=mla'):
-            test_api_response = get_citation('testUUID')
+            test_api_response = get_citation('a8512b02-779b-45c6-95a3-56f90831be46')
 
             assert test_api_response == '500response'
             mock_db_client.assert_called_once_with('testDBClient')
@@ -480,5 +480,19 @@ class TestCitationBlueprint:
             mock_utils['formatResponseObject'].assert_called_once_with(
                 500,
                 'citation',
-                {'message': 'Unable to get citation for work with id testUUID'}
+                {'message': 'Unable to get citation for work with id a8512b02-779b-45c6-95a3-56f90831be46'}
+            )
+
+    def test_get_citation_invalid_id(self, mock_utils, test_app):
+        mock_utils['formatResponseObject'].return_value = '400response'
+
+        with test_app.test_request_context('/?format=mla'):
+            test_api_response = get_citation('testUUID')
+
+            assert test_api_response == '400response'
+
+            mock_utils['formatResponseObject'].assert_called_once_with(
+                400,
+                'citation',
+                {'message': 'Work id testUUID is invalid'}
             )

--- a/tests/unit/test_api_collection_blueprint.py
+++ b/tests/unit/test_api_collection_blueprint.py
@@ -482,7 +482,7 @@ class TestCollectionBlueprint:
         mock_db_client = mocker.patch('api.blueprints.drbCollection.DBClient')
         mock_db_client.return_value = mock_db
 
-        collection = mocker.MagicMock(uuid="testUUID")
+        collection = mocker.MagicMock(uuid="d902fd44-7cbe-4401-b50c-5b1bda8b1059")
         mock_db.fetchSingleCollection.return_value = collection
 
         mock_feed_construct = mocker.patch(
@@ -493,7 +493,7 @@ class TestCollectionBlueprint:
         mock_utils['formatOPDS2Object'].return_value = 'testOPDS2Response'
 
         with test_app.test_request_context('/?sort=title&page=3'):
-            test_api_response = get_collection('testUUID')
+            test_api_response = get_collection('d902fd44-7cbe-4401-b50c-5b1bda8b1059')
 
             assert test_api_response == 'testOPDS2Response'
 
@@ -517,7 +517,7 @@ class TestCollectionBlueprint:
         mock_utils['formatResponseObject'].return_value = 'testErrorResponse'
 
         with test_app.test_request_context('/?sort=title&page=3'):
-            test_api_response = get_collection('testUUID')
+            test_api_response = get_collection('d902fd44-7cbe-4401-b50c-5b1bda8b1059')
 
             assert test_api_response == 'testErrorResponse'
 
@@ -526,7 +526,7 @@ class TestCollectionBlueprint:
             mock_utils['formatResponseObject'].assert_called_once_with(
                 404, 
                 'fetchCollection',
-                {'message': 'No collection found with id testUUID'}
+                {'message': 'No collection found with id d902fd44-7cbe-4401-b50c-5b1bda8b1059'}
             )
 
     def test_get_collection_error(self, test_app, mock_utils, mocker):
@@ -539,7 +539,7 @@ class TestCollectionBlueprint:
         mock_utils['formatResponseObject'].return_value = 'testErrorResponse'
 
         with test_app.test_request_context('/?sort=title&page=3'):
-            test_api_response = get_collection('testUUID')
+            test_api_response = get_collection('d902fd44-7cbe-4401-b50c-5b1bda8b1059')
 
             assert test_api_response == 'testErrorResponse'
 
@@ -548,7 +548,21 @@ class TestCollectionBlueprint:
             mock_utils['formatResponseObject'].assert_called_once_with(
                 500, 
                 'fetchCollection',
-                {'message': 'Unable to get collection with id testUUID'}
+                {'message': 'Unable to get collection with id d902fd44-7cbe-4401-b50c-5b1bda8b1059'}
+            )
+
+    def test_get_collection_invalid_id(self, test_app, mock_utils):
+        mock_utils['formatResponseObject'].return_value = '400response'
+
+        with test_app.test_request_context('/?sort=title&page=3'):
+            test_api_response = get_collection('testUUID')
+
+            assert test_api_response == '400response'
+
+            mock_utils['formatResponseObject'].assert_called_once_with(
+                400, 
+                'fetchCollection',
+                {'message': 'Collection id testUUID is invalid'}
             )
 
     def test_collection_delete_success(self, test_app, mock_utils, mocker):

--- a/tests/unit/test_api_work_blueprint.py
+++ b/tests/unit/test_api_work_blueprint.py
@@ -37,7 +37,7 @@ class TestWorkBlueprint:
         mock_utils['formatResponseObject'].return_value = 'singleWorkResponse'
 
         with test_app.test_request_context('/?showAll=true'):
-            test_api_response = get_work('testUUID')
+            test_api_response = get_work('a8512b02-779b-45c6-95a3-56f90831be46')
 
             assert test_api_response == 'singleWorkResponse'
             mock_db_client.assert_called_once_with('testDBClient')
@@ -69,7 +69,7 @@ class TestWorkBlueprint:
         mock_utils['formatResponseObject'].return_value = 'singleWorkResponse'
 
         with test_app.test_request_context('/?showAll=true'):
-            test_api_response = get_work('testUUID')
+            test_api_response = get_work('a8512b02-779b-45c6-95a3-56f90831be46')
 
             assert test_api_response == 'singleWorkResponse'
             mock_db_client.assert_called_once_with('testDBClient')
@@ -99,7 +99,7 @@ class TestWorkBlueprint:
         mock_utils['formatResponseObject'].return_value = 'singleWorkResponse'
 
         with test_app.test_request_context('/?showAll=false'):
-            test_api_response = get_work('testUUID')
+            test_api_response = get_work('a8512b02-779b-45c6-95a3-56f90831be46')
 
             assert test_api_response == 'singleWorkResponse'
             mock_db_client.assert_called_once_with('testDBClient')
@@ -124,8 +124,8 @@ class TestWorkBlueprint:
 
         mock_utils['formatResponseObject'].return_value = '404Response'
 
-        with test_app.test_request_context('/testUUID?showAll=false'):
-            test_api_response = get_work('testUUID')
+        with test_app.test_request_context('/a8512b02-779b-45c6-95a3-56f90831be46?showAll=false'):
+            test_api_response = get_work('a8512b02-779b-45c6-95a3-56f90831be46')
 
             assert test_api_response == '404Response'
             mock_db_client.assert_called_once_with('testDBClient')
@@ -135,7 +135,7 @@ class TestWorkBlueprint:
             mock_utils['formatResponseObject'].assert_called_once_with(
                 404,
                 'singleWork',
-                {'message': 'No work found with id testUUID'}
+                {'message': 'No work found with id a8512b02-779b-45c6-95a3-56f90831be46'}
             )
 
     def test_get_work_missing(self, mock_utils, test_app, mocker):
@@ -149,8 +149,8 @@ class TestWorkBlueprint:
 
         mock_utils['formatResponseObject'].return_value = '500Response'
 
-        with test_app.test_request_context('/testUUID?showAll=false'):
-            test_api_response = get_work('testUUID')
+        with test_app.test_request_context('/a8512b02-779b-45c6-95a3-56f90831be46?showAll=false'):
+            test_api_response = get_work('a8512b02-779b-45c6-95a3-56f90831be46')
 
             assert test_api_response == '500Response'
             mock_db_client.assert_called_once_with('testDBClient')
@@ -158,5 +158,19 @@ class TestWorkBlueprint:
             mock_utils['formatResponseObject'].assert_called_once_with(
                 500,
                 'singleWork',
-                {'message': 'Unable to get work with id testUUID'}
+                {'message': 'Unable to get work with id a8512b02-779b-45c6-95a3-56f90831be46'}
+            )
+
+    def test_get_work_invalid_id(self, mock_utils, test_app):
+        mock_utils['formatResponseObject'].return_value = '400Response'
+
+        with test_app.test_request_context('/testUUID?showAll=false'):
+            test_api_response = get_work('testUUID')
+
+            assert test_api_response == '400Response'
+            
+            mock_utils['formatResponseObject'].assert_called_once_with(
+                400,
+                'singleWork',
+                {'message': 'Work id testUUID is invalid'}
             )


### PR DESCRIPTION
## Description
- The database client does expect a valid uuid before querying, otherwise it will throw an error making it look like there's something wrong on the server
- This change adds validation to check the uuid is valid

## Testing
`make unit`