### PR TITLE
SFR-2267: Fixing duplicate work bug

### DIFF
--- a/managers/sfrRecord.py
+++ b/managers/sfrRecord.py
@@ -37,7 +37,7 @@ class SFRRecordManager:
             .filter(Edition.dcdw_uuids.overlap(list(dcdwUUIDs))).all():
             matchedWorks.append((matchedWork.id, matchedWork.uuid, matchedWork.date_created))
 
-        matchedWorks.sort(key=lambda x: x[1])
+        matchedWorks.sort(key=lambda x: x[2])
 
         allIdentifiers = self.work.identifiers.copy()
 
@@ -69,7 +69,7 @@ class SFRRecordManager:
 
         self.work = self.session.merge(self.work)
 
-        return [w[0] for w in matchedWorks[1:]]
+        return [w[1] for w in matchedWorks[1:]]
 
     def dedupeIdentifiers(self, identifiers):
         queryGroups = defaultdict(set)

--- a/managers/sfrRecord.py
+++ b/managers/sfrRecord.py
@@ -35,7 +35,7 @@ class SFRRecordManager:
             .join(Edition)\
             .filter(Work.uuid != self.work.uuid)\
             .filter(Edition.dcdw_uuids.overlap(list(dcdwUUIDs))).all():
-            matchedWorks.append((matchedWork.uuid, matchedWork.date_created))
+            matchedWorks.append((matchedWork.id, matchedWork.uuid, matchedWork.date_created))
 
         matchedWorks.sort(key=lambda x: x[1])
 
@@ -62,8 +62,10 @@ class SFRRecordManager:
                 self.assignIdentifierIDs(cleanIdentifiers, item.identifiers)
 
         if len(matchedWorks) > 0:
-            self.work.date_created = matchedWorks[0][1]
-            self.work.uuid = matchedWorks[0][0]
+            work_id, work_uuid, work_date_created = matchedWorks[0]
+            self.work.id = work_id
+            self.work.uuid = work_uuid
+            self.work.date_created = work_date_created
 
         self.work = self.session.merge(self.work)
 

--- a/processes/seed_local_data.py
+++ b/processes/seed_local_data.py
@@ -36,8 +36,9 @@ class SeedLocalDataProcess(CoreProcess):
             
             cluster_process = ClusterProcess(*process_args)
             cluster_process.runProcess()
-        except Exception:
+        except Exception as e:
             logger.exception(f'Failed to seed local data')
+            raise e
 
     def fetch_hathi_sample_data(self):
         self.import_from_hathi_trust_data_file()

--- a/tests/unit/test_sfrRecord_manager.py
+++ b/tests/unit/test_sfrRecord_manager.py
@@ -75,9 +75,9 @@ class TestSFRRecordManager:
         testInstance.work.uuid = 1
 
         matchingWorks = [
-            mocker.MagicMock(uuid=2, date_created='2020-01-01'),
-            mocker.MagicMock(uuid=3, date_created='2019-01-01'),
-            mocker.MagicMock(uuid=4, date_created='2018-01-01'),
+            mocker.MagicMock(id=2, uuid=2, date_created='2020-01-01'),
+            mocker.MagicMock(id=3, uuid=3, date_created='2019-01-01'),
+            mocker.MagicMock(id=4, uuid=4, date_created='2018-01-01'),
         ]
         testInstance.session.query().join().filter().filter().all.return_value\
             = matchingWorks
@@ -87,6 +87,7 @@ class TestSFRRecordManager:
 
         assert testUUIDsToDelete == [3, 2]
         assert testInstance.work.uuid == 4
+        assert testInstance.work.id == 4
         assert testInstance.work.date_created == '2018-01-01'
 
         testInstance.session.query().join().filter().filter().all.assert_called_once()


### PR DESCRIPTION
## Description
- Because we have a PK on id and not uuid we were not merging correctly and instead creating duplicate works with the same uuid but different ids
- This change sets the work id as the matched work id to merge properly

## Testing
`make test; python main.py -p SeedLocalDataProcess -e local (run multiple times)
<img width="1210" alt="Screenshot 2024-10-18 at 4 26 28 PM" src="https://github.com/user-attachments/assets/b50174af-2b33-432b-a951-c35ca5fd4d33">

 