### PR TITLE
SFR-2216: Adding ingest limit and logging to HathiTrust ingest

### DIFF
--- a/main.py
+++ b/main.py
@@ -29,7 +29,7 @@ def main(args):
     offset = args.offset
     options = args.options
 
-    logger.info('Staring Process {} in {}'.format(process, environment))
+    logger.info('Starting process {} in {}'.format(process, environment))
     logger.debug('Process Args Type: {}, Limit: {}, Offset: {}, Date: {}, File: {}, Record: {}'.format(
         procType, limit, offset, startDate, customFile, singleRecord
     ))

--- a/tests/unit/test_hathitrust_process.py
+++ b/tests/unit/test_hathitrust_process.py
@@ -22,6 +22,8 @@ class TestHathiTrustProcess:
         class TestHathiProcess(HathiTrustProcess):
             def __init__(self, process, customFile, ingestPeriod):
                 self.statics = {}
+                self.records = []
+                self.ingest_limit = None
         
         return TestHathiProcess('TestProcess', 'testFile', 'testDate')
     


### PR DESCRIPTION
## Description
- Adds ingest limit and logging to HathiTrust ingest

## Testing
`python main.py -p HathiTrustProcess -e local -i complete -l 10`
![Screenshot 2024-10-04 at 11 23 16 AM](https://github.com/user-attachments/assets/ab566036-345f-4c8b-bfe7-b84e303f3c94)
