### PR TITLE
SFR-2285: Fix duplicate works

### DIFF
--- a/managers/sfrRecord.py
+++ b/managers/sfrRecord.py
@@ -61,14 +61,13 @@ class SFRRecordManager:
                 self.assignIdentifierIDs(cleanIdentifiers, item.identifiers)
 
         if len(matchedWorks) > 0:
-            work_id, work_uuid, work_date_created = matchedWorks[0]
-            self.work.id = work_id
+            _, work_uuid, work_date_created = matchedWorks[0]
             self.work.uuid = work_uuid
             self.work.date_created = work_date_created
 
         self.work = self.session.merge(self.work)
 
-        return [w[1] for w in matchedWorks[1:]]
+        return [w[0] for w in matchedWorks]
 
     def dedupeIdentifiers(self, identifiers):
         queryGroups = defaultdict(set)

--- a/processes/cluster.py
+++ b/processes/cluster.py
@@ -133,7 +133,7 @@ class ClusterProcess(CoreProcess):
         self.index_works_in_elastic_search(works_to_index)
 
     def delete_stale_works(self, work_ids: set[str]):
-        self.deleteRecordsByQuery(self.session.query(Work).filter(Work.uuid.in_(list(work_ids))))
+        self.deleteRecordsByQuery(self.session.query(Work).filter(Work.id.in_(list(work_ids))))
 
     def cluster_matched_records(self, record_ids: list[str]):
         records = self.session.query(Record).filter(Record.id.in_(record_ids)).all()

--- a/tests/unit/test_sfrRecord_manager.py
+++ b/tests/unit/test_sfrRecord_manager.py
@@ -85,9 +85,8 @@ class TestSFRRecordManager:
 
         testUUIDsToDelete = testInstance.mergeRecords()
 
-        assert testUUIDsToDelete == [3, 2]
+        assert testUUIDsToDelete == [4, 3, 2]
         assert testInstance.work.uuid == 4
-        assert testInstance.work.id == 4
         assert testInstance.work.date_created == '2018-01-01'
 
         testInstance.session.query().join().filter().filter().all.assert_called_once()


### PR DESCRIPTION
## Description
- This change fixes duplicate works but does not merge the records like intended. 
- We will create a new work with a new PK but the same uuid. All editions and items will be new based on the most recent cluster. Because the entities are new, they will have new ids.
- The old works, editions, items will be deleted and new ones will be created. 

## Testing
- Tested against a few records in QA