### PR TITLE
SFR-2173: Improving error handling and logging in OCLC classify process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - Adding more specific logging and exception handling around OCLC manager errors
 - Upgrading flask-cors
 - implement restApi testing using pytest
+- Improving error handling and logging to OCLC classify process
 
 ## Fixed
 

--- a/managers/oclc_catalog.py
+++ b/managers/oclc_catalog.py
@@ -139,7 +139,7 @@ class OCLCCatalogManager:
 
             return bibs
         except Exception as e:
-            logger.error(f'Failed to query search bibs with query {query} due to {e.message}')
+            logger.error(f'Failed to query search bibs with query {query} due to {e}')
             return bibs
 
     def _search_bibs(self, query: str, offset: int=0):
@@ -172,7 +172,7 @@ class OCLCCatalogManager:
             
             return bibs_response.json()
         except Exception as e:
-            logger.error(f'Failed to query {bibs_endpoint} with query {query} due to {e.message}')
+            logger.error(f'Failed to query {bibs_endpoint} with query {query} due to {e}')
             return None
 
     def generate_search_query(self, identifier=None, identifier_type=None, title=None, author=None):

--- a/managers/oclc_catalog.py
+++ b/managers/oclc_catalog.py
@@ -95,15 +95,14 @@ class OCLCCatalogManager:
                 }
             )
 
+            status_code = other_editions_response.status_code
+
             if other_editions_response.status_code != 200:
                 logger.warning(
-                            f'OCLC search bibs request for OCLC no {oclc_number} failed '
-                            f'with status {other_editions_response.status_code}')
-                try:
-                            oclc_error_type = other_editions_response.json()["type"]
-                            logger.debug(f'{oclc_number} request failure reason: {oclc_error_type}')
-                except (JSONDecodeError, KeyError):
-                    logger.debug(f'No OCLC error type given for {oclc_number} request')
+                    f'OCLC other editions request for OCLC number {oclc_number} failed with status: {status_code} '
+                    f'and reason: {self._get_error_type(other_editions_response)}'
+                )
+
                 return None
 
             return other_editions_response.json()
@@ -140,7 +139,7 @@ class OCLCCatalogManager:
 
             return bibs
         except Exception as e:
-            logger.error(f'Failed to query search bibs with query {query}', e)
+            logger.error(f'Failed to query search bibs with query {query} due to {e.message}')
             return bibs
 
     def _search_bibs(self, query: str, offset: int=0):
@@ -161,19 +160,19 @@ class OCLCCatalogManager:
                 }
             )
 
-            if bibs_response.status_code != 200:
+            status_code = bibs_response.status_code
+
+            if status_code != 200:
                 logger.warning(
-                            f'OCLC search bibs request for query {query} failed '
-                            f'with status {bibs_response.status_code}')
-                try:
-                            oclc_error_type = bibs_response.json()["type"]
-                            logger.debug(f'Query failure reason: {oclc_error_type}')
-                except (JSONDecodeError, KeyError):
-                    logger.debug('No OCLC error type given')
+                    f'OCLC search bibs request for query {query} failed with status: {status_code} '
+                    f'and reason: {self._get_error_type(bibs_response)}'
+                )
+                
                 return None
+            
             return bibs_response.json()
         except Exception as e:
-            logger.error(f'Failed to query {bibs_endpoint} with query {query}. Exception: {e}')
+            logger.error(f'Failed to query {bibs_endpoint} with query {query} due to {e.message}')
             return None
 
     def generate_search_query(self, identifier=None, identifier_type=None, title=None, author=None):
@@ -195,6 +194,14 @@ class OCLCCatalogManager:
 
     def _generate_title_author_query(self, title, author):
         return f"ti:{title} au:{author}"
+    
+    def _get_error_type(oclc_response) -> Optional[str]:
+        default_error_type = 'unknown'
+
+        try:
+            return oclc_response.json().get('type', default_error_type)
+        except Exception:
+            return default_error_type
 
 class OCLCCatalogError(Exception):
     def __init__(self, message=None):

--- a/managers/oclc_catalog.py
+++ b/managers/oclc_catalog.py
@@ -74,7 +74,7 @@ class OCLCCatalogManager:
 
             return related_oclc_numbers
         except Exception as e:
-            logger.error(f'Failed to get related OCLC numbers for {oclc_number}', e)
+            logger.error(f'Failed to get related OCLC numbers for {oclc_number} due to {e}')
             return related_oclc_numbers
         
     def _get_other_editions(self, oclc_number: int, offset: int=0):
@@ -107,7 +107,7 @@ class OCLCCatalogManager:
 
             return other_editions_response.json()
         except Exception as e:
-            logger.error(f'Failed to query other editions endpoint {other_editions_url}', e)
+            logger.error(f'Failed to query other editions endpoint {other_editions_url} due to {e}')
             return None
 
     def _get_oclc_number_from_bibs(self, oclc_number: int, oclc_bibs) -> int:

--- a/managers/oclc_catalog.py
+++ b/managers/oclc_catalog.py
@@ -100,7 +100,7 @@ class OCLCCatalogManager:
             if other_editions_response.status_code != 200:
                 logger.warning(
                     f'OCLC other editions request for OCLC number {oclc_number} failed with status: {status_code} '
-                    f'and reason: {self._get_error_type(other_editions_response)}'
+                    f'due to: {self._get_error_detail(other_editions_response)}'
                 )
 
                 return None
@@ -165,7 +165,7 @@ class OCLCCatalogManager:
             if status_code != 200:
                 logger.warning(
                     f'OCLC search bibs request for query {query} failed with status: {status_code} '
-                    f'and reason: {self._get_error_type(bibs_response)}'
+                    f'due to: {self._get_error_detail(bibs_response)}'
                 )
                 
                 return None
@@ -195,13 +195,13 @@ class OCLCCatalogManager:
     def _generate_title_author_query(self, title, author):
         return f"ti:{title} au:{author}"
     
-    def _get_error_type(oclc_response) -> Optional[str]:
-        default_error_type = 'unknown'
+    def _get_error_detail(oclc_response) -> Optional[str]:
+        default_error_detail = 'unknown'
 
         try:
-            return oclc_response.json().get('type', default_error_type)
+            return oclc_response.json().get('detail', default_error_detail)
         except Exception:
-            return default_error_type
+            return default_error_detail
 
 class OCLCCatalogError(Exception):
     def __init__(self, message=None):

--- a/mappings/oclcCatalog.py
+++ b/mappings/oclcCatalog.py
@@ -161,9 +161,7 @@ class CatalogMapping(XMLMapping):
         self.record.source_id = self.record.identifiers[0]
         self.record.frbr_status = 'complete'
 
-        logger.info('Formatting OCLC Catalog record {}'.format(
-            self.record.source_id
-        ))
+        logger.info(f'Formatting OCLC Catalog record with id: {self.record.source_id}')
 
         # Parse language field
         logger.debug('Parsing ISO lang code from 008 fixed field')

--- a/mappings/xml.py
+++ b/mappings/xml.py
@@ -2,6 +2,9 @@ from itertools import zip_longest
 from lxml import etree
 
 from .core import Core
+from logger import createLog
+
+logger = createLog(__name__)
 
 
 class XMLMapping(Core):
@@ -19,7 +22,7 @@ class XMLMapping(Core):
                 else:
                     fieldData = [f for s in structure for f in self.getFieldData(s)]
             except IndexError:
-                print('Missing data from field {}'.format(field))
+                logger.debug(f'Missing data from field: {field}')
                 continue
             
             setattr(newRecord, field, fieldData)

--- a/processes/developmentSetup.py
+++ b/processes/developmentSetup.py
@@ -8,7 +8,6 @@ import requests
 import sqlalchemy as sa
 from sqlalchemy.exc import ProgrammingError
 from time import sleep
-import alembic.config
 
 from managers.db import DBManager
 from .core import CoreProcess
@@ -35,7 +34,6 @@ class DevelopmentSetupProcess(CoreProcess):
         self.createSession()
 
         self.initializeDatabase()
-        self.runDBMigration()
 
         self.createElasticConnection()
         self.waitForElasticSearch()
@@ -60,16 +58,6 @@ class DevelopmentSetupProcess(CoreProcess):
         
         clusterProc = ClusterProcess(*procArgs)
         clusterProc.runProcess()
-
-    def runDBMigration(self):
-        try:
-            alembicArgs = [
-                '--raiseerr',
-                'upgrade', 'head',
-            ]
-            alembic.config.main(argv=alembicArgs)
-        except Exception as e:
-            print(f'Failed to run database migration due to: {e}')
 
     def initializeDB(self):
         self.adminDBConnection.generateEngine()

--- a/processes/developmentSetup.py
+++ b/processes/developmentSetup.py
@@ -56,7 +56,7 @@ class DevelopmentSetupProcess(CoreProcess):
         classifyProc.runProcess()
 
         catalogProc = CatalogProcess(*procArgs)
-        catalogProc.runProcess()
+        catalogProc.runProcess(max_attempts=1)
         
         clusterProc = ClusterProcess(*procArgs)
         clusterProc.runProcess()

--- a/processes/oclcCatalog.py
+++ b/processes/oclcCatalog.py
@@ -41,7 +41,7 @@ class CatalogProcess(CoreProcess):
             )
 
             if msgProps is None:
-                if attempts <= 3:
+                if attempts <= 1:
                     waitTime = 60 * attempts
 
                     logger.info('Waiting {}s for addtl recs'.format(waitTime))

--- a/processes/oclcCatalog.py
+++ b/processes/oclcCatalog.py
@@ -41,7 +41,7 @@ class CatalogProcess(CoreProcess):
             )
 
             if msgProps is None:
-                if attempts <= 1:
+                if attempts <= 3:
                     waitTime = 60 * attempts
 
                     logger.info('Waiting {}s for addtl recs'.format(waitTime))

--- a/processes/oclcCatalog.py
+++ b/processes/oclcCatalog.py
@@ -24,20 +24,20 @@ class CatalogProcess(CoreProcess):
 
         self.oclcCatalogManager = OCLCCatalogManager()
 
-    def runProcess(self):
-        self.receiveAndProcessMessages()
+    def runProcess(self, max_attempts: int=3):
+        self.receiveAndProcessMessages(max_attempts=max_attempts)
 
         self.saveRecords()
         self.commitChanges()
 
-    def receiveAndProcessMessages(self):
+    def receiveAndProcessMessages(self, max_attempts: int=3):
         attempts = 1
 
         while True:
             msgProps, _, msgBody = self.getMessageFromQueue(os.environ['OCLC_QUEUE'])
 
             if msgProps is None:
-                if attempts <= 3:
+                if attempts <= max_attempts:
                     waitTime = 60 * attempts
 
                     logger.info(f'Waiting {waitTime}s for OCLC catalog messages')

--- a/processes/oclcCatalog.py
+++ b/processes/oclcCatalog.py
@@ -58,23 +58,24 @@ class CatalogProcess(CoreProcess):
 
     def processCatalogQuery(self, msgBody):
         message = json.loads(msgBody)
-        oclcNo = message['oclcNo']
+        oclcNo = message.get('oclcNo')
+        owiNo = message.get('owiNo')
         
         catalogXML = self.oclcCatalogManager.query_catalog(oclcNo)
 
         if not catalogXML:
             return
         
-        self.parseCatalogRecord(catalogXML, message['owiNo'])
+        self.parseCatalogRecord(catalogXML, oclcNo, owiNo)
 
 
-    def parseCatalogRecord(self, catalogXML, owiNo):
+    def parseCatalogRecord(self, catalogXML, oclcNo, owiNo):
         try:
             parseMARC = etree.fromstring(catalogXML.encode('utf-8'))
         except etree.XMLSyntaxError as e:
-            logger.error(f'OCLC catalog MARC xml is invalid for work id: {owiNo}')
+            logger.error(f'OCLC catalog MARC xml is invalid for OCLC number: {oclcNo}')
             logger.debug(e)
-            return None
+            return
 
         catalogRec = CatalogMapping(
             parseMARC,

--- a/processes/oclcClassify.py
+++ b/processes/oclcClassify.py
@@ -116,14 +116,14 @@ class ClassifyProcess(CoreProcess):
             try:
                 self.classify_record_by_metadata_v2(identifier, idenType, author, record.title)
             except Exception as e:
-                logger.warning(f'Unable to classify {record} due to {e.message}')
+                logger.warning(f'Unable to classify {record} due to {e}')
 
     def classify_record_by_metadata_v2(self, identifier, identifier_type, author, title):
         search_query = self.oclc_catalog_manager.generate_search_query(identifier, identifier_type, title, author)
 
         related_oclc_bibs = self.oclc_catalog_manager.query_bibs(search_query)
 
-        if not len(related_oclc_bib):
+        if not len(related_oclc_bibs):
             logger.warning(f'No OCLC bibs returned for query {search_query}')
 
         for related_oclc_bib in related_oclc_bibs:

--- a/processes/oclcClassify.py
+++ b/processes/oclcClassify.py
@@ -123,6 +123,9 @@ class ClassifyProcess(CoreProcess):
 
         related_oclc_bibs = self.oclc_catalog_manager.query_bibs(search_query)
 
+        if not len(related_oclc_bib):
+            logger.warning(f'No OCLC bibs returned for query {search_query}')
+
         for related_oclc_bib in related_oclc_bibs:
             oclc_number = related_oclc_bib.get('identifier', {}).get('oclcNumber')
             owi_number = related_oclc_bib.get('work', {}).get('id')
@@ -197,6 +200,7 @@ class ClassifyProcess(CoreProcess):
 
         for oclcNo, updateReq in checkedIDs:
             if updateReq is False:
+                logger.debug(f'Skipping catalog lookup process for OCLC number {oclcNo}')
                 continue
 
             self.sendCatalogLookupMessage(oclcNo, owiNo)
@@ -205,13 +209,11 @@ class ClassifyProcess(CoreProcess):
         if counter > 0:
             self.setIncrementerRedis('oclcCatalog', 'API', amount=counter)
 
-    def sendCatalogLookupMessage(self, oclcNo, owiNo):
-        logger.debug('Sending OCLC# {} to queue'.format(oclcNo))
-        self.sendMessageToQueue(
-            self.rabbitQueue,
-            self.rabbitRoute,
-            {'oclcNo': oclcNo, 'owiNo': owiNo}
-        )
+    def sendCatalogLookupMessage(self, oclc_number, owiNo):
+        catalog_lookup_message = { 'oclcNo': oclc_number, 'owiNo': owiNo }
+        logger.debug(f'Sending catalog lookup message {catalog_lookup_message} to queue')
+        
+        self.sendMessageToQueue(self.rabbitQueue, self.rabbitRoute, catalog_lookup_message)
 
     def check_if_classify_work_fetched(self, owi_number: int) -> bool:
         return self.checkSetRedis('classifyWork', owi_number, 'owi')

--- a/tests/unit/test_oclcCatalog_process.py
+++ b/tests/unit/test_oclcCatalog_process.py
@@ -68,7 +68,7 @@ class TestOCLCCatalogProcess:
         testInstance.processCatalogQuery('{"oclcNo": 1, "owiNo": 1}')
 
         testInstance.oclcCatalogManager.query_catalog.assert_called_once_with(1)
-        mockParser.assert_called_once_with('testXML', 1)
+        mockParser.assert_called_once_with('testXML', 1, 1)
 
     def test_processCatalogQuery_no_record_found(self, testInstance, mocker):
         testInstance.oclcCatalogManager.query_catalog.return_value = None
@@ -89,7 +89,7 @@ class TestOCLCCatalogProcess:
 
         mockAdd = mocker.patch.object(CatalogProcess, 'addDCDWToUpdateList')
 
-        testInstance.parseCatalogRecord('rawXML', 1)
+        testInstance.parseCatalogRecord('rawXML', 1, 1)
 
         mockXMLParser.assert_called_once_with(b'rawXML')
         mockMapping.assert_called_once_with(
@@ -110,7 +110,7 @@ class TestOCLCCatalogProcess:
 
         mockAdd = mocker.patch.object(CatalogProcess, 'addDCDWToUpdateList')
 
-        testInstance.parseCatalogRecord('rawXML', 1)
+        testInstance.parseCatalogRecord('rawXML', 1, 1)
 
         mockXMLParser.assert_called_once_with(b'rawXML')
         mockMapping.assert_called_once_with(
@@ -126,7 +126,7 @@ class TestOCLCCatalogProcess:
 
         mockAdd = mocker.patch.object(CatalogProcess, 'addDCDWToUpdateList')
 
-        testInstance.parseCatalogRecord('rawXML', 1)
+        testInstance.parseCatalogRecord('rawXML', 1, 1)
 
         mockMapping.assert_not_called()
         mockCatalogRec.applyMapping.assert_not_called()


### PR DESCRIPTION
## Description
- Improves error handling and logging in the OCLC classify process
- Switches to using detail from OCLC error response, e.g:
```
{
  "type": "INVALID_QUERY_PARAMETER_VALUE",
  "title": "Validation Failure",
  "detail": "oclcNumber must be a positive whole number"
}
```

## Testing 
`make test`