### PR TITLE
NO-REF: Fixing OCLC catalog query attempts bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 - Fixed edition API ID param
 - Fixed usage type bug
 - Fixed OCLC bib author mapping
+- Fixed OCLC catalog query attempts bug
 
 ## 2024-08-06 -- v0.13.1
 

--- a/mappings/oclcCatalog.py
+++ b/mappings/oclcCatalog.py
@@ -160,17 +160,10 @@ class CatalogMapping(XMLMapping):
         self.record.source = 'oclcCatalog'
         self.record.source_id = self.record.identifiers[0]
         self.record.frbr_status = 'complete'
-
-        logger.info(f'Formatting OCLC Catalog record with id: {self.record.source_id}')
-
-        # Parse language field
-        logger.debug('Parsing ISO lang code from 008 fixed field')
+        
         _, _, lang_3, *_ = tuple(self.record.languages[0].split('|'))
         self.record.languages = [('||{}'.format(lang_3[35:38]))]
-
-        # Parse has_part fields (fetch only top 10 for perfomance reasons)
-        logger.debug('Parsing has_part links for valid/resolvable URLs')
-
+        
         self.record.has_part = self.record.has_part[:10]
 
         self.record.has_part = list(filter(None, [

--- a/processes/oclcCatalog.py
+++ b/processes/oclcCatalog.py
@@ -64,10 +64,11 @@ class CatalogProcess(CoreProcess):
         catalogXML = self.oclcCatalogManager.query_catalog(oclcNo)
 
         if not catalogXML:
+            logger.warning(f'Unable to get catalog XML for OCLC number {oclcNo}')
             return
         
         self.parseCatalogRecord(catalogXML, oclcNo, owiNo)
-
+        logger.info(f'Processed OCLC catalog query for OCLC number {oclcNo}')
 
     def parseCatalogRecord(self, catalogXML, oclcNo, owiNo):
         try:

--- a/processes/oclcClassify.py
+++ b/processes/oclcClassify.py
@@ -139,6 +139,8 @@ class ClassifyProcess(CoreProcess):
 
             related_oclc_numbers = self.oclc_catalog_manager.get_related_oclc_numbers(oclc_number=oclc_number)
 
+            logger.info(f'Found {len(related_oclc_numbers)} related OCLC numbers for OCLC number: {oclc_number}')
+
             oclc_record = OCLCBibMapping(
                 oclc_bib=related_oclc_bib, 
                 related_oclc_numbers=related_oclc_numbers

--- a/processes/oclcClassify.py
+++ b/processes/oclcClassify.py
@@ -139,8 +139,6 @@ class ClassifyProcess(CoreProcess):
 
             related_oclc_numbers = self.oclc_catalog_manager.get_related_oclc_numbers(oclc_number=oclc_number)
 
-            logger.info(f'Found {len(related_oclc_numbers)} related OCLC numbers for OCLC number: {oclc_number}')
-
             oclc_record = OCLCBibMapping(
                 oclc_bib=related_oclc_bib, 
                 related_oclc_numbers=related_oclc_numbers

--- a/tests/unit/test_oclcCatalog_manager.py
+++ b/tests/unit/test_oclcCatalog_manager.py
@@ -13,8 +13,7 @@ class TestOCLCCatalogManager:
         return OCLCCatalogManager()
 
     def test_initializer(self, testInstance):
-        assert testInstance.oclcKey == 'test_api_key'
-        assert testInstance.attempts == 0
+        assert testInstance.oclc_key == 'test_api_key'
 
     def test_query_catalog_success(self, testInstance, mocker):
         mockResponse = mocker.MagicMock()


### PR DESCRIPTION
## Description
- We discovered that the ratio of OCLC catalog records in QA vs local did not make sense
- There was bug in the OCLC catalog manager where the attempts kept increasing since it was a class variable and we we would not actually call OCLC. 

## Testing
Ran ETL pipeline against subset of HathiTrust record to see the increase in OCLC catalog records:

<img width="532" alt="Screenshot 2024-09-19 at 4 56 41 PM" src="https://github.com/user-attachments/assets/881c6842-a4ba-4665-af1b-34d8e79beedc">
