### PR TITLE
SFR-2220: Cleaning up NYPL ingestion process

### DIFF
--- a/processes/core.py
+++ b/processes/core.py
@@ -1,4 +1,4 @@
-from managers import DBManager, RabbitMQManager, RedisManager, ElasticsearchManager, S3Manager, NyplApiManager
+from managers import DBManager, RabbitMQManager, RedisManager, ElasticsearchManager, S3Manager
 from model import Record
 from static.manager import StaticManager
 
@@ -8,7 +8,7 @@ from logger import createLog
 logger = createLog(__name__)
 
 
-class CoreProcess(DBManager, NyplApiManager, RabbitMQManager, RedisManager, StaticManager,
+class CoreProcess(DBManager, RabbitMQManager, RedisManager, StaticManager,
                   ElasticsearchManager, S3Manager):
     def __init__(self, process, customFile, ingestPeriod, singleRecord, batchSize=500):
         super(CoreProcess, self).__init__()

--- a/tests/unit/test_nypl_process.py
+++ b/tests/unit/test_nypl_process.py
@@ -21,11 +21,12 @@ class TestNYPLProcess:
         class TestNYPLProcess(NYPLProcess):
             def __init__(self, process, customFile, ingestPeriod):
                 self.statics = {}
-                self.bibDBConnection = mocker.MagicMock()
-                self.locationCodes = {}
-                self.cceAPI = 'test_cce_url'
-                self.ingestOffset = None
-                self.ingestLimit = None
+                self.bib_db_connection = mocker.MagicMock()
+                self.nypl_api_manager = mocker.MagicMock()
+                self.location_codes = {}
+                self.cce_api = 'test_cce_url'
+                self.ingest_offset = None
+                self.ingest_limit = None
         
         return TestNYPLProcess('TestProcess', 'testFile', 'testDate')
 
@@ -56,7 +57,7 @@ class TestNYPLProcess:
         ]
     
     def test_runProcess_daily(self, testInstance, mocker):
-        mockImport = mocker.patch.object(NYPLProcess, 'importBibRecords')
+        mockImport = mocker.patch.object(NYPLProcess, 'import_bib_records')
         mockSave = mocker.patch.object(NYPLProcess, 'saveRecords')
         mockCommit = mocker.patch.object(NYPLProcess, 'commitChanges')
 
@@ -68,19 +69,19 @@ class TestNYPLProcess:
         mockCommit.assert_called_once
 
     def test_runProcess_complete(self, testInstance, mocker):
-        mockImport = mocker.patch.object(NYPLProcess, 'importBibRecords')
+        mockImport = mocker.patch.object(NYPLProcess, 'import_bib_records')
         mockSave = mocker.patch.object(NYPLProcess, 'saveRecords')
         mockCommit = mocker.patch.object(NYPLProcess, 'commitChanges')
 
         testInstance.process = 'complete'
         testInstance.runProcess()
 
-        mockImport.assert_called_once_with(fullOrPartial=True)
+        mockImport.assert_called_once_with(full_or_partial=True)
         mockSave.assert_called_once
         mockCommit.assert_called_once
 
     def test_runProcess_custom(self, testInstance, mocker):
-        mockImport = mocker.patch.object(NYPLProcess, 'importBibRecords')
+        mockImport = mocker.patch.object(NYPLProcess, 'import_bib_records')
         mockSave = mocker.patch.object(NYPLProcess, 'saveRecords')
         mockCommit = mocker.patch.object(NYPLProcess, 'commitChanges')
 
@@ -88,126 +89,124 @@ class TestNYPLProcess:
         testInstance.ingestPeriod = 'customTimestamp'
         testInstance.runProcess()
 
-        mockImport.assert_called_once_with(startTimestamp='customTimestamp')
+        mockImport.assert_called_once_with(start_timestamp='customTimestamp')
         mockSave.assert_called_once
         mockCommit.assert_called_once
 
-    def test_loadLocationCodes(self, testInstance, mocker):
+    def test_load_location_codes(self, testInstance, mocker):
         mockGet = mocker.patch.object(requests, 'get')
         mockResp = mocker.MagicMock()
         mockResp.json.return_value = 'testLocationCodes'
         mockGet.return_value = mockResp
 
-        testResponse = testInstance.loadLocationCodes()
+        testResponse = testInstance.load_location_codes()
 
         assert testResponse == 'testLocationCodes'
         mockGet.assert_called_once_with('test_location_url')
         mockResp.json.assert_called_once
 
-    def test_isPDResearchBib_post_1964(self, testInstance, testBib, mocker):
-        assert testInstance.isPDResearchBib(testBib) is False
+    def test_is_pd_research_bib_post_1964(self, testInstance, testBib, mocker):
+        assert testInstance.is_pd_research_bib(testBib) is False
 
-    def test_isPDResearchBib_no_year(self, testInstance, testBib, mocker):
+    def test_is_pd_research_bib_no_year(self, testInstance, testBib, mocker):
         testBib['publish_year'] = None
-        assert testInstance.isPDResearchBib(testBib) is False
+        assert testInstance.is_pd_research_bib(testBib) is False
 
-    def test_isPDResearchBib_1925_to_1964_pd_non_research(self, testInstance, testBib, mocker):
-        testInstance.queryApi = mocker.MagicMock()
-        testInstance.queryApi.return_value = {'isResearch': False}
+    def test_is_pd_research_bib_1925_to_1964_pd_non_research(self, testInstance, testBib, mocker):
+        testInstance.nypl_api_manager.queryApi.return_value = {'isResearch': False}
 
         testBib['publish_year'] = '1950'
 
-        mockGetCopyright = mocker.patch.object(NYPLProcess, 'getCopyrightStatus')
+        mockGetCopyright = mocker.patch.object(NYPLProcess, 'get_copyright_status')
         mockGetCopyright.return_value = True
-        assert testInstance.isPDResearchBib(testBib) is False
+        assert testInstance.is_pd_research_bib(testBib) is False
 
-    def test_isPDResearchBib_pre_1925_research(self, testInstance, testBib, mocker):
-        testInstance.queryApi = mocker.MagicMock()
-        testInstance.queryApi.return_value = {'isResearch': True}
-        mockGetCopyright = mocker.patch.object(NYPLProcess, 'getCopyrightStatus')
+    def test_is_pd_research_bib_pre_1925_research(self, testInstance, testBib, mocker):
+        testInstance.nypl_api_manager.queryApi.return_value = {'isResearch': True}
+        mockGetCopyright = mocker.patch.object(NYPLProcess, 'get_copyright_status')
 
         testBib['publish_year'] = '1900'
 
-        assert testInstance.isPDResearchBib(testBib) is True 
+        assert testInstance.is_pd_research_bib(testBib) is True 
         mockGetCopyright.assert_not_called
 
-    def test_getCopyrightStatus_no_lccn(self, testInstance, testVarFields):
+    def test_get_copyright_status_no_lccn(self, testInstance, testVarFields):
         del testVarFields[1]
-        assert testInstance.getCopyrightStatus(testVarFields) is False
+        assert testInstance.get_copyright_status(testVarFields) is False
 
-    def test_getCopyrightStatus_api_error(self, testInstance, testVarFields, mocker):
+    def test_get_copyright_status_api_error(self, testInstance, testVarFields, mocker):
         mockReq = mocker.patch.object(requests, 'get')
         mockResp = mocker.MagicMock()
         mockResp.status_code = 500
         mockReq.return_value = mockResp
 
-        assert testInstance.getCopyrightStatus(testVarFields) is False
+        assert testInstance.get_copyright_status(testVarFields) is False
 
-    def test_getCopyrightStatus_no_registrations(self, testInstance, testVarFields, mocker):
+    def test_get_copyright_status_no_registrations(self, testInstance, testVarFields, mocker):
         mockReq = mocker.patch.object(requests, 'get')
         mockResp = mocker.MagicMock()
         mockResp.status_code = 200
         mockResp.json.return_value = {'data': {'results': []}}
         mockReq.return_value = mockResp
 
-        assert testInstance.getCopyrightStatus(testVarFields) is False
+        assert testInstance.get_copyright_status(testVarFields) is False
         mockReq.assert_called_once_with('test_cce_url/lccn/123456789')
 
-    def test_getCopyrightStatus_has_renewals(self, testInstance, testVarFields, mocker):
+    def test_get_copyright_status_has_renewals(self, testInstance, testVarFields, mocker):
         mockReq = mocker.patch.object(requests, 'get')
         mockResp = mocker.MagicMock()
         mockResp.status_code = 200
         mockResp.json.return_value = {'data': {'results': [{'renewals': ['ren1']}]}}
         mockReq.return_value = mockResp
 
-        assert testInstance.getCopyrightStatus(testVarFields) is False
+        assert testInstance.get_copyright_status(testVarFields) is False
         mockReq.assert_called_once_with('test_cce_url/lccn/123456789')
 
-    def test_getCopyrightStatus_not_renewed(self, testInstance, testVarFields, mocker):
+    def test_get_copyright_status_not_renewed(self, testInstance, testVarFields, mocker):
         mockReq = mocker.patch.object(requests, 'get')
         mockResp = mocker.MagicMock()
         mockResp.status_code = 200
         mockResp.json.return_value = {'data': {'results': [{'renewals': []}]}}
         mockReq.return_value = mockResp
 
-        assert testInstance.getCopyrightStatus(testVarFields) is True
+        assert testInstance.get_copyright_status(testVarFields) is True
         mockReq.assert_called_once_with('test_cce_url/lccn/123456789')
 
-    def test_fetchBibItems_success(self, testInstance, mocker):
-        testInstance.queryApi = mocker.MagicMock()
-        testInstance.queryApi.return_value = {'data': ['item1', 'item2', 'item3']}
+    def test_fetch_bib_items_success(self, testInstance, mocker):
+        testInstance.nypl_api_manager.queryApi = mocker.MagicMock()
+        testInstance.nypl_api_manager.queryApi.return_value = {'data': ['item1', 'item2', 'item3']}
 
-        testItems = testInstance.fetchBibItems({'nypl_source': 'sierra-test', 'id': 1})
+        testItems = testInstance.fetch_bib_items({'nypl_source': 'sierra-test', 'id': 1})
 
         assert testItems == ['item1', 'item2', 'item3']
 
-    def test_fetchBibItems_none(self, testInstance, mocker):
-        testInstance.queryApi = mocker.MagicMock()
-        testInstance.queryApi.return_value = {}
+    def test_fetch_bib_items_none(self, testInstance, mocker):
+        testInstance.nypl_api_manager.queryApi = mocker.MagicMock()
+        testInstance.nypl_api_manager.queryApi.return_value = {}
 
-        testItems = testInstance.fetchBibItems({'nypl_source': 'sierra-test', 'id': 1})
+        testItems = testInstance.fetch_bib_items({'nypl_source': 'sierra-test', 'id': 1})
 
         assert testItems == []
 
-    def test_parseNYPLDataRow_research(self, testInstance, mocker):
+    def test_parse_nypl_data_row_research(self, testInstance, mocker):
         processorMocks = mocker.patch.multiple(
             NYPLProcess,
-            isPDResearchBib=mocker.DEFAULT,
-            fetchBibItems=mocker.DEFAULT,
+            is_pd_research_bib=mocker.DEFAULT,
+            fetch_bib_items=mocker.DEFAULT,
             addDCDWToUpdateList=mocker.DEFAULT
         )
         mockMapping = mocker.patch('processes.nypl.NYPLMapping')
 
-        processorMocks['isPDResearchBib'].return_value = True
-        processorMocks['fetchBibItems'].return_value = 'testBibItems'
+        processorMocks['is_pd_research_bib'].return_value = True
+        processorMocks['fetch_bib_items'].return_value = 'testBibItems'
 
         mockRecord = mocker.MagicMock()
         mockMapping.return_value = mockRecord
 
-        testInstance.parseNYPLDataRow({'id': 1})
+        testInstance.parse_nypl_data_row({'id': 1})
 
-        processorMocks['isPDResearchBib'].assert_called_once_with({'id': 1})
-        processorMocks['fetchBibItems'].assert_called_once_with({'id': 1})
+        processorMocks['is_pd_research_bib'].assert_called_once_with({'id': 1})
+        processorMocks['fetch_bib_items'].assert_called_once_with({'id': 1})
         mockMapping.assert_called_once_with(
             {'id': 1}, 'testBibItems', {}, {}
         )
@@ -215,29 +214,29 @@ class TestNYPLProcess:
         processorMocks['addDCDWToUpdateList'].assert_called_once_with(mockRecord)
 
 
-    def test_parseNYPLDataRow_not_research(self, testInstance, mocker):
+    def test_parse_nypl_data_row_not_research(self, testInstance, mocker):
         processorMocks = mocker.patch.multiple(
             NYPLProcess,
-            isPDResearchBib=mocker.DEFAULT,
-            fetchBibItems=mocker.DEFAULT,
+            is_pd_research_bib=mocker.DEFAULT,
+            fetch_bib_items=mocker.DEFAULT,
             addDCDWToUpdateList=mocker.DEFAULT
         )
         mockMapping = mocker.patch('processes.nypl.NYPLMapping')
 
-        processorMocks['isPDResearchBib'].return_value = False
+        processorMocks['is_pd_research_bib'].return_value = False
 
-        testInstance.parseNYPLDataRow({'id': 1})
+        testInstance.parse_nypl_data_row({'id': 1})
 
-        processorMocks['isPDResearchBib'].assert_called_once_with({'id': 1})
-        processorMocks['fetchBibItems'].assert_not_called
+        processorMocks['is_pd_research_bib'].assert_called_once_with({'id': 1})
+        processorMocks['fetch_bib_items'].assert_not_called
         processorMocks['addDCDWToUpdateList'].assert_not_called
         mockMapping.assert_not_called
 
-    def test_importBibRecords_not_full_no_timestamp(self, testInstance, mocker):
+    def test_import_bib_records_not_full_no_timestamp(self, testInstance, mocker):
         mockDatetime = mocker.patch('processes.nypl.datetime')
         mockDatetime.now.return_value.replace.return_value = datetime(1900, 1, 2, 12, 0, 0)
 
-        mockParse = mocker.patch.object(NYPLProcess, 'parseNYPLDataRow')
+        mockParse = mocker.patch.object(NYPLProcess, 'parse_nypl_data_row')
 
         mockConn = mocker.MagicMock(name='Mock Connection')
         mockConn.execution_options().execute.return_value = [
@@ -246,19 +245,19 @@ class TestNYPLProcess:
             {'var_fields': 'bib3'}
         ]
 
-        testInstance.bibDBConnection.engine.connect.return_value.__enter__.return_value = mockConn
+        testInstance.bib_db_connection.engine.connect.return_value.__enter__.return_value = mockConn
 
-        testInstance.importBibRecords()
+        testInstance.import_bib_records()
 
         mockDatetime.now.assert_called_once
         mockConn.execution_options().execute.assert_called_once()
         mockParse.assert_has_calls([mocker.call({'var_fields': 'bib1'}), mocker.call({'var_fields': 'bib3'})])
 
-    def test_importBibRecords_not_full_custom_timestamp(self, testInstance, mocker):
+    def test_import_bib_records_not_full_custom_timestamp(self, testInstance, mocker):
         mockDatetime = mocker.patch('processes.nypl.datetime')
         mockDatetime.now.return_value.replace.return_value = datetime(1900, 1, 2, 12, 0, 0)
 
-        mockParse = mocker.patch.object(NYPLProcess, 'parseNYPLDataRow')
+        mockParse = mocker.patch.object(NYPLProcess, 'parse_nypl_data_row')
 
         mockConn = mocker.MagicMock(name='Mock Connection')
         mockConn.execution_options().execute.return_value = [
@@ -267,18 +266,18 @@ class TestNYPLProcess:
             {'var_fields': 'bib3'}
         ]
 
-        testInstance.bibDBConnection.engine.connect.return_value.__enter__.return_value = mockConn
+        testInstance.bib_db_connection.engine.connect.return_value.__enter__.return_value = mockConn
 
-        testInstance.importBibRecords(startTimestamp='customTimestamp')
+        testInstance.import_bib_records(start_timestamp='customTimestamp')
 
         mockDatetime.now.assert_not_called
         mockConn.execution_options().execute.assert_called_once()
         mockParse.assert_has_calls([mocker.call({'var_fields': 'bib1'}), mocker.call({'var_fields': 'bib3'})])
 
-    def test_importBibRecords_full(self, testInstance, mocker):
+    def test_import_bib_records_full(self, testInstance, mocker):
         mockDatetime = mocker.patch('processes.nypl.datetime')
 
-        mockParse = mocker.patch.object(NYPLProcess, 'parseNYPLDataRow')
+        mockParse = mocker.patch.object(NYPLProcess, 'parse_nypl_data_row')
 
         mockConn = mocker.MagicMock(name='Mock Connection')
         mockConn.execution_options().execute.return_value = [
@@ -287,18 +286,18 @@ class TestNYPLProcess:
             {'var_fields': 'bib3'}
         ]
 
-        testInstance.bibDBConnection.engine.connect.return_value.__enter__.return_value = mockConn
+        testInstance.bib_db_connection.engine.connect.return_value.__enter__.return_value = mockConn
 
-        testInstance.importBibRecords(fullOrPartial=True)
+        testInstance.import_bib_records(full_or_partial=True)
 
         mockDatetime.now.assert_not_called
         mockConn.execution_options().execute.assert_called_once()
         mockParse.assert_has_calls([mocker.call({'var_fields': 'bib1'}), mocker.call({'var_fields': 'bib3'})])
 
-    def test_importBibRecords_full_batch(self, testInstance, mocker):
+    def test_import_bib_records_full_batch(self, testInstance, mocker):
         mockDatetime = mocker.patch('processes.nypl.datetime')
 
-        mockParse = mocker.patch.object(NYPLProcess, 'parseNYPLDataRow')
+        mockParse = mocker.patch.object(NYPLProcess, 'parse_nypl_data_row')
 
         mockConn = mocker.MagicMock(name='Mock Connection')
         mockConn.execution_options().execute.return_value = [
@@ -307,10 +306,10 @@ class TestNYPLProcess:
             {'var_fields': None}
         ]
 
-        testInstance.ingestOffset = '1000'
-        testInstance.ingestLimit = '1000'
-        testInstance.bibDBConnection.engine.connect.return_value.__enter__.return_value = mockConn
-        testInstance.importBibRecords(fullOrPartial=True)
+        testInstance.ingest_offset = '1000'
+        testInstance.ingest_limit = '1000'
+        testInstance.bib_db_connection.engine.connect.return_value.__enter__.return_value = mockConn
+        testInstance.import_bib_records(full_or_partial=True)
 
         mockDatetime.now.assert_not_called
         mockConn.execution_options().execute.assert_called_once()


### PR DESCRIPTION
# Description
- This change cleans up and refactors the NYPL ingestion process
- Migrates to snake case as much as possible
- Removes the NyplApiManager from the CoreProcess as only the NYPLProcess depends on it

# Testing
`python main.py -p NYPLProcess -e local -i complete -l 10; make test`