### PR TITLE
NO-REF: Remove Elastic Search Manager Ancestor

### DIFF
--- a/processes/cluster.py
+++ b/processes/cluster.py
@@ -28,11 +28,11 @@ class ClusterProcess(CoreProcess):
 
         self.createRedisClient()
 
-        self.elasic_search_manager = ElasticsearchManager()
+        self.elastic_search_manager = ElasticsearchManager()
         
-        self.elasic_search_manager.createElasticConnection()
-        self.elasic_search_manager.createElasticSearchIngestPipeline()
-        self.elasic_search_manager.createElasticSearchIndex()
+        self.elastic_search_manager.createElasticConnection()
+        self.elastic_search_manager.createElasticSearchIngestPipeline()
+        self.elastic_search_manager.createElasticSearchIndex()
 
     def runProcess(self):
         try:
@@ -137,7 +137,7 @@ class ClusterProcess(CoreProcess):
         )
 
     def update_elastic_search(self, works_to_index: list, word_ids_to_delete: set):
-        self.elasic_search_manager.deleteWorkRecords(word_ids_to_delete)
+        self.elastic_search_manager.deleteWorkRecords(word_ids_to_delete)
         self.index_works_in_elastic_search(works_to_index)
 
     def delete_stale_works(self, work_ids: set[str]):
@@ -236,7 +236,7 @@ class ClusterProcess(CoreProcess):
             elastic_manager.getCreateWork()
             work_documents.append(elastic_manager.work)
 
-        self.elasic_search_manager.saveWorkRecords(work_documents)
+        self.elastic_search_manager.saveWorkRecords(work_documents)
 
     def titles_overlap(self, tokenized_record_title: set, tokenized_matched_record_title: set):
         if len(tokenized_record_title) == 1 and not tokenized_record_title <= tokenized_matched_record_title:

--- a/processes/cluster.py
+++ b/processes/cluster.py
@@ -4,7 +4,7 @@ from sqlalchemy.exc import DataError
 from typing import Optional
 
 from .core import CoreProcess
-from managers import SFRRecordManager, KMeansManager, SFRElasticRecordManager
+from managers import SFRRecordManager, KMeansManager, SFRElasticRecordManager, ElasticsearchManager
 from model import Record, Work
 from logger import createLog
 
@@ -27,10 +27,12 @@ class ClusterProcess(CoreProcess):
         self.createSession()
 
         self.createRedisClient()
+
+        self.elasic_search_manager = ElasticsearchManager()
         
-        self.createElasticConnection()
-        self.createElasticSearchIngestPipeline()
-        self.createElasticSearchIndex()
+        self.elasic_search_manager.createElasticConnection()
+        self.elasic_search_manager.createElasticSearchIngestPipeline()
+        self.elasic_search_manager.createElasticSearchIndex()
 
     def runProcess(self):
         try:
@@ -135,7 +137,7 @@ class ClusterProcess(CoreProcess):
         )
 
     def update_elastic_search(self, works_to_index: list, word_ids_to_delete: set):
-        self.deleteWorkRecords(word_ids_to_delete)
+        self.elasic_search_manager.deleteWorkRecords(word_ids_to_delete)
         self.index_works_in_elastic_search(works_to_index)
 
     def delete_stale_works(self, work_ids: set[str]):
@@ -234,7 +236,7 @@ class ClusterProcess(CoreProcess):
             elastic_manager.getCreateWork()
             work_documents.append(elastic_manager.work)
 
-        self.saveWorkRecords(work_documents)
+        self.elasic_search_manager.saveWorkRecords(work_documents)
 
     def titles_overlap(self, tokenized_record_title: set, tokenized_matched_record_title: set):
         if len(tokenized_record_title) == 1 and not tokenized_record_title <= tokenized_matched_record_title:

--- a/processes/core.py
+++ b/processes/core.py
@@ -1,4 +1,4 @@
-from managers import DBManager, RabbitMQManager, RedisManager, ElasticsearchManager, S3Manager
+from managers import DBManager, RabbitMQManager, RedisManager, S3Manager
 from model import Record
 from static.manager import StaticManager
 
@@ -8,8 +8,7 @@ from logger import createLog
 logger = createLog(__name__)
 
 
-class CoreProcess(DBManager, RabbitMQManager, RedisManager, StaticManager,
-                  ElasticsearchManager, S3Manager):
+class CoreProcess(DBManager, RabbitMQManager, RedisManager, StaticManager, S3Manager):
     def __init__(self, process, customFile, ingestPeriod, singleRecord, batchSize=500):
         super(CoreProcess, self).__init__()
         self.process = process

--- a/tests/unit/processes/test_core_process.py
+++ b/tests/unit/processes/test_core_process.py
@@ -34,10 +34,6 @@ class TestCoreProcess:
         assert coreInstance.port == 'test_psql_port'
         assert coreInstance.db == 'test_psql_name'
 
-        # Properties set by the ElasticSearchManager
-        assert coreInstance.index == 'test_es_index'
-        assert coreInstance.client is None
-
         # Properties set by the RabbitMQManager
         assert coreInstance.rabbitHost == 'test_rbmq_host'
         assert coreInstance.rabbitPort == 'test_rbmq_port'


### PR DESCRIPTION
## Description
- Removes elastic search manager from the core process inheritance tree.

## Testing
`make unit`; `python main.py -p SeedLocalDataProcess -e local`