### PR TITLE
NO-REF: Using exception for logging API errors

### DIFF
--- a/api/blueprints/drbCitation.py
+++ b/api/blueprints/drbCitation.py
@@ -40,8 +40,8 @@ def get_citation(uuid):
                     output_citations[format] = mla_citation
 
             return APIUtils.formatResponseObject(200, response_type, output_citations)
-    except Exception as e:
-        logger.error(e)
+    except Exception:
+        logger.exception(f'Unable to get citation for work with id {uuid}')
         return APIUtils.formatResponseObject(500, response_type, { 'message': f'Unable to get citation for work with id {uuid}' })
 
 

--- a/api/blueprints/drbCollection.py
+++ b/api/blueprints/drbCollection.py
@@ -286,8 +286,8 @@ def get_collection(uuid):
         return APIUtils.formatOPDS2Object(200, opds_feed)
     except NoResultFound:
         return APIUtils.formatResponseObject(404, response_type, { 'message': f'No collection found with id {uuid}' })
-    except Exception as e:
-        logger.error(e)
+    except Exception:
+        logger.exception(f'Unable to get collection with id {uuid}')
         return APIUtils.formatResponseObject(500, response_type, { 'message': f'Unable to get collection with id {uuid}' })
 
 @collection.route('/<uuid>', methods=['DELETE'])
@@ -400,8 +400,8 @@ def get_collections():
         db_client.closeSession()
 
         return APIUtils.formatOPDS2Object(200, opds_feed)
-    except Exception as e:
-        logger.error(e)
+    except Exception:
+        logger.exception('Unable to get collections')
         return APIUtils.formatResponseObject(500, response_type, { 'message': 'Unable to get collections' })
 
 

--- a/api/blueprints/drbEdition.py
+++ b/api/blueprints/drbEdition.py
@@ -39,6 +39,6 @@ def get_edition(edition_id):
                     edition, request=request, records=records, dbClient=db_client, showAll=show_all, formats=filtered_formats, reader=reader_version
                 )
             )
-    except Exception as e: 
-        logger.error(e)
+    except Exception: 
+        logger.exception(f'Unable to get edition with id {edition_id}')
         return APIUtils.formatResponseObject(500, response_type, { 'message': f'Unable to get edition with id {edition_id}' })

--- a/api/blueprints/drbFulfill.py
+++ b/api/blueprints/drbFulfill.py
@@ -44,8 +44,8 @@ def fulfill_item(link_id):
 
         if requires_authorization:
             return redirect_to_link_url(link.url)
-    except Exception as e:
-        logger.error(e)
+    except Exception:
+        logger.exception(f'Unable to fulfill link with id {link_id}')
         return APIUtils.formatResponseObject(
             500, 
             response_type, 

--- a/api/blueprints/drbLink.py
+++ b/api/blueprints/drbLink.py
@@ -32,8 +32,8 @@ def get_link(link_id):
                 response_type,
                 APIUtils.formatLinkOutput(link, request=request)
             )
-    except Exception as e:
-        logger.error(e)
+    except Exception:
+        logger.exception(f'Unable to get link with id {link_id}')
         return APIUtils.formatResponseObject(
             500, 
             response_type, 

--- a/api/blueprints/drbSearch.py
+++ b/api/blueprints/drbSearch.py
@@ -34,7 +34,7 @@ def query():
         try:
             search_result = es_client.searchQuery(terms, page=search_page, perPage=search_size)
         except ElasticClientError as e:
-            logger.error(e)
+            logger.exception('Unable to execute search')
             return APIUtils.formatResponseObject(500, response_type, { 'message': 'Unable to execute search' })
 
         results = []
@@ -82,6 +82,6 @@ def query():
         db_client.closeSession()
 
         return APIUtils.formatResponseObject(200, response_type, data_block)
-    except Exception as e:
-        logger.error(e) 
+    except Exception:
+        logger.exception('Unable to execute search') 
         return APIUtils.formatResponseObject(500, response_type, { 'message': 'Unable to execute search' })

--- a/api/blueprints/drbUtils.py
+++ b/api/blueprints/drbUtils.py
@@ -38,8 +38,8 @@ def get_languages():
             response_type,
             APIUtils.formatLanguages(language_query_results.aggregations, work_counts)
         )
-    except Exception as e:
-        logger.error(e)
+    except Exception:
+        logger.exception('Unable to get language counts')
         return APIUtils.formatResponseObject(500, response_type, 'Unable to get language counts')
 
 
@@ -52,8 +52,8 @@ def get_counts():
             total_counts = db_client.fetchRowCounts()
 
         return APIUtils.formatResponseObject(200, response_type, APIUtils.formatTotals(total_counts))
-    except Exception as e:
-        logger.error(e)
+    except Exception:
+        logger.exception('Unable to get total counts')
         return APIUtils.formatResponseObject(500, response_type, 'Unable to get total counts')
 
 
@@ -105,5 +105,5 @@ def proxy_response():
 
         return Response(response.content, response.status_code, headers)
     except Exception as e:
-        logger.error(e)
+        logger.error('Unable to proxy response', e)
         return Response('Unable to proxy response', 500)

--- a/api/blueprints/drbWork.py
+++ b/api/blueprints/drbWork.py
@@ -36,6 +36,6 @@ def get_work(uuid):
                     request=request, dbClient=db_client, formats=filtered_formats, reader=reader_version
                 )
             )
-    except Exception as e:
-        logger.error(e)
+    except Exception:
+        logger.exception(f'Unable to get work with id {uuid}')
         return APIUtils.formatResponseObject(500, response_type, { 'message': f'Unable to get work with id {uuid}' })


### PR DESCRIPTION
## Description
- logger.exception is a shorthand way of including the exception info in the error log: 

```
drb_local_api  | {"timestamp":1727728537921,"message":"Unable to get total counts","log.level":"ERROR","logger.name":"api.blueprints.drbUtils","thread.id":140425797289664,"thread.name":"Thread-2","process.id":1924,"process.name":"MainProcess","file.name":"/src/api/blueprints/drbUtils.py","line.number":57,"entity.type":"SERVICE","error.class":"builtins:Exception","error.message":"Hello"}
```

## Testing
`docker compose up`