### PR TITLE
SFR-2294: Only cluster records that have a title

### DIFF
--- a/processes/cluster.py
+++ b/processes/cluster.py
@@ -173,10 +173,6 @@ class ClusterProcess(CoreProcess):
 
             for matched_record in matched_records:
                 matched_record_title, matched_record_id, matched_record_identifiers = matched_record
-                
-                if not matched_record_title:
-                    logger.warning(f'Matched record with id {matched_record_id} has no title')
-                    continue
 
                 tokenized_matched_record_title = self.tokenize_title(matched_record_title)
 

--- a/processes/cluster.py
+++ b/processes/cluster.py
@@ -55,6 +55,7 @@ class ClusterProcess(CoreProcess):
                 .filter(Record.cluster_status == False)
                 .filter(Record.source != 'oclcClassify')
                 .filter(Record.source != 'oclcCatalog')
+                .filter(Record.title.isnot(None))
         )
 
         if not full:

--- a/processes/cluster.py
+++ b/processes/cluster.py
@@ -199,6 +199,7 @@ class ClusterProcess(CoreProcess):
                     self.session.query(Record.title, Record.id, Record.identifiers)
                         .filter(~Record.id.in_(list(already_matched_record_ids)))
                         .filter(Record.identifiers.overlap(id_batch))
+                        .filter(Record.title.isnot(None))
                         .all()
                 )
 

--- a/tests/unit/processes/test_cluster_process.py
+++ b/tests/unit/processes/test_cluster_process.py
@@ -152,7 +152,7 @@ class TestClusterProcess:
         mockQuery = mocker.MagicMock()
         testInstance.session = mockSession
 
-        mockSession.query().filter().filter().filter().filter.return_value = mockQuery
+        mockSession.query().filter().filter().filter().filter().filter.return_value = mockQuery
         mockQueryResponses = [mocker.MagicMock(id=1), mocker.MagicMock(id=2), None]
         mockQuery.first.side_effect = mockQueryResponses
 
@@ -318,7 +318,7 @@ class TestClusterProcess:
         mockFormatArray = mocker.patch.object(ClusterProcess, 'format_identifiers')
         mockFormatArray.return_value = 'testIdentifierArray'
 
-        testInstance.session.query().filter().filter().all.side_effect = [[1], [2, 3]]
+        testInstance.session.query().filter().filter().filter().all.side_effect = [[1], [2, 3]]
 
         testMatches = testInstance.get_matched_records([str(i) for i in range(103)], set([]))
 


### PR DESCRIPTION
## Description
- We are still seeing some NYPL records that we fail to cluster because the title is None
- Adding a filter to filter out records where the title is None in the first place.  