### PR TITLE
Classify logging improvements

### DIFF
--- a/processes/classify.py
+++ b/processes/classify.py
@@ -33,6 +33,7 @@ class ClassifyProcess(CoreProcess):
         self.createOrConnectQueue(self.rabbitQueue, self.rabbitRoute)
 
         self.classifiedRecords = {}
+        self.classified_count = 0
 
         self.oclc_catalog_manager = OCLCCatalogManager()
 
@@ -47,6 +48,7 @@ class ClassifyProcess(CoreProcess):
         self.saveRecords()
         self.updateClassifiedRecordsStatus()
         self.commitChanges()
+        logger.info(f'Classify process report: {self.classified_count} record updates')
 
     def classifyRecords(self, full=False, startDateTime=None):
         baseQuery = self.session.query(Record)\
@@ -80,12 +82,12 @@ class ClassifyProcess(CoreProcess):
                 break
 
             if len(self.classifiedRecords) >= windowSize:
-                logger.debug('Storing classified records')
                 self.updateClassifiedRecordsStatus()
                 self.classifiedRecords = {}
 
     def updateClassifiedRecordsStatus(self):
-        logger.info(f'Storing {len(self.classifiedRecords)} classified records')
+        logger.debug(f'Storing {len(self.classifiedRecords)} classified records')
+        self.classified_count += len(self.classifiedRecords)
         self.bulkSaveObjects([r for _, r in self.classifiedRecords.items()])
 
     def frbrizeRecord(self, record):

--- a/processes/classify.py
+++ b/processes/classify.py
@@ -132,14 +132,14 @@ class ClassifyProcess(CoreProcess):
             if not oclc_number or not owi_number:
                 logger.warning(f'Unable to get identifiers for bib: {related_oclc_bib}')
                 continue
-            
+
             if self.check_if_classify_work_fetched(owi_number=owi_number):
                 continue
 
             related_oclc_numbers = self.oclc_catalog_manager.get_related_oclc_numbers(oclc_number=oclc_number)
 
             oclc_record = OCLCBibMapping(
-                oclc_bib=related_oclc_bib, 
+                oclc_bib=related_oclc_bib,
                 related_oclc_numbers=related_oclc_numbers
             )
 

--- a/processes/classify.py
+++ b/processes/classify.py
@@ -85,6 +85,7 @@ class ClassifyProcess(CoreProcess):
                 self.classifiedRecords = {}
 
     def updateClassifiedRecordsStatus(self):
+        logger.info(f'Storing {len(self.classifiedRecords)} classified records')
         self.bulkSaveObjects([r for _, r in self.classifiedRecords.items()])
 
     def frbrizeRecord(self, record):

--- a/tests/unit/processes/test_classify_process.py
+++ b/tests/unit/processes/test_classify_process.py
@@ -23,6 +23,7 @@ class TestOCLCClassifyProcess:
                 self.ingestLimit = None
                 self.rabbitQueue = os.environ['OCLC_QUEUE']
                 self.rabbitRoute = os.environ['OCLC_ROUTING_KEY']
+                self.classified_count = 0
                 self.oclc_catalog_manager = mocker.MagicMock()
 
         return TestClassifyProcess('TestProcess', 'testFile', 'testDate')


### PR DESCRIPTION
- Adds a persistent count of records that have been updated during the process
- Adds a summary of this count before process exists
- Debug-level statement previously only logged per "chunk", aka when a full window of records was saved. Moved this debug statement to the function that actually persists these so that all occurrences of this are logged, since ingests of 5-10 records e.g. resulted in no debug statements