### PR TITLE
SFR-2234 SFR-2235: Fix bugs in DOAB ingestion process

### DIFF
--- a/managers/doabParser.py
+++ b/managers/doabParser.py
@@ -72,7 +72,12 @@ class DOABLinkManager:
         self.record.has_part = parsedLinks
     
     @staticmethod
-    def findFinalURI(uri, mediaType):
+    def findFinalURI(uri, mediaType, redirects=0):
+        max_redirects = 5
+
+        if redirects > max_redirects:
+            return (uri, mediaType)
+
         try:
             uriHeader = requests.head(uri, allow_redirects=False, timeout=15)
             headers = dict((key.lower(), value) for key, value in uriHeader.headers.items())
@@ -93,7 +98,9 @@ class DOABLinkManager:
                 uriRoot = re.split(r'(?<![\/:])\/{1}', uri)[0]
                 redirectURI = '{}{}'.format(uriRoot, redirectURI)
 
-            return DOABLinkManager.findFinalURI(redirectURI, mediaType)
+            redirects += 1
+
+            return DOABLinkManager.findFinalURI(redirectURI, mediaType, redirects)
         
         return (uri, mediaType)
 

--- a/managers/parsers/openEditionParser.py
+++ b/managers/parsers/openEditionParser.py
@@ -92,6 +92,9 @@ class OpenEditionParser(AbstractParser):
 
         accessElement = oePage.find(id='book-access')
 
+        if not accessElement:
+            return []
+
         accessLinks = accessElement.find_all('a')
 
         return list(filter(None, [self.parseBookLink(l) for l in accessLinks]))

--- a/processes/doab.py
+++ b/processes/doab.py
@@ -130,6 +130,10 @@ class DOABProcess(CoreProcess):
 
     def downloadOAIRecords(self, fullOrPartial, startTimestamp, resumptionToken=None):
         doabURL = os.environ['DOAB_OAI_URL']
+        headers = {
+            # Pass a user-agent header to prevent 403 unauthorized responses from DOAB
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3"
+        }
 
         urlParams = 'verb=ListRecords'
         if resumptionToken:
@@ -143,7 +147,7 @@ class DOABProcess(CoreProcess):
 
         doabURL = '{}{}'.format(doabURL, urlParams)
 
-        doabResponse = requests.get(doabURL, stream=True, timeout=30)
+        doabResponse = requests.get(doabURL, stream=True, timeout=30, headers=headers)
 
         if doabResponse.status_code == 200:
             content = bytes()

--- a/tests/unit/test_doab_process.py
+++ b/tests/unit/test_doab_process.py
@@ -2,6 +2,8 @@ import datetime
 from io import BytesIO
 import pytest
 import requests
+from unittest import mock
+
 
 from processes.doab import DOABProcess, DOABError
 from mappings.core import MappingError
@@ -212,7 +214,9 @@ class TestDOABProcess:
         assert testRecords.read() == b'marc'
         mockOAIQuery.assert_called_once_with(
             'test_doab_urlverb=ListRecords&metadataPrefix=oai_dc',
-            stream=True, timeout=30
+            stream=True, 
+            timeout=30,
+            headers=mock.ANY
         )
 
     def test_downloadOAIRecords_daily(self, testProcess, mockOAIQuery, mocker):
@@ -224,7 +228,9 @@ class TestDOABProcess:
         assert testRecords.read() == b'marc'
         mockOAIQuery.assert_called_once_with(
             'test_doab_urlverb=ListRecords&metadataPrefix=oai_dc&from=1900-01-01',
-            stream=True, timeout=30
+            stream=True, 
+            timeout=30,
+            headers=mock.ANY
         )
 
     def test_downloadOAIRecords_custom(self, testProcess, mockOAIQuery):
@@ -233,7 +239,9 @@ class TestDOABProcess:
         assert testRecords.read() == b'marc'
         mockOAIQuery.assert_called_once_with(
             'test_doab_urlverb=ListRecords&metadataPrefix=oai_dc&from=2020-01-01',
-            stream=True, timeout=30
+            stream=True, 
+            timeout=30,
+            headers=mock.ANY
         )
 
     def test_downloadOAIRecords_error(self, testProcess, mockOAIQuery, mocker):
@@ -250,7 +258,9 @@ class TestDOABProcess:
         assert testRecords.read() == b'marc'
         mockOAIQuery.assert_called_once_with(
             'test_doab_urlverb=ListRecords&resumptionToken=testRes',
-            stream=True, timeout=30
+            stream=True, 
+            timeout=30,
+            headers=mock.ANY
         )
 
     def test_parseDOABRecord_success(self, testProcess, mocker):


### PR DESCRIPTION
# Description
- DOAB is returning 200 from the browser but not from Python code
- Adding a user agent header to mimic the header that the browser sends 
- Fixes bug where book-access element does not exist
- Fixes bug where finding final URI had too many redirects and hit the recursion call stack limit of 1000

# Testing 
`python main.py -p DOABProcess -e local -i complete -l 10`

