### PR TITLE
SFR-2285: Dedupe editions during recluster

### DIFF
--- a/managers/sfrRecord.py
+++ b/managers/sfrRecord.py
@@ -481,10 +481,10 @@ class SFRRecordManager:
     def publicationDateCheck(edition):
         publicationDate = None
 
-        if isinstance(edition['publication_date'], datetime):
+        if isinstance(edition['publication_date'], date):
             publicationDate = edition['publication_date']
         elif re.match(r'([0-9]{4})-([0-9]{2})-([0-9]{2})', edition['publication_date']):
-            publicationDate = datetime.strptime(edition['publication_date'], '%Y-%m-%d')
+            publicationDate = datetime.strptime(edition['publication_date'], '%Y-%m-%d').date()
         else:
             pubYearGroup = re.search(r'([0-9]{4})', str(edition['publication_date']))
 

--- a/model/postgres/edition.py
+++ b/model/postgres/edition.py
@@ -55,8 +55,8 @@ class Edition(Base, Core):
     )
 
     def __repr__(self):
-        return '<Edition(place={}, date={}, publisher={})>'.format(
-            self.publication_place, self.publication_date, self.publishers
+        return '<Edition(id={}, place={}, date={}, publisher={})>'.format(
+            self.id, self.publication_place, self.publication_date, self.publishers
         )
     
     def __dir__(self):

--- a/model/postgres/identifier.py
+++ b/model/postgres/identifier.py
@@ -12,8 +12,8 @@ class Identifier(Base, Core):
     __table_args__ = (UniqueConstraint('identifier', 'authority', name='uc_identifier_authority'),)
 
     def __repr__(self):
-        return '<Identifier(value={}, authority={})>'.format(
-            self.identifier, self.authority
+        return '<Identifier(id={}, value={}, authority={})>'.format(
+            self.id, self.identifier, self.authority
         )
 
     def __dir__(self):

--- a/model/postgres/item.py
+++ b/model/postgres/item.py
@@ -39,8 +39,8 @@ class Item(Base, Core):
     rights = relationship('Rights', secondary=ITEM_RIGHTS, backref='items', cascade='all, delete')
 
     def __repr__(self):
-        return '<Item(source={}, content_type={})>'.format(
-            self.source, self.content_type
+        return '<Item(id={}, source={}, content_type={}, contributors={})>'.format(
+            self.id, self.source, self.content_type, self.contributors
         )
 
     def __dir__(self):

--- a/processes/cluster.py
+++ b/processes/cluster.py
@@ -28,9 +28,9 @@ class ClusterProcess(CoreProcess):
 
         self.createRedisClient()
         
-        self.createElasticConnection()
-        self.createElasticSearchIngestPipeline()
-        self.createElasticSearchIndex()
+        # self.createElasticConnection()
+        # self.createElasticSearchIngestPipeline()
+        # self.createElasticSearchIndex()
 
     def runProcess(self):
         try:
@@ -55,6 +55,7 @@ class ClusterProcess(CoreProcess):
                 .filter(Record.cluster_status == False)
                 .filter(Record.source != 'oclcClassify')
                 .filter(Record.source != 'oclcCatalog')
+                .filter(Record.uuid == 'a78e5901-9b4e-48d8-a0ae-ad52115cc1d6')
         )
 
         if not full:
@@ -83,7 +84,7 @@ class ClusterProcess(CoreProcess):
                 raise e
 
             if len(works_to_index) >= self.CLUSTER_BATCH_SIZE:
-                self.update_elastic_search(works_to_index, work_ids_to_delete)
+                # self.update_elastic_search(works_to_index, work_ids_to_delete)
                 logger.info(f'Clustered {len(works_to_index)} works')
                 works_to_index = []
 
@@ -93,7 +94,7 @@ class ClusterProcess(CoreProcess):
                 self.session.commit()
 
         logger.info(f'Clustered {len(works_to_index)} works')
-        self.update_elastic_search(works_to_index, work_ids_to_delete)
+        # self.update_elastic_search(works_to_index, work_ids_to_delete)
         self.delete_stale_works(work_ids_to_delete)
 
         self.session.commit()

--- a/processes/cluster.py
+++ b/processes/cluster.py
@@ -28,9 +28,9 @@ class ClusterProcess(CoreProcess):
 
         self.createRedisClient()
         
-        # self.createElasticConnection()
-        # self.createElasticSearchIngestPipeline()
-        # self.createElasticSearchIndex()
+        self.createElasticConnection()
+        self.createElasticSearchIngestPipeline()
+        self.createElasticSearchIndex()
 
     def runProcess(self):
         try:
@@ -55,7 +55,6 @@ class ClusterProcess(CoreProcess):
                 .filter(Record.cluster_status == False)
                 .filter(Record.source != 'oclcClassify')
                 .filter(Record.source != 'oclcCatalog')
-                .filter(Record.uuid == 'a78e5901-9b4e-48d8-a0ae-ad52115cc1d6')
         )
 
         if not full:
@@ -84,7 +83,7 @@ class ClusterProcess(CoreProcess):
                 raise e
 
             if len(works_to_index) >= self.CLUSTER_BATCH_SIZE:
-                # self.update_elastic_search(works_to_index, work_ids_to_delete)
+                self.update_elastic_search(works_to_index, work_ids_to_delete)
                 logger.info(f'Clustered {len(works_to_index)} works')
                 works_to_index = []
 
@@ -94,7 +93,7 @@ class ClusterProcess(CoreProcess):
                 self.session.commit()
 
         logger.info(f'Clustered {len(works_to_index)} works')
-        # self.update_elastic_search(works_to_index, work_ids_to_delete)
+        self.update_elastic_search(works_to_index, work_ids_to_delete)
         self.delete_stale_works(work_ids_to_delete)
 
         self.session.commit()

--- a/tests/unit/test_sfrRecord_manager.py
+++ b/tests/unit/test_sfrRecord_manager.py
@@ -1,6 +1,6 @@
 import pytest
 
-from datetime import datetime, timedelta, timezone
+from datetime import date, timedelta
 
 from managers import SFRRecordManager
 
@@ -255,7 +255,7 @@ class TestSFRRecordManager:
     def test_publicationDateCheck1(self):
         testEdition = SFRRecordManager.createEmptyEditionRecord()
 
-        testEdition['publication_date'] = datetime(1900, 1, 1)
+        testEdition['publication_date'] = date(1900, 1, 1)
         testPubDateCheck = SFRRecordManager.publicationDateCheck(testEdition)
         assert testPubDateCheck.year == 1900
 
@@ -267,19 +267,19 @@ class TestSFRRecordManager:
     def test_publicationDateCheck2(self):
         testEdition2 = SFRRecordManager.createEmptyEditionRecord()
 
-        testEdition2['publication_date'] = datetime.now(timezone.utc).replace(tzinfo=None)
+        testEdition2['publication_date'] = date.today()
         testPubDateCheck2 = SFRRecordManager.publicationDateCheck(testEdition2)
-        assert testPubDateCheck2.year == datetime.now(timezone.utc).replace(tzinfo=None).year
+        assert testPubDateCheck2.year == date.today().year
 
-        testEdition2['publication_date'] = datetime.now(timezone.utc).replace(tzinfo=None).strftime('%Y-%m-%d')
+        testEdition2['publication_date'] = date.today().strftime('%Y-%m-%d')
         testPubDateCheck2 = SFRRecordManager.publicationDateCheck(testEdition2)
-        assert testPubDateCheck2.year == datetime.now(timezone.utc).replace(tzinfo=None).year
+        assert testPubDateCheck2.year == date.today().year
     
     #Test for publication date with earliest year in our date range
     def test_publicationDateCheck3(self):
         testEdition3 = SFRRecordManager.createEmptyEditionRecord()
 
-        testEdition3['publication_date'] = datetime(1488, 1, 1)
+        testEdition3['publication_date'] = date(1488, 1, 1)
         testPubDateCheck3 = SFRRecordManager.publicationDateCheck(testEdition3)
         assert testPubDateCheck3.year == 1488
 
@@ -292,7 +292,7 @@ class TestSFRRecordManager:
         #Tests for incorrect date ranges
         testEdition4 = SFRRecordManager.createEmptyEditionRecord()
 
-        testEdition4['publication_date'] = datetime(1300, 1, 1)
+        testEdition4['publication_date'] = date(1300, 1, 1).strftime('%Y-%m-%d')
         testPubDateCheck4 = SFRRecordManager.publicationDateCheck(testEdition4)
         assert testPubDateCheck4 == None
 
@@ -304,11 +304,11 @@ class TestSFRRecordManager:
     def test_publicationDateCheck5(self):
         testEdition5 = SFRRecordManager.createEmptyEditionRecord()
 
-        testEdition5['publication_date'] = datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(1)
+        testEdition5['publication_date'] = date.today() + timedelta(days=1)
         testPubDateCheck5 = SFRRecordManager.publicationDateCheck(testEdition5)
         assert testPubDateCheck5 == None
     
-        testEdition5['publication_date'] = (datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(1)).strftime('%Y-%m-%d')
+        testEdition5['publication_date'] = (date.today() + timedelta(days=1)).strftime('%Y-%m-%d')
         testPubDateCheck5 = SFRRecordManager.publicationDateCheck(testEdition5)
         assert testPubDateCheck5 == None
 

--- a/tests/unit/test_sfrRecord_manager.py
+++ b/tests/unit/test_sfrRecord_manager.py
@@ -292,7 +292,7 @@ class TestSFRRecordManager:
         #Tests for incorrect date ranges
         testEdition4 = SFRRecordManager.createEmptyEditionRecord()
 
-        testEdition4['publication_date'] = date(1300, 1, 1).strftime('%Y-%m-%d')
+        testEdition4['publication_date'] = date(1300, 1, 1)
         testPubDateCheck4 = SFRRecordManager.publicationDateCheck(testEdition4)
         assert testPubDateCheck4 == None
 


### PR DESCRIPTION
## Description
- Reclustering does not work because we were not deduping editions and items
- This change dedupes editions based on the publication year and also removes the items that were previously clustered before saving the clustered data

## Testing
- tested against 1 record in QA:

![Screenshot 2024-10-25 at 10 58 14](https://github.com/user-attachments/assets/6d57e984-cb29-4618-977d-0a4a94bc7f0b)
![Screenshot 2024-10-25 at 10 57 55](https://github.com/user-attachments/assets/7607c91f-991e-4384-aa39-6bd33d7aa05b)
![Screenshot 2024-10-25 at 10 58 35](https://github.com/user-attachments/assets/b754cebf-30eb-479c-b992-e5eda6bee298)


```
python main.py -p ClusterProcess -e local-qa -i complete
{"timestamp":1729801581368,"message":"Starting process ClusterProcess in local-qa","log.level":"INFO","logger.name":"__main__","thread.id":140704660770304,"thread.name":"MainThread","process.id":13948,"process.name":"MainProcess","file.name":"/Users/kylejacksonvillegas/workspace/drb-etl-pipeline-venv/drb-etl-pipeline/main.py","line.number":32,"entity.type":"SERVICE"}
{"timestamp":1729801586776,"message":"Clustered 1 works","log.level":"INFO","logger.name":"processes.cluster","thread.id":140704660770304,"thread.name":"MainThread","process.id":13948,"process.name":"MainProcess","file.name":"/Users/kylejacksonvillegas/workspace/drb-etl-pipeline-venv/drb-etl-pipeline/processes/cluster.py","line.number":96,"entity.type":"SERVICE"}
```