### PR TITLE
SFR-2347: Improve IA readability check exception logging

### DIFF
--- a/mappings/oclcCatalog.py
+++ b/mappings/oclcCatalog.py
@@ -212,9 +212,8 @@ class CatalogMapping(XMLMapping):
         try:
             metadataResp = requests.get(metadataURL, timeout=5)
             metadataResp.raise_for_status()
-        except (ReadTimeout, HTTPError) as e:
-            logger.debug('Unable to read InternetArchive link')
-            logger.error(e)
+        except (ReadTimeout, HTTPError):
+            logger.exception(f'Failed to check Internet Archive readability for {iaURL}')
             return False
 
         iaData = metadataResp.json()


### PR DESCRIPTION
## Description
- Changes the error message when we fail to check the Internet Archive readability for a specific catalog record.