### PR TITLE
SFR-2291: Throw error if we fail to generate webpub 

### DIFF
--- a/managers/rabbitmq.py
+++ b/managers/rabbitmq.py
@@ -93,3 +93,11 @@ class RabbitMQManager:
             self.createRabbitConnection()
             self.createChannel()
             self.acknowledgeMessageProcessed(deliveryTag)
+
+    def reject_message(self, delivery_tag: str, requeue=False):
+        try:
+            self.channel.basic_reject(delivery_tag=delivery_tag, requeue=requeue)
+        except (ConnectionWrongStateError, StreamLostError):
+            self.createRabbitConnection()
+            self.createChannel()
+            self.reject_message(delivery_tag, requeue)      

--- a/processes/file/s3_files.py
+++ b/processes/file/s3_files.py
@@ -124,5 +124,6 @@ class S3Process(CoreProcess):
             webpub_response.raise_for_status()
 
             return webpub_response.content
-        except Exception:
+        except Exception as e:
             logger.exception(f'Failed to generate webpub for {file_root}')
+            raise e

--- a/processes/file/s3_files.py
+++ b/processes/file/s3_files.py
@@ -8,6 +8,7 @@ from urllib.parse import quote_plus
 from ..core import CoreProcess
 from managers import S3Manager, RabbitMQManager
 from logger import createLog
+from utils import retry_request
 
 
 logger = createLog(__name__)
@@ -95,44 +96,41 @@ class S3Process(CoreProcess):
                 rabbit_mq_manager.reject_message(delivery_tag=message_props.delivery_tag)
 
     @staticmethod
+    @retry_request()
     def get_file_contents(file_url: str):
-        file_url_response = requests.get(
-            file_url,
-            stream=True,
-            timeout=15,
-            headers={ 'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5)' }
-        )
+        try:
+            file_url_response = requests.get(
+                file_url,
+                stream=True,
+                timeout=15,
+                headers={ 'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5)' }
+            )
 
-        if file_url_response.status_code == 200:
+            file_url_response.raise_for_status()
+
             file_contents = bytes()
 
             for byte_chunk in file_url_response.iter_content(1024 * 250):
                 file_contents += byte_chunk
 
             return file_contents
-
-        raise Exception(f'Unable to fetch file from url: {file_url}')
+        except Exception as e:
+            logger.exception(f'Failed to get file contents from {file_url}')
+            raise e
 
     @staticmethod
+    @retry_request()
     def generate_webpub(file_root, bucket):
         webpub_conversion_url = os.environ['WEBPUB_CONVERSION_URL']
         s3_file_path = f'https://{bucket}.s3.amazonaws.com/{file_root}/META-INF/container.xml'
         webpub_conversion_url = f'{webpub_conversion_url}/api/{quote_plus(s3_file_path)}'
-        retry_limit = 3
 
-        for attempt in range(retry_limit):
-            try:
-                webpub_response = requests.get(webpub_conversion_url, timeout=15)
+        try:
+            webpub_response = requests.get(webpub_conversion_url, timeout=15)
 
-                webpub_response.raise_for_status()
+            webpub_response.raise_for_status()
 
-                return webpub_response.content
-            except (requests.ConnectionError, requests.Timeout) as e:
-                if attempt < retry_limit - 1:
-                    sleep(60 * (attempt + 1))
-                else:
-                    logger.exception(f'Failed to generate webpub for {file_root}')
-                    raise e
-            except Exception as e:
-                logger.exception(f'Failed to generate webpub for {file_root}')
-                raise e
+            return webpub_response.content
+        except Exception as e:
+            logger.exception(f'Failed to generate webpub for {file_root}')
+            raise e

--- a/tests/unit/processes/file/test_s3_files_process.py
+++ b/tests/unit/processes/file/test_s3_files_process.py
@@ -139,9 +139,8 @@ class TestS3Process:
         mock_response.raise_for_status.side_effect = Exception
         mock_get_request.return_value = mock_response
 
-        test_webpub = S3Process.generate_webpub('testRoot', 'testBucket')
-
-        assert test_webpub == None
+        with pytest.raises(Exception):
+            S3Process.generate_webpub('testRoot', 'testBucket')
 
         mock_get_request.assert_called_once_with(
             'test_conversion_url/api/https%3A%2F%2FtestBucket.s3.amazonaws.com%2FtestRoot%2FMETA-INF%2Fcontainer.xml',

--- a/tests/unit/processes/file/test_s3_files_process.py
+++ b/tests/unit/processes/file/test_s3_files_process.py
@@ -113,7 +113,7 @@ class TestS3Process:
     def test_get_file_contents_error(self, test_instance, mocker):
         mock_get_request = mocker.patch.object(requests, 'get')
         mock_response = mocker.MagicMock()
-        mock_response.status_code = 500
+        mock_response.raise_for_status.side_effect = Exception
         mock_get_request.return_value = mock_response
 
         with pytest.raises(Exception):

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,1 @@
+from .retry_request import retry_request

--- a/utils/retry_request.py
+++ b/utils/retry_request.py
@@ -1,0 +1,23 @@
+import functools
+from requests import ConnectionError, Timeout
+import time
+
+
+def retry_request(max_retries: int=3, wait_seconds: int=60):
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            for attempt in range(max_retries):
+                try:
+                    return func(*args, **kwargs)
+                except (ConnectionError, Timeout) as e:
+                    if attempt < max_retries - 1:
+                        time.sleep(wait_seconds * (attempt + 1))
+                    else:
+                        raise e
+                except Exception as e:
+                    raise e
+        
+        return wrapper
+    
+    return decorator


### PR DESCRIPTION
## Description
- We don't want to silently fail to generate a webpub 
- If we can't, we should not acknowledge the message and retry the processing of the message

## Testing
`make unit`