### PR TITLE
SFR-2344: Set New Relic Log Level to Warning

### DIFF
--- a/newrelic.ini
+++ b/newrelic.ini
@@ -65,7 +65,7 @@ log_file = stdout
 # of information very quickly, so it is best not to keep the
 # agent at this level for longer than it takes to reproduce the
 # problem you are experiencing.
-log_level = debug
+log_level = warning
 
 # High Security Mode enforces certain security settings, and prevents
 # them from being overridden, so that no sensitive data is sent to New


### PR DESCRIPTION
## Description
- We get an incredible amount of debug and info logs from New Relic agent
- We don't care about these logs
- Setting the log level to warning accordingly 

