### PR TITLE
SFR-2342: Deploy to both CF and TF ECS Clusters in QA

### DIFF
--- a/.github/workflows/build-qa.yaml
+++ b/.github/workflows/build-qa.yaml
@@ -36,3 +36,7 @@ jobs:
       - name: Force ECS Update
         run: |
           aws ecs update-service --cluster sfr-pipeline-qa --service sfr-pipeline-qa --force-new-deployment
+
+      - name: Force ECS TF Update
+        run: |
+          aws ecs update-service --cluster sfr-pipeline-qa-tf --service sfr-pipeline-qa-tf --force-new-deployment


### PR DESCRIPTION
## Description
- Deploys to both the CF and TF ECS Clusters in QA
- Once we are confident everything looks good in the TF ECS Cluster, we will stop deploying to the TF ECS Cluster. 