### PR TITLE
NO-REF: Remove RedisManager as an ancestor of CoreProcess

### DIFF
--- a/processes/cluster.py
+++ b/processes/cluster.py
@@ -4,7 +4,7 @@ from sqlalchemy.exc import DataError
 from typing import Optional
 
 from .core import CoreProcess
-from managers import SFRRecordManager, KMeansManager, SFRElasticRecordManager, ElasticsearchManager
+from managers import SFRRecordManager, KMeansManager, SFRElasticRecordManager, ElasticsearchManager, RedisManager
 from model import Record, Work
 from logger import createLog
 
@@ -26,7 +26,8 @@ class ClusterProcess(CoreProcess):
         self.generateEngine()
         self.createSession()
 
-        self.createRedisClient()
+        self.redis_manager = RedisManager()
+        self.redis_manager.createRedisClient()
 
         self.elastic_search_manager = ElasticsearchManager()
         

--- a/processes/core.py
+++ b/processes/core.py
@@ -1,4 +1,4 @@
-from managers import DBManager, RabbitMQManager, RedisManager, S3Manager
+from managers import DBManager, RabbitMQManager, S3Manager
 from model import Record
 from static.manager import StaticManager
 
@@ -8,7 +8,7 @@ from logger import createLog
 logger = createLog(__name__)
 
 
-class CoreProcess(DBManager, RabbitMQManager, RedisManager, StaticManager, S3Manager):
+class CoreProcess(DBManager, RabbitMQManager, StaticManager, S3Manager):
     def __init__(self, process, customFile, ingestPeriod, singleRecord, batchSize=500):
         super(CoreProcess, self).__init__()
         self.process = process

--- a/processes/file/covers.py
+++ b/processes/file/covers.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta, timezone
 import os
 
 from ..core import CoreProcess
-from managers import CoverManager
+from managers import CoverManager, RedisManager
 from model import Edition, Link
 from model.postgres.edition import EDITION_LINKS
 from logger import createLog
@@ -17,7 +17,8 @@ class CoverProcess(CoreProcess):
         self.generateEngine()
         self.createSession()
 
-        self.createRedisClient()
+        self.redis_manager = RedisManager()
+        self.redis_manager.createRedisClient()
 
         self.createS3Client()
         self.fileBucket = os.environ['FILE_BUCKET']
@@ -73,7 +74,7 @@ class CoverProcess(CoreProcess):
 
     def getEditionIdentifiers(self, edition):
         for iden in edition.identifiers:
-            if self.checkSetRedis('sfrCovers', iden.identifier, iden.authority, expirationTime=60*60*24*30):
+            if self.redis_manager.checkSetRedis('sfrCovers', iden.identifier, iden.authority, expirationTime=60*60*24*30):
                 logger.debug('{} recently queried. Skipping'.format(iden))
                 continue
 

--- a/processes/frbr/classify.py
+++ b/processes/frbr/classify.py
@@ -4,7 +4,7 @@ import newrelic.agent
 import re
 
 from ..core import CoreProcess
-from managers import OCLCCatalogManager
+from managers import OCLCCatalogManager, RedisManager
 from mappings.oclc_bib import OCLCBibMapping
 from model import Record
 from logger import createLog
@@ -24,7 +24,8 @@ class ClassifyProcess(CoreProcess):
         self.generateEngine()
         self.createSession()
 
-        self.createRedisClient()
+        self.redis_manager = RedisManager()
+        self.redis_manager.createRedisClient()
 
         self.catalog_queue = os.environ['OCLC_QUEUE']
         self.catalog_route = os.environ['OCLC_ROUTING_KEY']
@@ -78,7 +79,7 @@ class ClassifyProcess(CoreProcess):
             record.frbr_status = 'complete'
             frbrized_records.append(record)
 
-            if self.checkIncrementerRedis('oclcCatalog', 'API'):
+            if self.redis_manager.checkIncrementerRedis('oclcCatalog', 'API'):
                 logger.warning('Exceeded max requests to OCLC catalog')
                 break
 
@@ -109,7 +110,7 @@ class ClassifyProcess(CoreProcess):
             except Exception:
                 author = None
 
-            if identifier and self.checkSetRedis('classify', identifier, identifier_type):
+            if identifier and self.redis_manager.checkSetRedis('classify', identifier, identifier_type):
                 continue
 
             try:
@@ -157,7 +158,7 @@ class ClassifyProcess(CoreProcess):
 
         oclc_numbers = list(oclc_numbers)
 
-        cached_oclc_numbers = self.multiCheckSetRedis('catalog', oclc_numbers, 'oclc')
+        cached_oclc_numbers = self.redis_manager.multiCheckSetRedis('catalog', oclc_numbers, 'oclc')
 
         for oclc_number, uncached in cached_oclc_numbers:
             if not uncached:
@@ -168,10 +169,10 @@ class ClassifyProcess(CoreProcess):
             catalogued_record_count += 1
 
         if catalogued_record_count > 0:
-            self.setIncrementerRedis('oclcCatalog', 'API', amount=catalogued_record_count)
+            self.redis_manager.setIncrementerRedis('oclcCatalog', 'API', amount=catalogued_record_count)
 
     def check_if_classify_work_fetched(self, owi_number: int) -> bool:
-        return self.checkSetRedis('classifyWork', owi_number, 'owi')
+        return self.redis_manager.checkSetRedis('classifyWork', owi_number, 'owi')
 
     def _get_queryable_identifiers(self, identifiers):
         return list(filter(

--- a/processes/local_development/seed_local_data.py
+++ b/processes/local_development/seed_local_data.py
@@ -6,6 +6,7 @@ import requests
 
 from ..core import CoreProcess
 from logger import createLog
+from managers import RedisManager
 from mappings.hathitrust import HathiMapping
 from processes import CatalogProcess, ClassifyProcess, ClusterProcess
 
@@ -16,6 +17,8 @@ class SeedLocalDataProcess(CoreProcess):
     def __init__(self, *args):
         super(SeedLocalDataProcess, self).__init__(*args[:4])
 
+        self.redis_manager = RedisManager()
+
     def runProcess(self):
         try:
             self.generateEngine()
@@ -25,8 +28,9 @@ class SeedLocalDataProcess(CoreProcess):
 
             process_args = ['complete'] + ([None] * 4)
 
-            self.createRedisClient()
-            self.clear_cache()
+
+            self.redis_manager.createRedisClient()
+            self.redis_manager.clear_cache()
 
             classify_process = ClassifyProcess(*process_args)
             classify_process.runProcess()

--- a/tests/unit/processes/frbr/test_classify_process.py
+++ b/tests/unit/processes/frbr/test_classify_process.py
@@ -25,6 +25,7 @@ class TestOCLCClassifyProcess:
                 self.catalog_route = os.environ['OCLC_ROUTING_KEY']
                 self.classified_count = 0
                 self.oclc_catalog_manager = mocker.MagicMock()
+                self.redis_manager = mocker.MagicMock()
 
         return TestClassifyProcess('TestProcess', 'testFile', 'testDate')
 
@@ -83,8 +84,7 @@ class TestOCLCClassifyProcess:
         mock_window_query = mocker.patch.object(ClassifyProcess, 'windowedQuery')
         mock_window_query.return_value = mock_records
 
-        mock_check_redis = mocker.patch.object(ClassifyProcess, 'checkIncrementerRedis')
-        mock_check_redis.side_effect = [False] * 100
+        test_instance.redis_manager.checkIncrementerRedis.side_effect = [False] * 100
 
         mock_bulk_save_objects = mocker.patch.object(ClassifyProcess, 'bulkSaveObjects')
 
@@ -107,8 +107,7 @@ class TestOCLCClassifyProcess:
         mock_window_query = mocker.patch.object(ClassifyProcess, 'windowedQuery')
         mock_window_query.return_value = mock_records
 
-        mock_check_redis = mocker.patch.object(ClassifyProcess, 'checkIncrementerRedis')
-        mock_check_redis.side_effect = [False] * 100
+        test_instance.redis_manager.checkIncrementerRedis.side_effect = [False] * 100
 
         mock_bulk_save_objects = mocker.patch.object(ClassifyProcess, 'bulkSaveObjects')
 
@@ -132,8 +131,7 @@ class TestOCLCClassifyProcess:
         mock_window_query = mocker.patch.object(ClassifyProcess, 'windowedQuery')
         mock_window_query.return_value = mock_records
 
-        mock_check_redis = mocker.patch.object(ClassifyProcess, 'checkIncrementerRedis')
-        mock_check_redis.side_effect = [False] * 50 + [True]
+        test_instance.redis_manager.checkIncrementerRedis.side_effect = [False] * 50 + [True]
 
         mock_bulk_save_objects = mocker.patch.object(ClassifyProcess, 'bulkSaveObjects')
 
@@ -157,8 +155,7 @@ class TestOCLCClassifyProcess:
         mock_window_query = mocker.patch.object(ClassifyProcess, 'windowedQuery')
         mock_window_query.return_value = mock_records
 
-        mock_check_redis = mocker.patch.object(ClassifyProcess, 'checkIncrementerRedis')
-        mock_check_redis.side_effect = [False] * 100
+        test_instance.redis_manager.checkIncrementerRedis.side_effect = [False] * 100
 
         mock_bulk_save_objects = mocker.patch.object(ClassifyProcess, 'bulkSaveObjects')
 
@@ -174,23 +171,21 @@ class TestOCLCClassifyProcess:
         mock_identifiers = mocker.patch.object(ClassifyProcess, '_get_queryable_identifiers')
         mock_identifiers.return_value = ['1|test']
 
-        mock_check_redis = mocker.patch.object(ClassifyProcess, 'checkSetRedis')
-        mock_check_redis.return_value = False
+        test_instance.redis_manager.checkSetRedis.return_value = False
 
         mock_classify_record = mocker.patch.object(ClassifyProcess, 'classify_record_by_metadata')
 
         test_instance.frbrize_record(test_record)
 
         mock_identifiers.assert_called_once_with(test_record.identifiers)
-        mock_check_redis.assert_called_once_with('classify', '1', 'test')
+        test_instance.redis_manager.checkSetRedis.assert_called_once_with('classify', '1', 'test')
         mock_classify_record.assert_called_once_with('1', 'test', 'Author, Test', 'Test Record')
 
     def test_frbrize_record_success_author_missing(self, test_instance, test_record, mocker):
         mock_identifiers = mocker.patch.object(ClassifyProcess, '_get_queryable_identifiers')
         mock_identifiers.return_value = ['1|test']
 
-        mock_check_redis = mocker.patch.object(ClassifyProcess, 'checkSetRedis')
-        mock_check_redis.return_value = False
+        test_instance.redis_manager.checkSetRedis.return_value = False
 
         mock_classify_record = mocker.patch.object(ClassifyProcess, 'classify_record_by_metadata')
 
@@ -198,15 +193,14 @@ class TestOCLCClassifyProcess:
         test_instance.frbrize_record(test_record)
 
         mock_identifiers.assert_called_once_with(test_record.identifiers)
-        mock_check_redis.assert_called_once_with('classify', '1', 'test')
+        test_instance.redis_manager.checkSetRedis.assert_called_once_with('classify', '1', 'test')
         mock_classify_record.assert_called_once_with('1', 'test', None, 'Test Record')
 
     def test_frbrize_record_identifier_in_redis(self, test_instance, test_record, mocker):
         mock_identifiers = mocker.patch.object(ClassifyProcess, '_get_queryable_identifiers')
         mock_identifiers.return_value = ['1|test']
 
-        mock_check_redis = mocker.patch.object(ClassifyProcess, 'checkSetRedis')
-        mock_check_redis.return_value = True
+        test_instance.redis_manager.checkSetRedis.return_value = True
 
         mock_classify_record = mocker.patch.object(ClassifyProcess, 'classify_record_by_metadata')
 
@@ -214,44 +208,39 @@ class TestOCLCClassifyProcess:
         test_instance.frbrize_record(test_record)
 
         mock_identifiers.assert_called_once_with(test_record.identifiers)
-        mock_check_redis.assert_called_once_with('classify', '1', 'test')
+        test_instance.redis_manager.checkSetRedis.assert_called_once_with('classify', '1', 'test')
         mock_classify_record.assert_not_called
 
     def test_frbrize_record_identifier_missing(self, test_instance, test_record, mocker):
         mock_identifiers = mocker.patch.object(ClassifyProcess, '_get_queryable_identifiers')
         mock_identifiers.return_value = []
-        mock_check_redis = mocker.patch.object(ClassifyProcess, 'checkSetRedis')
         mock_classify_record = mocker.patch.object(ClassifyProcess, 'classify_record_by_metadata')
 
         test_instance.frbrize_record(test_record)
 
         mock_identifiers.assert_called_once_with(test_record.identifiers)
-        mock_check_redis.assert_not_called()
+        test_instance.redis_manager.checkSetRedis.assert_not_called()
         mock_classify_record.assert_called_once_with(None, None, 'Author, Test', 'Test Record')
 
     def test_get_oclc_catalog_records_no_redis_match(self, test_instance, mocker):
-        mock_check_redis = mocker.patch.object(ClassifyProcess, 'multiCheckSetRedis')
-        mock_check_redis.return_value = [('2', True)]
+        test_instance.redis_manager.multiCheckSetRedis.return_value = [('2', True)]
         mock_send_message_to_queue = mocker.patch.object(ClassifyProcess, 'sendMessageToQueue')
-        mock_set_redis = mocker.patch.object(ClassifyProcess, 'setIncrementerRedis')
 
         test_instance.get_oclc_catalog_records(['1|owi', '2|oclc'])
 
-        mock_check_redis.assert_called_once_with('catalog', ['2'], 'oclc')
+        test_instance.redis_manager.multiCheckSetRedis.assert_called_once_with('catalog', ['2'], 'oclc')
         mock_send_message_to_queue.assert_called_once_with('test_oclc_queue', 'test_oclc_key', {'oclcNo': '2', 'owiNo': '1'})
-        mock_set_redis.assert_called_once_with('oclcCatalog', 'API', amount=1)
+        test_instance.redis_manager.setIncrementerRedis.assert_called_once_with('oclcCatalog', 'API', amount=1)
 
     def test_get_oclc_catalog_records_redis_match(self, test_instance, mocker):
-        mock_check_redis = mocker.patch.object(ClassifyProcess, 'multiCheckSetRedis')
-        mock_check_redis.return_value = [(2, False)]
+        test_instance.redis_manager.multiCheckSetRedis.return_value = [(2, False)]
         mock_send_message_to_queue = mocker.patch.object(ClassifyProcess, 'sendMessageToQueue')
-        mock_set_redis = mocker.patch.object(ClassifyProcess, 'setIncrementerRedis')
 
         test_instance.get_oclc_catalog_records(['1|test', '2|oclc'])
 
-        mock_check_redis.assert_called_once_with('catalog', ['2'], 'oclc')
+        test_instance.redis_manager.multiCheckSetRedis.assert_called_once_with('catalog', ['2'], 'oclc')
         mock_send_message_to_queue.assert_not_called()
-        mock_set_redis.assert_not_called()
+        test_instance.redis_manager.setIncrementerReids.assert_not_called()
     
     def test_get_queryable_identifiers(self, test_instance):
         assert test_instance._get_queryable_identifiers(['1|isbn', '2|test']) == ['1|isbn']

--- a/tests/unit/processes/test_core_process.py
+++ b/tests/unit/processes/test_core_process.py
@@ -38,10 +38,6 @@ class TestCoreProcess:
         assert coreInstance.rabbitHost == 'test_rbmq_host'
         assert coreInstance.rabbitPort == 'test_rbmq_port'
 
-        # Properties set by the RedisManager
-        assert coreInstance.redisHost == 'test_redis_host'
-        assert coreInstance.redisPort == 'test_redis_port'
-
     def test_addDCDWToUpdateList_existing(self, coreInstance, mocker):
         mockSession = mocker.MagicMock()
         mockSession.query().filter().first.return_value = 'existing_record'


### PR DESCRIPTION
## Description
- Removes RedisManager as an ancestor of CoreProcess
- Uses composition for the RedisManager instances with the processes that rely on this manager

## Testing
`make unit`