### PR TITLE
SFR-2292: Skip clustering records with no title

### DIFF
--- a/main.py
+++ b/main.py
@@ -76,7 +76,7 @@ def createArgParser():
     parser.add_argument('-o', '--offset',
                         help='Set start offset for current processed (for batched import process)')
     parser.add_argument('-r', '--singleRecord',
-                        help='Single record ID for ingesting an individual record (only applicable for DOAB)')
+                        help='Single record ID for ingesting an individual record')
     parser.add_argument('options', nargs='*', help='Additional arguments')
 
     return parser

--- a/processes/cluster.py
+++ b/processes/cluster.py
@@ -40,6 +40,8 @@ class ClusterProcess(CoreProcess):
                 self.cluster_records(full=True)
             elif self.process == 'custom':
                 self.cluster_records(start_datetime=self.ingestPeriod)
+            elif self.process == 'single':
+                self.cluster_records(record_uuid=self.singleRecord)
             else: 
                 logger.warning(f'Unknown cluster process type {self.process}')
         except Exception as e:
@@ -48,7 +50,7 @@ class ClusterProcess(CoreProcess):
         finally:
             self.close_connection()
 
-    def cluster_records(self, full=False, start_datetime=None):
+    def cluster_records(self, full=False, start_datetime=None, record_uuid=None):
         get_unclustered_records_query = (
             self.session.query(Record)
                 .filter(Record.frbr_status == 'complete')
@@ -64,6 +66,9 @@ class ClusterProcess(CoreProcess):
                 start_datetime = datetime.strptime(start_datetime, '%Y-%m-%dT%H:%M:%S')
 
             get_unclustered_records_query = get_unclustered_records_query.filter(Record.date_modified > start_datetime)
+
+        if record_uuid:
+            get_unclustered_records_query = get_unclustered_records_query.filter(Record.uuid == record_uuid)
 
         works_to_index = []
         work_ids_to_delete = set()
@@ -167,6 +172,11 @@ class ClusterProcess(CoreProcess):
 
             for matched_record in matched_records:
                 matched_record_title, matched_record_id, matched_record_identifiers = matched_record
+                
+                if not matched_record_title:
+                    logger.warning(f'Matched record with id {matched_record_id} has no title')
+                    continue
+
                 tokenized_matched_record_title = self.tokenize_title(matched_record_title)
 
                 if match_distance > 0 and not self.titles_overlap(tokenized_record_title, tokenized_matched_record_title):


### PR DESCRIPTION
## Description
- Clustering fails if we try to tokenize a null title
- This change skips trying to cluster records without a title 

## Testing
`python main.py -p ClusterProcess -e local-qa -i single -r 1ad13bf1-e48b-4f8f-8868-457d98b302a8`

```
{"timestamp":1730226129848,"message":"Starting process ClusterProcess in local-qa","log.level":"INFO","logger.name":"__main__","thread.id":140704663367552,"thread.name":"MainThread","process.id":13466,"process.name":"MainProcess","file.name":"/Users/kylejacksonvillegas/workspace/drb-etl-pipeline-venv/drb-etl-pipeline/main.py","line.number":32,"entity.type":"SERVICE"}
{"timestamp":1730226132070,"message":"Clustering 1ad13bf1-e48b-4f8f-8868-457d98b302a8","log.level":"INFO","logger.name":"processes.cluster","thread.id":140704663367552,"thread.name":"MainThread","process.id":13466,"process.name":"MainProcess","file.name":"/Users/kylejacksonvillegas/workspace/drb-etl-pipeline-venv/drb-etl-pipeline/processes/cluster.py","line.number":71,"entity.type":"SERVICE"}
{"timestamp":1730226132524,"message":"Matched record with id 36624282 has no title","log.level":"WARNING","logger.name":"processes.cluster","thread.id":140704663367552,"thread.name":"MainThread","process.id":13466,"process.name":"MainProcess","file.name":"/Users/kylejacksonvillegas/workspace/drb-etl-pipeline-venv/drb-etl-pipeline/processes/cluster.py","line.number":178,"entity.type":"SERVICE"}
{"timestamp":1730226182016,"message":"Clustered 1 works","log.level":"INFO","logger.name":"processes.cluster","thread.id":140704663367552,"thread.name":"MainThread","process.id":13466,"process.name":"MainProcess","file.name":"/Users/kylejacksonvillegas/workspace/drb-etl-pipeline-venv/drb-etl-pipeline/processes/cluster.py","line.number":101,"entity.type":"SERVICE"}
```

In this case, one of our NYPL bibs caused us to fail clustering. 