### PR TITLE
NO-REF: Pin werkzeug to 2.2.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,6 @@ requests_oauthlib==1.3.1
 scikit-learn==1.2.2
 sqlalchemy==2.0.20
 waitress==2.1.2
-werkzeug<2.1.0
+werkzeug<=2.2.2
 newrelic==8.8.0
 geocoder==1.38.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,5 +25,6 @@ requests_oauthlib==1.3.1
 scikit-learn==1.2.2
 sqlalchemy==2.0.20
 waitress==2.1.2
+werkzeug<2.1.0
 newrelic==8.8.0
 geocoder==1.38.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,6 @@ requests_oauthlib==1.3.1
 scikit-learn==1.2.2
 sqlalchemy==2.0.20
 waitress==2.1.2
-werkzeug<=2.2.2
+werkzeug==2.2.2
 newrelic==8.8.0
 geocoder==1.38.1


### PR DESCRIPTION
# Description
- Unit tests started failing because werkzeup.__version__ attribute was no longer there. 
- This cahnge pins the package to 2.2.2 which should fix the unit tests. 