### PR TITLE
SFR-2247: Fixing deep copy work identifiers bug

### DIFF
--- a/managers/sfrRecord.py
+++ b/managers/sfrRecord.py
@@ -3,7 +3,7 @@ from datetime import date, datetime, timezone
 import json
 from Levenshtein import jaro_winkler
 import pycountry
-import re, copy
+import re
 from uuid import uuid4
 
 from model import Work, Edition, Item, Identifier, Link, Rights
@@ -39,7 +39,7 @@ class SFRRecordManager:
 
         matchedWorks.sort(key=lambda x: x[1])
 
-        allIdentifiers = copy.deepcopy(self.work.identifiers)
+        allIdentifiers = self.work.identifiers.copy()
 
         for edition in self.work.editions:
             allIdentifiers.extend(edition.identifiers)


### PR DESCRIPTION
This hotfix PR is meant to fix a bug when making a deep copy of the workIdentifiers array since there are Instance objects and deep copy isn't naturally designed to make copies of Instance objects. In this case, it would be better to make a new array that references the Instance objects instead with a shallow copy.