### PR TITLE
NO-REF: Rename base mapping classes

### DIFF
--- a/mappings/base_mapping.py
+++ b/mappings/base_mapping.py
@@ -2,11 +2,11 @@ from datetime import datetime, timezone
 from string import Formatter
 from uuid import uuid4
 
-from .abstractMapping import AbstractMapping
+from .record_mapping import RecordMapping
 from model import Record
 
 
-class Core(AbstractMapping):
+class BaseMapping(RecordMapping):
     def __init__(self, source, statics):
         self.mapping = {}
         self.source = source

--- a/mappings/csv.py
+++ b/mappings/csv.py
@@ -1,9 +1,9 @@
-from .core import Core
+from .base_mapping import BaseMapping
 from logger import createLog
 
 logger = createLog(__name__)
 
-class CSVMapping(Core):
+class CSVMapping(BaseMapping):
     def __init__(self, source, statics):
         super().__init__(source, statics)
 

--- a/mappings/json.py
+++ b/mappings/json.py
@@ -1,7 +1,7 @@
-from .core import Core
+from .base_mapping import BaseMapping
 
 
-class JSONMapping(Core):
+class JSONMapping(BaseMapping):
     def __init__(self, source, statics):
         super().__init__(source, statics)
 

--- a/mappings/marc.py
+++ b/mappings/marc.py
@@ -1,12 +1,12 @@
 import re
 
-from .core import Core
+from .base_mapping import BaseMapping
 from logger import createLog
 
 logger = createLog(__name__)
 
 
-class MARCMapping(Core):
+class MARCMapping(BaseMapping):
     def __init__(self, source, statics):
         super().__init__(source, statics)
 

--- a/mappings/oclc_bib.py
+++ b/mappings/oclc_bib.py
@@ -3,10 +3,10 @@ from typing import Optional
 from uuid import uuid4
 
 from model import Record
-from .core import Core
+from .base_mapping import BaseMapping
 
 
-class OCLCBibMapping(Core):
+class OCLCBibMapping(BaseMapping):
     def __init__(self, oclc_bib, related_oclc_numbers=[]):
         self.record = self._map_to_record(oclc_bib, related_oclc_numbers)
 

--- a/mappings/record_mapping.py
+++ b/mappings/record_mapping.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 
-class AbstractMapping(ABC):
+class RecordMapping(ABC):
     @abstractmethod
     def __init__(self):
         pass

--- a/mappings/sql.py
+++ b/mappings/sql.py
@@ -1,10 +1,10 @@
-from .core import Core
+from .base_mapping import BaseMapping
 from logger import createLog
 
 logger = createLog(__name__)
 
 
-class SQLMapping(Core):
+class SQLMapping(BaseMapping):
     def __init__(self, source, statics):
         super().__init__(source, statics)
     

--- a/mappings/xml.py
+++ b/mappings/xml.py
@@ -1,13 +1,13 @@
 from itertools import zip_longest
 from lxml import etree
 
-from .core import Core
+from .base_mapping import BaseMapping
 from logger import createLog
 
 logger = createLog(__name__)
 
 
-class XMLMapping(Core):
+class XMLMapping(BaseMapping):
     def __init__(self, source, namespace, statics):
         super().__init__(source, statics)
         self.namespace = namespace

--- a/processes/ingest/doab.py
+++ b/processes/ingest/doab.py
@@ -7,7 +7,7 @@ import requests
 from ..core import CoreProcess
 from logger import createLog
 from mappings.doab import DOABMapping
-from mappings.core import MappingError
+from mappings.base_mapping import MappingError
 from managers import DOABLinkManager
 
 logger = createLog(__name__)

--- a/processes/ingest/loc.py
+++ b/processes/ingest/loc.py
@@ -3,7 +3,7 @@ import os, requests
 from requests.exceptions import HTTPError, ConnectionError
 
 from ..core import CoreProcess
-from mappings.core import MappingError
+from mappings.base_mapping import MappingError
 from mappings.loc import LOCMapping
 from managers import WebpubManifest
 from logger import createLog

--- a/processes/ingest/met.py
+++ b/processes/ingest/met.py
@@ -5,7 +5,7 @@ import requests
 from requests.exceptions import HTTPError, ConnectionError
 
 from ..core import CoreProcess
-from mappings.core import MappingError
+from mappings.base_mapping import MappingError
 from mappings.met import METMapping
 from managers import WebpubManifest
 from logger import createLog

--- a/processes/ingest/u_of_m.py
+++ b/processes/ingest/u_of_m.py
@@ -5,7 +5,7 @@ from botocore.exceptions import ClientError
 
 from ..core import CoreProcess
 from urllib.error import HTTPError
-from mappings.core import MappingError
+from mappings.base_mapping import MappingError
 from mappings.UofM import UofMMapping
 from managers import WebpubManifest
 from logger import createLog

--- a/processes/ingest/u_of_sc.py
+++ b/processes/ingest/u_of_sc.py
@@ -3,7 +3,7 @@ import os
 from requests.exceptions import HTTPError, ConnectionError
 
 from ..core import CoreProcess
-from mappings.core import MappingError
+from mappings.base_mapping import MappingError
 from mappings.UofSC import UofSCMapping
 from managers import WebpubManifest
 from logger import createLog

--- a/services/sources/source_service.py
+++ b/services/sources/source_service.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from datetime import datetime
 from typing import Optional
 
-from mappings.abstractMapping import AbstractMapping
+from mappings.record_mapping import RecordMapping
 
 class SourceService(ABC):
 
@@ -13,5 +13,5 @@ class SourceService(ABC):
         start_timestamp: Optional[datetime]=None,
         offset: Optional[int]=None,
         limit: Optional[int]=None
-    ) -> list[AbstractMapping]:
+    ) -> list[RecordMapping]:
         pass

--- a/tests/unit/processes/file/test_fulfill_manifest_process.py
+++ b/tests/unit/processes/file/test_fulfill_manifest_process.py
@@ -1,6 +1,6 @@
 import pytest
 
-from mappings.core import MappingError
+from mappings.base_mapping import MappingError
 from processes.file.fulfill_url_manifest import FulfillURLManifestProcess
 from tests.helper import TestHelpers
 

--- a/tests/unit/processes/ingest/test_chicago_isac_process.py
+++ b/tests/unit/processes/ingest/test_chicago_isac_process.py
@@ -1,6 +1,6 @@
 import pytest
 
-from mappings.core import MappingError
+from mappings.base_mapping import MappingError
 from processes import ChicagoISACProcess
 from tests.helper import TestHelpers
 

--- a/tests/unit/processes/ingest/test_doab_process.py
+++ b/tests/unit/processes/ingest/test_doab_process.py
@@ -6,7 +6,7 @@ from unittest import mock
 
 
 from processes.ingest.doab import DOABProcess, DOABError
-from mappings.core import MappingError
+from mappings.base_mapping import MappingError
 from tests.helper import TestHelpers
 
 

--- a/tests/unit/processes/ingest/test_loc_process.py
+++ b/tests/unit/processes/ingest/test_loc_process.py
@@ -1,6 +1,6 @@
 import pytest
 
-from mappings.core import MappingError
+from mappings.base_mapping import MappingError
 from model import Record
 from processes import LOCProcess
 from tests.helper import TestHelpers

--- a/tests/unit/processes/ingest/test_met_process.py
+++ b/tests/unit/processes/ingest/test_met_process.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 import pytest
 
-from mappings.core import MappingError
+from mappings.base_mapping import MappingError
 from processes.ingest.met import METProcess, METError
 from tests.helper import TestHelpers
 

--- a/tests/unit/processes/ingest/test_u_of_m_process.py
+++ b/tests/unit/processes/ingest/test_u_of_m_process.py
@@ -1,6 +1,6 @@
 import pytest
 
-from mappings.core import MappingError
+from mappings.base_mapping import MappingError
 from processes import UofMProcess
 from tests.helper import TestHelpers
 

--- a/tests/unit/test_base_mapping_mapping.py
+++ b/tests/unit/test_base_mapping_mapping.py
@@ -1,19 +1,19 @@
 import pytest
 
-from mappings.core import Core
+from mappings.base_mapping import BaseMapping
 
 
 class TestCoreMapping:
     @pytest.fixture
     def testMapping(self, mocker):
-        class TestCore(Core):
+        class TestCore(BaseMapping):
             def ___init__(self, source, statics):
                 super(self, TestCore).__init__(source, statics)
 
             def createMapping(self):
                 pass
 
-        mockFormatter = mocker.patch('mappings.core.CustomFormatter')
+        mockFormatter = mocker.patch('mappings.base_mapping.CustomFormatter')
         mockFormatter.return_value = 'mockFormatter'
         return TestCore('test', {'static': 'values'})
 
@@ -25,11 +25,11 @@ class TestCoreMapping:
         assert testMapping.formatter == 'mockFormatter'
 
     def test_initEmptyRecord(self, testMapping, mocker):
-        mockUUID = mocker.patch('mappings.core.uuid4')
+        mockUUID = mocker.patch('mappings.base_mapping.uuid4')
         mockUUID.return_value = 'testUUID'
-        mockDate = mocker.patch('mappings.core.datetime')
+        mockDate = mocker.patch('mappings.base_mapping.datetime')
         mockDate.now.return_value.replace.side_effect = ['testCreated', 'testModified']
-        mockRecord = mocker.patch('mappings.core.Record')
+        mockRecord = mocker.patch('mappings.base_mapping.Record')
         mockRecord.return_value = 'testRecord'
 
         testRecord = testMapping.initEmptyRecord()
@@ -41,7 +41,7 @@ class TestCoreMapping:
         )
 
     def test_applyMapping(self, testMapping, mocker):
-        mockInitEmpty = mocker.patch.object(Core, 'initEmptyRecord')
+        mockInitEmpty = mocker.patch.object(BaseMapping, 'initEmptyRecord')
 
         testMapping.applyMapping()
 

--- a/tests/unit/test_custom_formatter_mapping.py
+++ b/tests/unit/test_custom_formatter_mapping.py
@@ -1,6 +1,6 @@
 import pytest
 
-from mappings.core import CustomFormatter
+from mappings.base_mapping import CustomFormatter
 
 
 class TestCustomFormatter:

--- a/tests/unit/test_doab_mapping.py
+++ b/tests/unit/test_doab_mapping.py
@@ -1,7 +1,7 @@
 import pytest
 
 from mappings.doab import DOABMapping
-from mappings.core import MappingError
+from mappings.base_mapping import MappingError
 
 
 class TestDOABMapping:


### PR DESCRIPTION
## Description
- Core and AbstractMapping were not clear names
- Renames Core to BaseMapping
- Renames AbstractMapping to RecordMapping

## Testing
`make unit`