### PR TITLE
NO-REF: Only run unit tests if requirements or source code changes

### DIFF
--- a/.github/workflows/tests-unit.yaml
+++ b/.github/workflows/tests-unit.yaml
@@ -2,7 +2,19 @@ name: ETL Pipeline Tests (Pull Request)
 
 on:
   pull_request:
-    actions: [ opened ]
+    types: [opened]
+    paths:
+      - 'api/*'
+      - 'managers/*'
+      - 'mappings/*'
+      - 'model/*'
+      - 'processes/*'
+      - 'tests/*'
+      - 'utils/*'
+      - 'dev-requirements.txt'
+      - 'requirements.txt'
+      - 'main.py'
+      - 'Makefile' 
 
 jobs:
   test:


### PR DESCRIPTION
## Description
- We should not run unit tests on every change to the repo
- This change triggers the unit tests GH action workflow only if files change in certain folders
- We should see a reduction hopefully in cost

