### PR TITLE
SFR-2278: Improving cluster process logging

### DIFF
--- a/managers/elasticsearch.py
+++ b/managers/elasticsearch.py
@@ -264,8 +264,6 @@ class ElasticsearchManager:
         )
 
     def saveWorkRecords(self, works, attempt=1):
-        logger.info('Saving {} ES Work Records'.format(len(works)))
-
         try:
             saveRes = bulk(
                 self.es, self._upsertGenerator(works), raise_on_error=False
@@ -307,8 +305,6 @@ class ElasticsearchManager:
             }
 
     def deleteWorkRecords(self, uuids):
-        logger.info('Deleting {} ES Work Records'.format(len(uuids)))
-
         deleteRes = bulk(self.es, self._deleteGenerator(uuids), raise_on_error=False)
         logger.debug(deleteRes)
 

--- a/managers/kMeans.py
+++ b/managers/kMeans.py
@@ -103,8 +103,6 @@ class KMeansManager:
         return ''
 
     def createDF(self):
-        logger.info('Generating DataFrame from instance data')
-
         frameRows = []
 
         for i in self.instances:
@@ -211,15 +209,10 @@ class KMeansManager:
         return ''
     
     def generateClusters(self):
-        logger.info('Generating Clusters from instances')
         try:
-            logger.info('Calculating number of clusters, max {}'.format(
-                self.maxK
-            ))
             self.getK(2, self.maxK)
-            logger.info('Setting K to {}'.format(self.k))
         except ZeroDivisionError:
-            logger.info('Single instance found setting K to 1')
+            logger.warning('Single instance found - setting K to 1')
             self.k = 1
         
         try:
@@ -244,8 +237,6 @@ class KMeansManager:
 
         while True:
             middle = int((stop + start)/2)
-
-            logger.info('Getting Scores for Start: {}, Stop: {}, Middle: {}'.format(start, stop, middle))
 
             try:
                 if start != prevStart: startScore = self.cluster(start, score=True) 
@@ -303,7 +294,6 @@ class KMeansManager:
     
     def parseEditions(self):
         eds = []
-        logger.info('Generating editions from clusters')
         for clust in dict(self.clusters):
             yearEds = defaultdict(list)
             logger.debug('Parsing cluster {}'.format(clust))

--- a/managers/kMeans.py
+++ b/managers/kMeans.py
@@ -40,7 +40,6 @@ class KMeansManager:
                 ('selector', FeatureSelector(key='place')),
                 ('tfidf', TfidfVectorizer(
                     preprocessor=KMeansManager.pubProcessor,
-                    stop_words='english',
                     strip_accents='unicode',
                     analyzer='char_wb',
                     ngram_range=(2,4))
@@ -50,7 +49,6 @@ class KMeansManager:
                 ('selector', FeatureSelector(key='publisher')),
                 ('tfidf', TfidfVectorizer(
                     preprocessor=KMeansManager.pubProcessor,
-                    stop_words='english',
                     strip_accents='unicode',
                     analyzer='char_wb',
                     ngram_range=(2,4))
@@ -60,7 +58,6 @@ class KMeansManager:
                 ('selector', FeatureSelector(key='edition')),
                 ('tfidf', TfidfVectorizer(
                     preprocessor=KMeansManager.pubProcessor,
-                    stop_words='english',
                     strip_accents='unicode',
                     analyzer='char_wb',
                     ngram_range=(1,3))

--- a/managers/sfrRecord.py
+++ b/managers/sfrRecord.py
@@ -48,7 +48,6 @@ class SFRRecordManager:
                 allIdentifiers.extend(item.identifiers)
                 item.links = self.dedupeLinks(item.links)
 
-        logger.info('Deduping Indentifiers')
         cleanIdentifiers = self.dedupeIdentifiers(allIdentifiers)
 
         self.seenIdentifiers = {}

--- a/processes/cluster.py
+++ b/processes/cluster.py
@@ -84,6 +84,7 @@ class ClusterProcess(CoreProcess):
 
             if len(works_to_index) >= self.CLUSTER_BATCH_SIZE:
                 self.update_elastic_search(works_to_index, work_ids_to_delete)
+                logger.info(f'Clustered {len(works_to_index)} works')
                 works_to_index = []
 
                 self.delete_stale_works(work_ids_to_delete)
@@ -91,14 +92,13 @@ class ClusterProcess(CoreProcess):
 
                 self.session.commit()
 
+        logger.info(f'Clustered {len(works_to_index)} works')
         self.update_elastic_search(works_to_index, work_ids_to_delete)
         self.delete_stale_works(work_ids_to_delete)
 
         self.session.commit()
 
     def cluster_record(self, record: Record):
-        logger.info('Clustering {}'.format(record))
-
         matched_record_ids = self.find_all_matching_records(record) + [record.id]
 
         clustered_editions, records = self.cluster_matched_records(matched_record_ids)


### PR DESCRIPTION
## Description
- Removes stop_words parameter since it can only be used by the word analyzer. This change removes these warnings:
```
The parameter 'stop_words' will not be used since 'analyzer' != 'word'
```

### Testing
`python main.py -p SeedLocalDataProcess -e local`

### Output
```
{"timestamp":1729629646693,"message":"Clustered 10 works","log.level":"INFO","logger.name":"processes.cluster","thread.id":140704660770304,"thread.name":"MainThread","process.id":69301,"process.name":"MainProcess","file.name":"/Users/kylejacksonvillegas/workspace/drb-etl-pipeline-venv/drb-etl-pipeline/processes/cluster.py","line.number":95,"entity.type":"SERVICE"}
```