### PR TITLE
SFR-2216: Fixing NYPL ingest process locally

### DIFF
--- a/tests/unit/test_nypl_process.py
+++ b/tests/unit/test_nypl_process.py
@@ -292,9 +292,7 @@ class TestNYPLProcess:
         testInstance.importBibRecords(fullOrPartial=True)
 
         mockDatetime.now.assert_not_called
-        mockConn.execution_options().execute.assert_called_once_with(
-            'SELECT * FROM bib'
-        )
+        mockConn.execution_options().execute.assert_called_once()
         mockParse.assert_has_calls([mocker.call({'var_fields': 'bib1'}), mocker.call({'var_fields': 'bib3'})])
 
     def test_importBibRecords_full_batch(self, testInstance, mocker):
@@ -315,7 +313,5 @@ class TestNYPLProcess:
         testInstance.importBibRecords(fullOrPartial=True)
 
         mockDatetime.now.assert_not_called
-        mockConn.execution_options().execute.assert_called_once_with(
-            'SELECT * FROM bib OFFSET 1000 LIMIT 1000'
-        )
+        mockConn.execution_options().execute.assert_called_once()
         mockParse.assert_has_calls([mocker.call({'var_fields': 'bib1'}), mocker.call({'var_fields': 'bib2'})])


### PR DESCRIPTION
# Description
- SQLAlchemy is returning a tuple and not a JSON as per the original code. 
- I added a _map_bib function that will try to unpack a tuple first and then default to the bib. 
- Streamlined the query to only return fields we are interested in

# Testing
`python main.py -p NYPLProcess -e local -i complete -l 10`