### PR TITLE
NO-REF: Removing RabbitMQManager as a CoreProcess ancestor

### DIFF
--- a/model/__init__.py
+++ b/model/__init__.py
@@ -18,3 +18,5 @@ from .elasticsearch.rights import Rights as ESRights
 from .elasticsearch.subject import Subject as ESSubject
 from .elasticsearch.work import Work as ESWork
 from .elasticsearch.base import PerLanguageField
+
+from .queue.file_message import get_file_message

--- a/model/queue/file_message.py
+++ b/model/queue/file_message.py
@@ -1,0 +1,7 @@
+def get_file_message(file_url: str, bucket_path: str):
+    return {
+        'fileData': {
+            'fileURL': file_url,
+            'bucketPath': bucket_path
+        }
+    }

--- a/processes/core.py
+++ b/processes/core.py
@@ -1,4 +1,4 @@
-from managers import DBManager, RabbitMQManager, RedisManager, S3Manager
+from managers import DBManager, RedisManager, S3Manager
 from model import Record
 from static.manager import StaticManager
 
@@ -8,7 +8,7 @@ from logger import createLog
 logger = createLog(__name__)
 
 
-class CoreProcess(DBManager, RabbitMQManager, RedisManager, StaticManager, S3Manager):
+class CoreProcess(DBManager, RedisManager, StaticManager, S3Manager):
     def __init__(self, process, customFile, ingestPeriod, singleRecord, batchSize=500):
         super(CoreProcess, self).__init__()
         self.process = process
@@ -67,12 +67,3 @@ class CoreProcess(DBManager, RabbitMQManager, RedisManager, StaticManager, S3Man
 
     def saveRecords(self):
         self.bulkSaveObjects(self.records)
-
-    def sendFileToProcessingQueue(self, fileURL, s3Location):
-        s3Message = {
-            'fileData': {
-                'fileURL': fileURL,
-                'bucketPath': s3Location
-            }
-        }
-        self.sendMessageToQueue(self.fileQueue, self.fileRoute, s3Message)

--- a/tests/unit/processes/frbr/test_classify_process.py
+++ b/tests/unit/processes/frbr/test_classify_process.py
@@ -25,6 +25,7 @@ class TestOCLCClassifyProcess:
                 self.catalog_route = os.environ['OCLC_ROUTING_KEY']
                 self.classified_count = 0
                 self.oclc_catalog_manager = mocker.MagicMock()
+                self.rabbitmq_manager = mocker.MagicMock()
 
         return TestClassifyProcess('TestProcess', 'testFile', 'testDate')
 
@@ -232,25 +233,23 @@ class TestOCLCClassifyProcess:
     def test_get_oclc_catalog_records_no_redis_match(self, test_instance, mocker):
         mock_check_redis = mocker.patch.object(ClassifyProcess, 'multiCheckSetRedis')
         mock_check_redis.return_value = [('2', True)]
-        mock_send_message_to_queue = mocker.patch.object(ClassifyProcess, 'sendMessageToQueue')
         mock_set_redis = mocker.patch.object(ClassifyProcess, 'setIncrementerRedis')
 
         test_instance.get_oclc_catalog_records(['1|owi', '2|oclc'])
 
         mock_check_redis.assert_called_once_with('catalog', ['2'], 'oclc')
-        mock_send_message_to_queue.assert_called_once_with('test_oclc_queue', 'test_oclc_key', {'oclcNo': '2', 'owiNo': '1'})
+        test_instance.rabbitmq_manager.sendMessageToQueue.assert_called_once_with('test_oclc_queue', 'test_oclc_key', {'oclcNo': '2', 'owiNo': '1'})
         mock_set_redis.assert_called_once_with('oclcCatalog', 'API', amount=1)
 
     def test_get_oclc_catalog_records_redis_match(self, test_instance, mocker):
         mock_check_redis = mocker.patch.object(ClassifyProcess, 'multiCheckSetRedis')
         mock_check_redis.return_value = [(2, False)]
-        mock_send_message_to_queue = mocker.patch.object(ClassifyProcess, 'sendMessageToQueue')
         mock_set_redis = mocker.patch.object(ClassifyProcess, 'setIncrementerRedis')
 
         test_instance.get_oclc_catalog_records(['1|test', '2|oclc'])
 
         mock_check_redis.assert_called_once_with('catalog', ['2'], 'oclc')
-        mock_send_message_to_queue.assert_not_called()
+        test_instance.rabbitmq_manager.sendMessageToQueue.assert_not_called()
         mock_set_redis.assert_not_called()
     
     def test_get_queryable_identifiers(self, test_instance):

--- a/tests/unit/processes/test_core_process.py
+++ b/tests/unit/processes/test_core_process.py
@@ -34,10 +34,6 @@ class TestCoreProcess:
         assert coreInstance.port == 'test_psql_port'
         assert coreInstance.db == 'test_psql_name'
 
-        # Properties set by the RabbitMQManager
-        assert coreInstance.rabbitHost == 'test_rbmq_host'
-        assert coreInstance.rabbitPort == 'test_rbmq_port'
-
         # Properties set by the RedisManager
         assert coreInstance.redisHost == 'test_redis_host'
         assert coreInstance.redisPort == 'test_redis_port'


### PR DESCRIPTION
## Description
- Removes RabbitMQManager as a CoreProcess ancestor
- Uses composition with processes that use the RabbitMQManager


## Testing
`make unit`