### PR TITLE
SFR-2349: Increasing CSV Field Size Limit

### DIFF
--- a/processes/ingest/hathi_trust.py
+++ b/processes/ingest/hathi_trust.py
@@ -5,6 +5,7 @@ import gzip
 import os
 import requests
 from requests.exceptions import ReadTimeout, HTTPError
+import sys
 
 from constants.get_constants import get_constants
 from ..core import CoreProcess
@@ -106,6 +107,8 @@ class HathiTrustProcess(CoreProcess):
             self.readHathiFile(hathi_tsv, start_date_time)
 
     def readHathiFile(self, hathi_tsv, start_date_time=None):
+        csv.field_size_limit(sys.maxsize)
+
         for number_of_books_ingested, book in enumerate(hathi_tsv):
             if self.ingest_limit and number_of_books_ingested > self.ingest_limit:
                 break
@@ -114,7 +117,10 @@ class HathiTrustProcess(CoreProcess):
             book_date_updated = (len(book) > 14 and book[14]) or None
 
             if book_date_updated:
-                hathi_date_modified = datetime.strptime(book_date_updated, '%Y-%m-%d %H:%M:%S').replace(tzinfo=None)
+                try:
+                    hathi_date_modified = datetime.strptime(book_date_updated, '%Y-%m-%d %H:%M:%S').replace(tzinfo=None)
+                except Exception: 
+                    hathi_date_modified = None
 
             if book_right and book_right not in self.HATHI_RIGHTS_SKIPS:
                 if not start_date_time or hathi_date_modified >= start_date_time:

--- a/processes/ingest/hathi_trust.py
+++ b/processes/ingest/hathi_trust.py
@@ -5,7 +5,6 @@ import gzip
 import os
 import requests
 from requests.exceptions import ReadTimeout, HTTPError
-import sys
 
 from constants.get_constants import get_constants
 from ..core import CoreProcess

--- a/processes/ingest/hathi_trust.py
+++ b/processes/ingest/hathi_trust.py
@@ -16,6 +16,7 @@ logger = create_log(__name__)
 
 class HathiTrustProcess(CoreProcess):
     HATHI_RIGHTS_SKIPS = ['ic', 'icus', 'ic-world', 'und']
+    FIELD_SIZE_LIMIT = 131072 * 2 # 131072 is the default size limit
 
     def __init__(self, *args):
         super(HathiTrustProcess, self).__init__(*args[:4], batchSize=1000)
@@ -107,7 +108,7 @@ class HathiTrustProcess(CoreProcess):
             self.readHathiFile(hathi_tsv, start_date_time)
 
     def readHathiFile(self, hathi_tsv, start_date_time=None):
-        csv.field_size_limit(sys.maxsize)
+        csv.field_size_limit(self.FIELD_SIZE_LIMIT)
 
         for number_of_books_ingested, book in enumerate(hathi_tsv):
             if self.ingest_limit and number_of_books_ingested > self.ingest_limit:


### PR DESCRIPTION
## Description
- There was an error this morning where a CSV field was too large
- This change increases the field size limit to the max size of the system
- Also if we are unable to parse a date, we just set it to None and ignore it

## Testing
`python main.py -p HathiTrustProcess -e local -i daily`