### PR TITLE
NO-REF: Switching to v2 classify record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Adding OCLC query bibs call
 - Finalizing OCLC implementation
 - Implemented script to aggregate access logs
+- Switching over to classify record by metadata v2
 
 ## Fixed
 - Changed HATHI_DATAFILES outdated link in development, example, and local yaml files 

--- a/processes/oclcClassify.py
+++ b/processes/oclcClassify.py
@@ -113,8 +113,7 @@ class ClassifyProcess(CoreProcess):
                 continue
 
             try:
-                # TODO: switch this to classify_record_by_metadata_v2
-                self.classifyRecordByMetadata(identifier, idenType, author, record.title)
+                self.classify_record_by_metadata_v2(identifier, idenType, author, record.title)
             except ClassifyError as err:
                 logger.warning('Unable to Classify {}'.format(record))
                 logger.debug(err.message)

--- a/tests/unit/test_oclcClassify_process.py
+++ b/tests/unit/test_oclcClassify_process.py
@@ -27,6 +27,7 @@ class TestOCLCClassifyProcess:
                 self.ingestLimit = None
                 self.rabbitQueue = os.environ['OCLC_QUEUE']
                 self.rabbitRoute = os.environ['OCLC_ROUTING_KEY']
+                self.oclc_catalog_manager = mocker.MagicMock()
         
         return TestClassifyProcess('TestProcess', 'testFile', 'testDate')
     
@@ -199,7 +200,7 @@ class TestOCLCClassifyProcess:
         mockRedisCheck = mocker.patch.object(ClassifyProcess, 'checkSetRedis')
         mockRedisCheck.return_value = False
 
-        mockClassifyRec = mocker.patch.object(ClassifyProcess, 'classifyRecordByMetadata')
+        mockClassifyRec = mocker.patch.object(ClassifyProcess, 'classify_record_by_metadata_v2')
 
         testInstance.frbrizeRecord(testRecord)
 
@@ -214,7 +215,7 @@ class TestOCLCClassifyProcess:
         mockRedisCheck = mocker.patch.object(ClassifyProcess, 'checkSetRedis')
         mockRedisCheck.return_value = False
 
-        mockClassifyRec = mocker.patch.object(ClassifyProcess, 'classifyRecordByMetadata')
+        mockClassifyRec = mocker.patch.object(ClassifyProcess, 'classify_record_by_metadata_v2')
 
         testRecord.authors = []
         testInstance.frbrizeRecord(testRecord)
@@ -230,7 +231,7 @@ class TestOCLCClassifyProcess:
         mockRedisCheck = mocker.patch.object(ClassifyProcess, 'checkSetRedis')
         mockRedisCheck.return_value = True
 
-        mockClassifyRec = mocker.patch.object(ClassifyProcess, 'classifyRecordByMetadata')
+        mockClassifyRec = mocker.patch.object(ClassifyProcess, 'classify_record_by_metadata_v2')
 
         testRecord.authors = []
         testInstance.frbrizeRecord(testRecord)
@@ -245,7 +246,7 @@ class TestOCLCClassifyProcess:
 
         mockRedisCheck = mocker.patch.object(ClassifyProcess, 'checkSetRedis')
 
-        mockClassifyRec = mocker.patch.object(ClassifyProcess, 'classifyRecordByMetadata')
+        mockClassifyRec = mocker.patch.object(ClassifyProcess, 'classify_record_by_metadata_v2')
 
         testInstance.frbrizeRecord(testRecord)
 


### PR DESCRIPTION
## Description
- Switching over to the v2 classify record implementation 

## Testing 
`make unit`