### PR TITLE
NO-REF: Fix and simplify classify record updates

### DIFF
--- a/processes/frbr/classify.py
+++ b/processes/frbr/classify.py
@@ -14,12 +14,10 @@ logger = createLog(__name__)
 
 
 class ClassifyProcess(CoreProcess):
-    WINDOW_SIZE = 100
-
     def __init__(self, *args):
-        super(ClassifyProcess, self).__init__(*args[:4], batchSize=50)
+        super(ClassifyProcess, self).__init__(*args[:4], batchSize=1)
 
-        self.ingestLimit = int(args[4]) if len(args) >= 5 and args[4] else None
+        self.ingest_limit = int(args[4]) if len(args) >= 5 and args[4] else None
 
         self.generateEngine()
         self.createSession()
@@ -49,11 +47,11 @@ class ClassifyProcess(CoreProcess):
             else:
                 logger.warning(f'Unknown classify process type: {self.process}')
                 return
-
+            
             self.saveRecords()
             self.commitChanges()
             
-            logger.info(f'Classified {self.classified_count} records and saved {len(self.records)} classify records')
+            logger.info(f'Classified {self.classified_count} records')
         except Exception as e:
             logger.exception(f'Failed to run classify process')
             raise e
@@ -71,29 +69,21 @@ class ClassifyProcess(CoreProcess):
             
             get_unfrbrized_records_query = get_unfrbrized_records_query.filter(Record.date_modified > start_date_time)
 
-        window_size = min(self.ingestLimit or self.WINDOW_SIZE, self.WINDOW_SIZE)
-        frbrized_records = []
+        while unfrbrized_record := get_unfrbrized_records_query.first():
+            self.frbrize_record(unfrbrized_record)
 
-        for record in self.windowedQuery(Record, get_unfrbrized_records_query, windowSize=window_size):
-            self.frbrize_record(record)
+            unfrbrized_record.cluster_status = False
+            unfrbrized_record.frbr_status = 'complete'
 
-            record.cluster_status = False
-            record.frbr_status = 'complete'
-            frbrized_records.append(record)
+            self.commitChanges()
+            self.classified_count += 1
+
+            if self.ingest_limit and self.classified_count >= self.ingest_limit:
+                break
 
             if self.redis_manager.checkIncrementerRedis('oclcCatalog', 'API'):
                 logger.warning('Exceeded max requests to OCLC catalog')
                 break
-
-            if len(frbrized_records) >= window_size:
-                self.classified_count += len(frbrized_records)
-                self.bulkSaveObjects(frbrized_records)
-                
-                frbrized_records = []
-
-        if len(frbrized_records):
-            self.classified_count += len(frbrized_records)
-            self.bulkSaveObjects(frbrized_records)
 
     def frbrize_record(self, record: Record):
         queryable_ids = self._get_queryable_identifiers(record.identifiers)

--- a/processes/frbr/classify.py
+++ b/processes/frbr/classify.py
@@ -75,7 +75,8 @@ class ClassifyProcess(CoreProcess):
             unfrbrized_record.cluster_status = False
             unfrbrized_record.frbr_status = 'complete'
 
-            self.commitChanges()
+            self.session.add(unfrbrized_record)
+            self.session.commit()
             self.classified_count += 1
 
             if self.ingest_limit and self.classified_count >= self.ingest_limit:

--- a/processes/frbr/classify.py
+++ b/processes/frbr/classify.py
@@ -15,7 +15,7 @@ logger = createLog(__name__)
 
 class ClassifyProcess(CoreProcess):
     def __init__(self, *args):
-        super(ClassifyProcess, self).__init__(*args[:4], batchSize=1)
+        super(ClassifyProcess, self).__init__(*args[:4], batchSize=50)
 
         self.ingest_limit = int(args[4]) if len(args) >= 5 and args[4] else None
 


### PR DESCRIPTION
## Description
- Switches to first query to loop through unfrbrized records
- Adds ingest limit
- Commits changes to frbrized records 1 at a time
- Saves bulk objects separately
- There was a bug with the window query returning different objects than records. During bulk save, those different objects were lacking ids and the necessary sqlalchemy decorations.  

## Testing
`make unit` `python main.py -p SeedLocalDataProcess -e local`