### PR TITLE
SFR-2220: Adding MET process ingestion count log

### DIFF
--- a/processes/met.py
+++ b/processes/met.py
@@ -51,6 +51,8 @@ class METProcess(CoreProcess):
         self.saveRecords()
         self.commitChanges()
 
+        logger.info(f'Ingested {len(self.records)} MET records')
+
     def setStartTime(self):
         if not self.fullImport:
             if not self.ingestPeriod:

--- a/tests/unit/test_met_process.py
+++ b/tests/unit/test_met_process.py
@@ -22,6 +22,7 @@ class TestMetProcess:
                 self.s3Bucket = 'test_aws_bucket'
                 self.fileQueue = 'test_file_queue'
                 self.fileRoute = 'test_file_key'
+                self.records = []
         
         return TestMET()
 


### PR DESCRIPTION
## Description 
- Adds MET process ingestion count log 

## Testing 
```
python main.py -p METProcess -e local -i complete -l 100
{"timestamp":1729009077778,"message":"Starting process METProcess in local","log.level":"INFO","logger.name":"__main__","thread.id":140704660770304,"thread.name":"MainThread","process.id":41582,"process.name":"MainProcess","file.name":"/Users/kylejacksonvillegas/workspace/drb-etl-pipeline-venv/drb-etl-pipeline/main.py","line.number":32,"entity.type":"SERVICE"}
{"timestamp":1729009099641,"message":"Ingested 57 MET records","log.level":"INFO","logger.name":"processes.met","thread.id":140704660770304,"thread.name":"MainThread","process.id":41582,"process.name":"MainProcess","file.name":"/Users/kylejacksonvillegas/workspace/drb-etl-pipeline-venv/drb-etl-pipeline/processes/met.py","line.number":54,"entity.type":"SERVICE"}
```