### PR TITLE
SFR-2327: Removing S3Manager as an Ancestor of CoreProcess

### DIFF
--- a/processes/core.py
+++ b/processes/core.py
@@ -1,4 +1,4 @@
-from managers import DBManager, S3Manager
+from managers import DBManager
 from model import Record
 
 from logger import create_log
@@ -7,7 +7,7 @@ from logger import create_log
 logger = create_log(__name__)
 
 
-class CoreProcess(DBManager, S3Manager):
+class CoreProcess(DBManager):
     def __init__(self, process, customFile, ingestPeriod, singleRecord, batchSize=500):
         super(CoreProcess, self).__init__()
         self.process = process

--- a/processes/file/covers.py
+++ b/processes/file/covers.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta, timezone
 import os
 
 from ..core import CoreProcess
-from managers import CoverManager, RedisManager
+from managers import CoverManager, RedisManager, S3Manager
 from model import Edition, Link
 from model.postgres.edition import EDITION_LINKS
 from logger import create_log
@@ -20,7 +20,8 @@ class CoverProcess(CoreProcess):
         self.redis_manager = RedisManager()
         self.redis_manager.createRedisClient()
 
-        self.createS3Client()
+        self.s3_manager = S3Manager()
+        self.s3_manager.createS3Client()
         self.fileBucket = os.environ['FILE_BUCKET']
 
         self.ingestLimit = None
@@ -87,7 +88,7 @@ class CoverProcess(CoreProcess):
             manager.coverFormat.lower()
         )
 
-        self.putObjectInBucket(manager.coverContent, coverPath, self.fileBucket)
+        self.s3_manager.putObjectInBucket(manager.coverContent, coverPath, self.fileBucket)
 
         coverLink = Link(
             url='https://{}.s3.amazonaws.com/{}'.format(self.fileBucket, coverPath),

--- a/processes/ingest/chicago_isac.py
+++ b/processes/ingest/chicago_isac.py
@@ -3,7 +3,7 @@ import os
 
 from ..core import CoreProcess
 from mappings.chicagoISAC import ChicagoISACMapping
-from managers import WebpubManifest
+from managers import S3Manager, WebpubManifest
 from logger import create_log
 
 logger = create_log(__name__)
@@ -17,7 +17,8 @@ class ChicagoISACProcess(CoreProcess):
         self.createSession()
 
         self.s3Bucket = os.environ['FILE_BUCKET']
-        self.createS3Client()
+        self.s3_manager = S3Manager()
+        self.s3_manager.createS3Client()
 
     def runProcess(self):    
         with open('ingestJSONFiles/chicagoISAC_metadata.json') as f:
@@ -56,7 +57,7 @@ class ChicagoISACProcess(CoreProcess):
 
                 manifest_json = self.generate_manifest(record, uri, manifest_url)
 
-                self.createManifestInS3(manifest_path, manifest_json)
+                self.s3_manager.createManifestInS3(manifest_path, manifest_json)
 
                 link_string = '|'.join([
                     item_no,

--- a/processes/ingest/doab.py
+++ b/processes/ingest/doab.py
@@ -9,7 +9,7 @@ from ..core import CoreProcess
 from logger import create_log
 from mappings.doab import DOABMapping
 from mappings.base_mapping import MappingError
-from managers import DOABLinkManager, RabbitMQManager
+from managers import DOABLinkManager, RabbitMQManager, S3Manager
 from model import get_file_message
 
 
@@ -35,7 +35,8 @@ class DOABProcess(CoreProcess):
         self.generateEngine()
         self.createSession()
 
-        self.createS3Client()
+        self.s3_manager = S3Manager()
+        self.s3_manager.createS3Client()
         self.s3Bucket = os.environ['FILE_BUCKET']
 
         self.fileQueue = os.environ['FILE_QUEUE']
@@ -75,7 +76,7 @@ class DOABProcess(CoreProcess):
 
         for manifest in linkManager.manifests:
             manifestPath, manifestJSON = manifest
-            self.createManifestInS3(manifestPath, manifestJSON)
+            self.s3_manager.createManifestInS3(manifestPath, manifestJSON)
 
         for epubLink in linkManager.ePubLinks:
             ePubPath, ePubURI = epubLink

--- a/processes/ingest/loc.py
+++ b/processes/ingest/loc.py
@@ -5,7 +5,7 @@ from requests.exceptions import HTTPError, ConnectionError
 from ..core import CoreProcess
 from mappings.base_mapping import MappingError
 from mappings.loc import LOCMapping
-from managers import RabbitMQManager, WebpubManifest
+from managers import RabbitMQManager, S3Manager, WebpubManifest
 from model import get_file_message
 from logger import create_log
 from datetime import datetime, timedelta, timezone
@@ -28,6 +28,8 @@ class LOCProcess(CoreProcess):
         self.generateEngine()
         self.createSession()
 
+        self.createS3Client()
+        self.s3_manager = S3Manager()
         self.createS3Client()
         self.s3Bucket = os.environ['FILE_BUCKET']
 
@@ -226,7 +228,7 @@ class LOCProcess(CoreProcess):
 
                 manifestJSON = self.generateManifest(record, uri, manifestURI)
 
-                self.createManifestInS3(manifestPath, manifestJSON)
+                self.s3_manager.createManifestInS3(manifestPath, manifestJSON)
 
                 linkString = '|'.join([
                     itemNo,

--- a/processes/ingest/met.py
+++ b/processes/ingest/met.py
@@ -7,7 +7,7 @@ from requests.exceptions import HTTPError, ConnectionError
 from ..core import CoreProcess
 from mappings.base_mapping import MappingError
 from mappings.met import METMapping
-from managers import RabbitMQManager, WebpubManifest
+from managers import RabbitMQManager, S3Manager, WebpubManifest
 from model import get_file_message
 from logger import create_log
 
@@ -42,7 +42,8 @@ class METProcess(CoreProcess):
         self.rabbitmq_manager.createOrConnectQueue(self.fileQueue, self.fileRoute)
 
         self.s3Bucket = os.environ['FILE_BUCKET']
-        self.createS3Client()
+        self.s3_manager = S3Manager()
+        self.s3_manager.createS3Client()
 
     def runProcess(self):
         self.setStartTime()
@@ -173,7 +174,7 @@ class METProcess(CoreProcess):
 
                 manifestJSON = self.generateManifest(record, uri, manifestURI)
 
-                self.createManifestInS3(manifestPath, manifestJSON)
+                self.s3_manager.createManifestInS3(manifestPath, manifestJSON)
 
                 linkString = '|'.join([
                     itemNo,

--- a/processes/ingest/muse.py
+++ b/processes/ingest/muse.py
@@ -8,7 +8,7 @@ from requests.exceptions import ReadTimeout, HTTPError
 
 from ..core import CoreProcess
 from mappings.muse import MUSEMapping
-from managers import MUSEError, MUSEManager, RabbitMQManager
+from managers import MUSEError, MUSEManager, RabbitMQManager, S3Manager
 from model import get_file_message
 from logger import create_log
 
@@ -27,7 +27,8 @@ class MUSEProcess(CoreProcess):
         self.generateEngine()
         self.createSession()
 
-        self.createS3Client()
+        self.s3_manager = S3Manager()
+        self.s3_manager.createS3Client()
 
         self.fileQueue = os.environ['FILE_QUEUE']
         self.fileRoute = os.environ['FILE_ROUTING_KEY']
@@ -70,7 +71,7 @@ class MUSEProcess(CoreProcess):
         museManager.addReadableLinks()
 
         if museManager.pdfWebpubManifest:
-            self.putObjectInBucket(
+            self.s3_manager.putObjectInBucket(
                 museManager.pdfWebpubManifest.toJson().encode('utf-8'),
                 museManager.s3PDFReadPath,
                 museManager.s3Bucket

--- a/processes/ingest/publisher_backlist.py
+++ b/processes/ingest/publisher_backlist.py
@@ -3,6 +3,7 @@ from ..util import airtable_integration
 
 from ..core import CoreProcess
 from logger import create_log
+from managers import S3Manager
 
 logger = create_log(__name__)
 
@@ -18,7 +19,7 @@ class PublisherBacklistProcess(CoreProcess):
         self.createSession()
 
         self.s3_bucket = os.environ['FILE_BUCKET']
-        self.createS3Client()
+        self.s3_manager = S3Manager()
 
     def runProcess(self):
         try:

--- a/processes/ingest/u_of_m.py
+++ b/processes/ingest/u_of_m.py
@@ -7,7 +7,7 @@ from ..core import CoreProcess
 from urllib.error import HTTPError
 from mappings.base_mapping import MappingError
 from mappings.UofM import UofMMapping
-from managers import WebpubManifest
+from managers import S3Manager, WebpubManifest
 from logger import create_log
 
 logger = create_log(__name__)
@@ -25,7 +25,8 @@ class UofMProcess(CoreProcess):
         self.createSession()
 
         self.s3Bucket = os.environ['FILE_BUCKET']
-        self.createS3Client()
+        self.s3_manager = S3Manager()
+        self.s3_manager.createS3Client()
 
     def runProcess(self):
         with open('ingestJSONFiles/UofM_Updated_CSV.json') as f:
@@ -57,7 +58,7 @@ class UofMProcess(CoreProcess):
 
         try:
             #The get_object method is to make sure the object with a specific bucket and key exists in S3
-            self.s3Client.get_object(Bucket=bucket, 
+            self.s3_manager.s3Client.get_object(Bucket=bucket, 
                                     Key=f'{resultsRecord["File ID 1"]}_060pct.pdf')
             key = f'{resultsRecord["File ID 1"]}_060pct.pdf'
             urlPDFObject = f'https://{bucket}.s3.amazonaws.com/{key}'
@@ -91,7 +92,7 @@ class UofMProcess(CoreProcess):
         if not record.has_part:
             try:
                 #The get_object method is to make sure the object with a specific bucket and key exists in S3
-                self.s3Client.get_object(Bucket= 'ump-pdf-repository', 
+                self.s3_manager.s3Client.get_object(Bucket= 'ump-pdf-repository', 
                                         Key= f'{resultsRecord["File ID 1"]}_100pct.pdf')
                 key = f'{resultsRecord["File ID 1"]}_100pct.pdf'
                 urlPDFObject = f'https://{bucket}.s3.amazonaws.com/{key}'
@@ -138,7 +139,7 @@ class UofMProcess(CoreProcess):
 
                 manifestJSON = self.generateManifest(record, uri, manifestURI)
 
-                self.createManifestInS3(manifestPath, manifestJSON)
+                self.s3_manager.createManifestInS3(manifestPath, manifestJSON)
 
                 if 'in_copyright' in record.rights:
                     linkString = '|'.join([

--- a/processes/ingest/u_of_sc.py
+++ b/processes/ingest/u_of_sc.py
@@ -5,7 +5,7 @@ from requests.exceptions import HTTPError, ConnectionError
 from ..core import CoreProcess
 from mappings.base_mapping import MappingError
 from mappings.UofSC import UofSCMapping
-from managers import WebpubManifest
+from managers import S3Manager, WebpubManifest
 from logger import create_log
 
 logger = create_log(__name__)
@@ -23,7 +23,8 @@ class UofSCProcess(CoreProcess):
         self.createSession()
 
         self.s3Bucket = os.environ['FILE_BUCKET']
-        self.createS3Client()
+        self.s3_manager = S3Manager()
+        self.s3_manager.createS3Client()
 
     def runProcess(self):
         with open('UofSC_metadata.json') as f:
@@ -61,7 +62,7 @@ class UofSCProcess(CoreProcess):
 
                 manifestJSON = self.generateManifest(record, uri, manifestURI)
 
-                self.createManifestInS3(manifestPath, manifestJSON)
+                self.s3_manager.createManifestInS3(manifestPath, manifestJSON)
 
                 linkString = '|'.join([
                     itemNo,

--- a/tests/unit/processes/file/test_cover_process.py
+++ b/tests/unit/processes/file/test_cover_process.py
@@ -15,6 +15,7 @@ class TestCoverProcess:
                 self.batchSize = 3
                 self.runTime = datetime(1900, 1, 1)
                 self.redis_manager = mocker.MagicMock()
+                self.s3_manager = mocker.MagicMock(s3Client=mocker.MagicMock())
 
         return TestCoverProcess()
 
@@ -182,7 +183,6 @@ class TestCoverProcess:
         ])
 
     def test_storeFoundCover(self, testProcess, mocker):
-        mockPut = mocker.patch.object(CoverProcess, 'putObjectInBucket')
         mockSave = mocker.patch.object(CoverProcess, 'bulkSaveObjects')
 
         mockFetcher = mocker.MagicMock(SOURCE='test', coverID=1)
@@ -197,4 +197,4 @@ class TestCoverProcess:
         assert mockEdition.links[0].media_type == 'image/tst'
         assert mockEdition.links[0].flags == {'cover': True}
         assert mockSave.call_args[0][0] == set(['ed1', 'ed2', mockEdition])
-        mockPut.assert_called_once_with('testBytes', 'covers/test/1.tst', 'test_aws_bucket')
+        testProcess.s3_manager.putObjectInBucket.assert_called_once_with('testBytes', 'covers/test/1.tst', 'test_aws_bucket')

--- a/tests/unit/processes/file/test_fulfill_manifest_process.py
+++ b/tests/unit/processes/file/test_fulfill_manifest_process.py
@@ -17,7 +17,7 @@ class TestUofMProcess:
         class TestFulfill(FulfillURLManifestProcess):
             def __init__(self):
                 self.s3Bucket = 'test_aws_bucket'
-                self.s3Client = mocker.MagicMock(s3Client='testS3Client')
+                self.s3_manager = mocker.MagicMock(s3Client=mocker.MagicMock())
                 self.session = mocker.MagicMock(session='testSession')
                 self.records = mocker.MagicMock(record='testRecord')
                 self.batchSize = mocker.MagicMock(batchSize='testBatchSize')
@@ -41,14 +41,11 @@ class TestUofMProcess:
 
 
     def test_fetch_and_update_manifests(self, test_process, mocker):
-        process_mocks = mocker.patch.multiple(FulfillURLManifestProcess,
-            load_batches=mocker.DEFAULT,
-            update_metadata_object=mocker.DEFAULT
-        )
+        mocker.patch.multiple(FulfillURLManifestProcess, update_metadata_object=mocker.DEFAULT)
 
         mock_timestamp = mocker.MagicMock(time_stamp='test_timestamp')
         
         test_process.fetch_and_update_manifests(mock_timestamp)
 
-        process_mocks['load_batches'].assert_called_once_with('testPrefix','test_aws_bucket')
+        test_process.s3_manager.load_batches.assert_called_once_with('testPrefix','test_aws_bucket')
         

--- a/tests/unit/processes/ingest/test_chicago_isac_process.py
+++ b/tests/unit/processes/ingest/test_chicago_isac_process.py
@@ -18,7 +18,7 @@ class TestChicagoISACProcess:
         class TestISAC(ChicagoISACProcess):
             def __init__(self):
                 self.s3Bucket = 'test_aws_bucket'
-                self.s3_client = mocker.MagicMock(s3_client='test_s3_client')
+                self.s3_manager = mocker.MagicMock(s3Client=mocker.MagicMock())
                 self.session = mocker.MagicMock(session='test_session')
                 self.records = mocker.MagicMock(record='test_record')
                 self.batch_size = mocker.MagicMock(batch_size='test_batch_size')
@@ -71,7 +71,6 @@ class TestChicagoISACProcess:
 
         mock_generate_man = mocker.patch.object(ChicagoISACProcess, 'generate_manifest')
         mock_generate_man.return_value = 'test_json'
-        mock_create_man = mocker.patch.object(ChicagoISACProcess, 'createManifestInS3')
 
         test_process.store_pdf_manifest(mock_record)
 
@@ -79,7 +78,7 @@ class TestChicagoISACProcess:
         assert mock_record.has_part[0] == '1|{}|isac|application/webpub+json|{{}}'.format(test_manifest_url)
 
         mock_generate_man.assert_called_once_with(mock_record, 'test_url', test_manifest_url)
-        mock_create_man.assert_called_once_with('manifests/isac/1.json', 'test_json')
+        test_process.s3_manager.createManifestInS3.assert_called_once_with('manifests/isac/1.json', 'test_json')
 
     def test_generate_manifest(self, mocker):
         mock_manifest = mocker.MagicMock(links=[])

--- a/tests/unit/processes/ingest/test_met_process.py
+++ b/tests/unit/processes/ingest/test_met_process.py
@@ -20,6 +20,7 @@ class TestMetProcess:
     def testProcess(self, mocker):
         class TestMET(METProcess):
             def __init__(self):
+                self.s3_manager = mocker.MagicMock(s3Client=mocker.MagicMock())
                 self.s3Bucket = 'test_aws_bucket'
                 self.fileQueue = 'test_file_queue'
                 self.fileRoute = 'test_file_key'
@@ -184,7 +185,6 @@ class TestMetProcess:
 
         mockGenerateMan = mocker.patch.object(METProcess, 'generateManifest')
         mockGenerateMan.return_value = 'testJSON'
-        mockCreateMan = mocker.patch.object(METProcess, 'createManifestInS3')
 
         testProcess.storePDFManifest(mockRecord)
 
@@ -192,14 +192,7 @@ class TestMetProcess:
         assert mockRecord.has_part[0] == '1|{}|met|application/webpub+json|{{}}'.format(testManifestURI)
 
         mockGenerateMan.assert_called_once_with(mockRecord, 'testURI', testManifestURI)
-        mockCreateMan.assert_called_once_with('manifests/met/1.json', 'testJSON')
-
-    def test_createManifestInS3(self, testProcess, mocker):
-        mockPut = mocker.patch.object(METProcess, 'putObjectInBucket')
-        
-        testProcess.createManifestInS3('testPath', '{"data": "testJSON"}')
-
-        mockPut.assert_called_once_with(b'{"data": "testJSON"}', 'testPath', 'test_aws_bucket')
+        testProcess.s3_manager.createManifestInS3.assert_called_once_with('manifests/met/1.json', 'testJSON')
 
     def test_generateManifest(self, mocker):
         mockManifest = mocker.MagicMock(links=[])

--- a/tests/unit/processes/ingest/test_muse_process.py
+++ b/tests/unit/processes/ingest/test_muse_process.py
@@ -23,6 +23,7 @@ class TestMUSEProcess:
         class TestMUSE(MUSEProcess):
             def __init__(self):
                 self.s3Bucket = 'test_aws_bucket'
+                self.s3_manager = mocker.MagicMock(s3Client=mocker.MagicMock())
                 self.records = []
                 self.ingest_limit = None
                 self.fileQueue = 'fileQueue'
@@ -258,11 +259,7 @@ class TestMUSEProcess:
         mockManagerInit = mocker.patch('processes.ingest.muse.MUSEManager')
         mockManagerInit.return_value = mockManager
 
-        processMocks = mocker.patch.multiple(
-            MUSEProcess,
-            putObjectInBucket=mocker.DEFAULT,
-            addDCDWToUpdateList=mocker.DEFAULT
-        )
+        processMocks = mocker.patch.multiple(MUSEProcess, addDCDWToUpdateList=mocker.DEFAULT)
 
         testProcess.parseMuseRecord('testMARC')
 
@@ -273,7 +270,7 @@ class TestMUSEProcess:
         mockManager.identifyReadableVersions.assert_called_once()
         mockManager.addReadableLinks.assert_called_once()
 
-        processMocks['putObjectInBucket'].assert_called_once_with(
+        testProcess.s3_manager.putObjectInBucket.assert_called_once_with(
             b'testManifest', 'testPDFPath', 'testBucket'
         )
         testProcess.rabbitmq_manager.sendMessageToQueue.assert_called_once_with(

--- a/tests/unit/processes/ingest/test_u_of_m_process.py
+++ b/tests/unit/processes/ingest/test_u_of_m_process.py
@@ -18,7 +18,7 @@ class TestUofMProcess:
         class TestUofM(UofMProcess):
             def __init__(self):
                 self.s3Bucket = 'test_aws_bucket'
-                self.s3Client = mocker.MagicMock(s3Client='testS3Client')
+                self.s3_manager = mocker.MagicMock(s3Client=mocker.MagicMock())
                 self.session = mocker.MagicMock(session='testSession')
                 self.records = mocker.MagicMock(record='testRecord')
                 self.batchSize = mocker.MagicMock(batchSize='testBatchSize')
@@ -82,13 +82,6 @@ class TestUofMProcess:
 
     #     mockGenerateMan.assert_called_once_with(mockRecord, 'testURI', testManifestURI)
     #     mockCreateMan.assert_called_once_with('manifests/UofM/1.json', 'testJSON')
-
-    def test_createManifestInS3(self, testProcess, mocker):
-        mockPut = mocker.patch.object(UofMProcess, 'putObjectInBucket')
-        
-        testProcess.createManifestInS3('testPath', '{"data": "testJSON"}')
-
-        mockPut.assert_called_once_with(b'{"data": "testJSON"}', 'testPath', 'test_aws_bucket')
 
     def test_generateManifest(self, mocker):
         mockManifest = mocker.MagicMock(links=[])


### PR DESCRIPTION
## Description
- Removes S3Manager as a CoreProcess ancestor
- Uses composition with the classes that need the S3Manager
- Removes unnecessary tests

## Testing
`make unit`