### PR TITLE
SFR-2346: Fix edition verion unpacking

### DIFF
--- a/managers/sfrRecord.py
+++ b/managers/sfrRecord.py
@@ -391,7 +391,7 @@ class SFRRecordManager:
 
         # Set Edition Data
         if len(edition['edition_data']):
-            editionStmt, editionNo = tuple(edition['edition_data'].most_common(1)[0][0].split('|'))
+            editionStmt, editionNo, *_ = tuple(edition['edition_data'].most_common(1)[0][0].split('|'))
             newEd.edition_statement = editionStmt
             try:
                 newEd.edition = int(editionNo)


### PR DESCRIPTION
## Description
- Some NYPL records have some different has_version columns, e.g. `2d ed.||2|2`
- These versions were causing issues while unpacking the edition statement and number
- Updated the code to handle these cases

## Testing
`python main.py -p ClusterProcess -e local-qa -i daily`