### PR TITLE
NO-REF: add error handling error process init

### DIFF
--- a/main.py
+++ b/main.py
@@ -36,10 +36,14 @@ def main(args):
 
     availableProcesses = registerProcesses()
 
-    procClass = availableProcesses[process]
-    processInstance = procClass(
-        procType, customFile, startDate, singleRecord, limit, offset, options
-    )
+    try:
+        procClass = availableProcesses[process]
+        processInstance = procClass(
+            procType, customFile, startDate, singleRecord, limit, offset, options
+        )
+    except:
+        logger.exception(f'Failed to initialize process {process} in {environment}')
+        return
 
     if process in (
         "APIProcess", # Covered by newrelic's automatic Flask integration

--- a/main.py
+++ b/main.py
@@ -54,6 +54,7 @@ def main(args):
     else:
         app = newrelic.agent.register_application(timeout=10.0)
         with newrelic.agent.BackgroundTask(app, name=process):
+            logger.info(f'Running process {process} in {environment}')
             processInstance.runProcess()
 
 


### PR DESCRIPTION
## Description
- Sometimes I see that a process is starting from main.py but no other logs from the process files
- Adding some error handling to see if initiatlization fails. 
- We have a lot of code in our constructors, so this is an outer try/except block that will catch errors that occur initializing our processes. 