### PR TITLE
SFR-2188: Removed Metrics_Type Column + Updated File Names

### DIFF
--- a/analytics/upress_reporting/counter_5_controller.py
+++ b/analytics/upress_reporting/counter_5_controller.py
@@ -53,7 +53,7 @@ class Counter5Controller:
     def create_reports(self):
         print("Generating Counter 5 reports...", datetime.now())
 
-        # self.pull_aggregated_logs()
+        self.pull_aggregated_logs()
         publisher_project_data = self.pull_publisher_project_data()
 
         for publisher in self.publishers:

--- a/analytics/upress_reporting/counter_5_controller.py
+++ b/analytics/upress_reporting/counter_5_controller.py
@@ -53,7 +53,7 @@ class Counter5Controller:
     def create_reports(self):
         print("Generating Counter 5 reports...", datetime.now())
 
-        self.pull_aggregated_logs()
+        # self.pull_aggregated_logs()
         publisher_project_data = self.pull_publisher_project_data()
 
         for publisher in self.publishers:
@@ -68,12 +68,12 @@ class Counter5Controller:
 
                 view_data_poller = InteractionEventPoller(date_range=self.reporting_period,
                                           reporting_data=df,
-                                          file_id_regex=r"REST.GET.OBJECT manifests/(.*?json)\s",
+                                          file_id_regex=VIEW_FILE_ID_REGEX,
                                           bucket_name=self.view_bucket,
                                           interaction_type=InteractionType.VIEW)
                 download_data_poller = InteractionEventPoller(date_range=self.reporting_period,
                                               reporting_data=df,
-                                              file_id_regex=r"REST.GET.OBJECT (.+pdf\s)",
+                                              file_id_regex=DOWNLOAD_FILE_ID_REGEX,
                                               bucket_name=self.download_bucket,
                                               interaction_type=InteractionType.DOWNLOAD)
 

--- a/analytics/upress_reporting/models/data/interaction_event.py
+++ b/analytics/upress_reporting/models/data/interaction_event.py
@@ -25,5 +25,4 @@ class InteractionEvent():
     publication_year: Optional[str]
     disciplines: Optional[str]
     usage_type: str
-    interaction_type: Optional[str]
     timestamp: Optional[str]

--- a/analytics/upress_reporting/models/pollers/interaction_event_poller.py
+++ b/analytics/upress_reporting/models/pollers/interaction_event_poller.py
@@ -98,7 +98,6 @@ class InteractionEventPoller():
             publication_year=match_data["publication_year"],
             disciplines=match_data["disciplines"],
             usage_type=match_data["usage_type"],
-            interaction_type=self.interaction_type.value,
             timestamp=match_time[0]
         )
     

--- a/analytics/upress_reporting/models/reports/counter_5_report.py
+++ b/analytics/upress_reporting/models/reports/counter_5_report.py
@@ -150,7 +150,7 @@ class Counter5Report(ABC):
         if "/" in file_name:
             file_name = file_name.replace("/ ", "(") + ")"
 
-        with open(file_name, 'w') as csv_file:
+        with open(file_name+".csv", 'w') as csv_file:
             writer = csv.writer(csv_file, delimiter="|",
                                 quoting=csv.QUOTE_NONE)
             for key, value in header.items():

--- a/analytics/upress_reporting/models/reports/counter_5_report.py
+++ b/analytics/upress_reporting/models/reports/counter_5_report.py
@@ -34,11 +34,9 @@ class Counter5Report(ABC):
             "Publication Year",
             "Disciplines",
             "Usage Type",
-            "Metric Type",
             "Timestamp"
         ]
 
-        interaction_type = events[0].interaction_type
         accessed_titles_df = self._create_events_df(events, columns)
         accessed_titles_df["Timestamp"] = accessed_titles_df["Timestamp"].apply(
             self._reformat_timestamp_data)
@@ -64,7 +62,7 @@ class Counter5Report(ABC):
 
         zeroed_out_titles_df = self._format_zeroed_out_titles(
             df=reporting_data, columns=columns, 
-            monthly_columns=monthly_columns, interaction_type=interaction_type)
+            monthly_columns=monthly_columns)
 
         merged_df = pandas.concat(
             [accessed_titles_df, zeroed_out_titles_df], ignore_index=True)
@@ -87,11 +85,9 @@ class Counter5Report(ABC):
             "Publication Year",
             "Disciplines",
             "Usage Type",
-            "Metric Type",
             "Timestamp"
         ]
 
-        interaction_type = events[0].interaction_type
         accessed_titles_df = self._create_events_df(events=events,
                                                     columns=columns,
                                                     include_country=True)
@@ -117,7 +113,7 @@ class Counter5Report(ABC):
 
         zeroed_out_titles_df = self._format_zeroed_out_titles(
             df=reporting_data, columns=columns, 
-            monthly_columns=monthly_columns, interaction_type=interaction_type,
+            monthly_columns=monthly_columns,
             include_country=True)
 
         accessed_titles_df.loc[:,
@@ -133,7 +129,7 @@ class Counter5Report(ABC):
 
         return (merged_df.columns.tolist(), merged_df.to_dict(orient="records"))
 
-    def build_header(self, report_name, report_description):
+    def build_header(self, report_name, report_description, metric_type):
         """TODO: Add further Record.source mappings to publishers as we advance 
         in project (ex. University of Louisiana, Lafayette)"""
         publisher_mappings = {
@@ -144,12 +140,16 @@ class Counter5Report(ABC):
             "Report_ID": self.generate_report_id(),
             "Report_Description": report_description,
             "Publisher_Name": publisher_mappings.get(self.publisher, ""),
+            "Metric_Type": metric_type,
             "Reporting_Period": self._format_reporting_period_to_string(),
             "Created": self.created,
             "Created_By": "NYPL",
         }
 
     def write_to_csv(self, file_name, header, column_names, data):
+        if "/" in file_name:
+            file_name = file_name.replace("/ ", "(") + ")"
+
         with open(file_name, 'w') as csv_file:
             writer = csv.writer(csv_file, delimiter="|",
                                 quoting=csv.QUOTE_NONE)
@@ -161,7 +161,7 @@ class Counter5Report(ABC):
                 writer.writerow(title.values())
 
     def _format_zeroed_out_titles(self, df, columns, monthly_columns, 
-                                  interaction_type, include_country=False):
+                                  include_country=False):
         unaccessed_titles = df.loc[df["accessed"] == False]
         recarray = unaccessed_titles.to_records()
 
@@ -175,7 +175,6 @@ class Counter5Report(ABC):
             publication_year=title.publication_year,
             disciplines=title.disciplines,
             usage_type=title.usage_type,
-            interaction_type=interaction_type,
             timestamp=None) for title in recarray]
 
         zeroed_out_df = self._create_events_df(zeroed_out_events, columns, 

--- a/analytics/upress_reporting/models/reports/country_level.py
+++ b/analytics/upress_reporting/models/reports/country_level.py
@@ -9,13 +9,13 @@ class CountryLevelReport(Counter5Report):
         print("Building country-level report...")
         
         if len(events) > 0:
-            file_name = f"{self.publisher}_country_level_report_{self.created}.csv"
             header = self.build_header(report_name="NYPL DRB Total Item Requests by Title by Country",
-                                       report_description="Usage of your books on NYPL's Digital Research Books by country.")
+                                       report_description="Usage of your books on NYPL's Digital Research Books by country.",
+                                       metric_type="Views + Downloads")
             columns, final_data = self.aggregate_interaction_events_by_country(events, 
                                                                                reporting_data)
             
-            self.write_to_csv(file_name=file_name,
+            self.write_to_csv(file_name=header["Report_Name"],
                               header=header,
                               column_names=columns,
                               data=final_data)

--- a/analytics/upress_reporting/models/reports/downloads.py
+++ b/analytics/upress_reporting/models/reports/downloads.py
@@ -9,12 +9,12 @@ class DownloadsReport(Counter5Report):
         print("Building downloads report...")
 
         if len(events) > 0:
-            file_name = f"{self.publisher}_downloads_report_{self.created}.csv"
             header = self.build_header(report_name="NYPL DRB Total Item Requests by Title / Downloads",
-                                       report_description="Downloads of your books from NYPL's Digital Research Books by title.")
+                                       report_description="Downloads of your books from NYPL's Digital Research Books by title.",
+                                       metric_type="Downloads (loading of title contents)")
             columns, final_data = self.aggregate_interaction_events(events, reporting_data)
             
-            self.write_to_csv(file_name=file_name,
+            self.write_to_csv(file_name=header["Report_Name"],
                               header=header,
                               column_names=columns,
                               data=final_data)

--- a/analytics/upress_reporting/models/reports/total_usage.py
+++ b/analytics/upress_reporting/models/reports/total_usage.py
@@ -9,12 +9,12 @@ class TotalUsageReport(Counter5Report):
         print("Building total usage report...")
 
         if len(events) > 0:
-            file_name = f"{self.publisher}_total_usage_{self.created}.csv"
             header = self.build_header(report_name="NYPL DRB Total Item Requests by Title",
-                                       report_description="Usage of your books on NYPL's Digital Research Books.")
+                                       report_description="Usage of your books on NYPL's Digital Research Books.",
+                                       metric_type="Views (clicks on title) + Downloads (loading of title contents)")
             columns, final_data = self.aggregate_interaction_events(events, reporting_data)
             
-            self.write_to_csv(file_name=file_name,
+            self.write_to_csv(file_name=header["Report_Name"],
                               header=header,
                               column_names=columns,
                               data=final_data)

--- a/analytics/upress_reporting/models/reports/views.py
+++ b/analytics/upress_reporting/models/reports/views.py
@@ -9,12 +9,12 @@ class ViewsReport(Counter5Report):
         print("Building views report...")
 
         if len(events) > 0:
-            file_name = f"{self.publisher}_views_report_{self.created}.csv"
             header = self.build_header(report_name="NYPL DRB Total Item Requests by Title / Views",
-                                       report_description="Views of your books from NYPL's Digital Research Books by title.")
+                                       report_description="Views of your books from NYPL's Digital Research Books by title.",
+                                       metric_type="Views (clicks on title)")
             columns, final_data = self.aggregate_interaction_events(events, reporting_data)
             
-            self.write_to_csv(file_name=file_name, 
+            self.write_to_csv(file_name=header["Report_Name"], 
                               header=header, 
                               column_names=columns, 
                               data=final_data)


### PR DESCRIPTION
**Changes Made**
- Updated file names to reflect report titles (as per business partner feedback)
- Added `Metrics_Type` row to overhead description (as per business partner feedback) and removed `Metrics_Type` column

[Sample reports link](https://docs.google.com/spreadsheets/d/1-geK3StSJVIRxr9ylkKuqZ_X880qKnGriMc9HcvDd7g/edit?usp=sharing)