### PR TITLE
SFR-2308_PubBacklistMapping

### DIFF
--- a/mappings/publisher_backlist.py
+++ b/mappings/publisher_backlist.py
@@ -22,12 +22,10 @@ class PublisherBacklistMapping(JSONMapping):
             'publisher_project_source': ('Publisher (from Projects)', '{0}')
         }
 
-    def apply_formatting(self):
+    def applyFormatting(self):
         self.record.has_part = []
-
         if self.record.source:
             source_list = self.record.source.split(' ')
-            print(source_list)
             self.record.source = source_list[0]
 
         if self.record.publisher_project_source:

--- a/mappings/publisher_backlist.py
+++ b/mappings/publisher_backlist.py
@@ -18,14 +18,15 @@ class PublisherBacklistMapping(JSONMapping):
             'rights': ('DRB Rights Classification', '{0}||||'),
             'contributors': [('Contributors', '{0}|||contributor')],
             'subjects': ('Subject 1', '{0}'),
-            'source': ('Projects', '{0}'),
+            'source': ('Project Name (from Projects)', '{0}'),
+            'source_id': ('DRB Record_ID', '{0}'),
             'publisher_project_source': ('Publisher (from Projects)', '{0}')
         }
 
     def applyFormatting(self):
         self.record.has_part = []
         if self.record.source:
-            source_list = self.record.source.split(' ')
+            source_list = self.record.source[0].split(' ')
             self.record.source = source_list[0]
 
         if self.record.publisher_project_source:
@@ -39,65 +40,58 @@ class PublisherBacklistMapping(JSONMapping):
             self.record.subjects = self.format_subjects()
 
         if self.record.identifiers:
-            if len(self.record.identifiers) == 1:
-                source_id = self.record.identifiers[0].split('|')[0]
-                self.record.source_id = f'{self.record.source}_{source_id}'
-                self.record.identifiers = self.format_identifiers()
-            else:
-                source_id = self.record.identifiers[1].split('|')[0]
-                self.record.source_id = f'{self.record.source}_{source_id}'
-                self.record.identifiers = self.format_identifiers()
+            self.record.identifiers = self.format_identifiers()
 
         self.record.rights = self.format_rights()
 
     def format_authors(self):
-        authorList = []
+        author_list = []
 
         if ';' in self.record.authors:
-            authorList = self.record.authors.split('; ')
-            newAuthorList = [f'{author}|||true' for author in authorList] 
-            return newAuthorList
+            author_list = self.record.authors.split('; ')
+            new_author_list = [f'{author}|||true' for author in author_list] 
+            return new_author_list
         else:
-            authorList.append(f'{self.record.authors}|||true)')
-            return authorList
+            author_list.append(f'{self.record.authors}|||true)')
+            return author_list
         
         
     def format_identifiers(self):
         if 'isbn' in self.record.identifiers[0]:
-            isbnString = self.record.identifiers[0].split('|')[0]
-            if ';' in isbnString:
-                isbnList = isbnString.split('; ')
-                newISBNList = [f'{isbn}|isbn' for isbn in isbnList]
+            isbn_string = self.record.identifiers[0].split('|')[0]
+            if ';' in isbn_string:
+                isbnList = isbn_string.split('; ')
+                new_isbn_list = [f'{isbn}|isbn' for isbn in isbnList]
                 if len(self.record.identifiers) > 1 and 'oclc' in self.record.identifiers[1]:
-                    newISBNList.append(f'{self.record.identifiers[1]}')
-                    return newISBNList
+                    new_isbn_list.append(f'{self.record.identifiers[1]}')
+                    return new_isbn_list
                 else:
-                    return newISBNList
+                    return new_isbn_list
                 
         return self.record.identifiers
     
     def format_subjects(self):
-        subjectList = []
+        subject_list = []
 
         if '|' in self.record.subjects:
-            subjectList = self.record.subjects.split('|')
-            newSubjectList = [f'{subject}||' for subject in subjectList] 
-            return newSubjectList
+            subject_list = self.record.subjects.split('|')
+            new_subject_list = [f'{subject}||' for subject in subject_list] 
+            return new_subject_list
         else:
-            subjectList.append(f'{self.record.subjects}||')
-            return subjectList
+            subject_list.append(f'{self.record.subjects}||')
+            return subject_list
     
     def format_rights(self):
         if not self.record.rights: 
             return None
 
-        rightsElements = self.record.rights.split('|')
-        rightsStatus = rightsElements[0]
+        rights_elements = self.record.rights.split('|')
+        rights_status = rights_elements[0]
 
-        if rightsStatus == 'in copyright':
+        if rights_status == 'in copyright':
             return '{}|{}||{}|'.format('self.record.source', 'in_copyright', 'In Copyright') 
         
-        if rightsStatus == 'public domain':
+        if rights_status == 'public domain':
             return '{}|{}||{}|'.format('self.record.source', 'public_domain', 'Public Domain') 
         
         return None

--- a/mappings/publisher_backlist.py
+++ b/mappings/publisher_backlist.py
@@ -60,13 +60,13 @@ class PublisherBacklistMapping(JSONMapping):
         if 'isbn' in self.record.identifiers[0]:
             isbn_string = self.record.identifiers[0].split('|')[0]
             if ';' in isbn_string:
-                isbnList = isbn_string.split('; ')
-                new_isbn_list = [f'{isbn}|isbn' for isbn in isbnList]
+                isbns = isbn_string.split('; ')
+                formatted_isbns = [f'{isbn}|isbn' for isbn in isbns]
                 if len(self.record.identifiers) > 1 and 'oclc' in self.record.identifiers[1]:
-                    new_isbn_list.append(f'{self.record.identifiers[1]}')
-                    return new_isbn_list
+                    formatted_isbns.append(f'{self.record.identifiers[1]}')
+                    return formatted_isbns
                 else:
-                    return new_isbn_list
+                    return formatted_isbns
                 
         return self.record.identifiers
     
@@ -75,8 +75,7 @@ class PublisherBacklistMapping(JSONMapping):
 
         if '|' in self.record.subjects:
             subject_list = self.record.subjects.split('|')
-            new_subject_list = [f'{subject}||' for subject in subject_list] 
-            return new_subject_list
+            return [f'{subject}||' for subject in subject_list]
         else:
             subject_list.append(f'{self.record.subjects}||')
             return subject_list

--- a/mappings/publisher_backlist.py
+++ b/mappings/publisher_backlist.py
@@ -1,10 +1,9 @@
 from .json import JSONMapping
 
-
-class UofMMapping(JSONMapping):
+class PublisherBacklistMapping(JSONMapping):
     def __init__(self, source):
         super().__init__(source, {})
-        self.mapping = self.createMapping() 
+        self.mapping = self.createMapping()
 
     def createMapping(self):
         return {
@@ -19,33 +18,41 @@ class UofMMapping(JSONMapping):
             'rights': ('DRB Rights Classification', '{0}||||'),
             'contributors': [('Contributors', '{0}|||contributor')],
             'subjects': ('Subject 1', '{0}'),
+            'source': ('Projects', '{0}'),
+            'publisher_project_source': ('Publisher (from Projects)', '{0}')
         }
 
-    def applyFormatting(self):
+    def apply_formatting(self):
         self.record.has_part = []
-        self.record.spatial = 'Michigan'
-        self.record.source = 'UofM'
-        self.record.publisher_project_source = 'UofMichigan Press'
+
+        if self.record.source:
+            source_list = self.record.source.split(' ')
+            print(source_list)
+            self.record.source = source_list[0]
+
+        if self.record.publisher_project_source:
+            publisher_source = self.record.publisher_project_source[0]
+            self.record.publisher_project_source = publisher_source
 
         if self.record.authors:
-            self.record.authors = self.formatAuthors()
+            self.record.authors = self.format_authors()
 
         if self.record.subjects:
-            self.record.subjects = self.formatSubjects()
+            self.record.subjects = self.format_subjects()
 
         if self.record.identifiers:
             if len(self.record.identifiers) == 1:
                 source_id = self.record.identifiers[0].split('|')[0]
-                self.record.source_id = f'UofM_{source_id}'
-                self.record.identifiers = self.formatIdentifiers()
+                self.record.source_id = f'{self.record.source}_{source_id}'
+                self.record.identifiers = self.format_identifiers()
             else:
                 source_id = self.record.identifiers[1].split('|')[0]
-                self.record.source_id = f'UofM_{source_id}'
-                self.record.identifiers = self.formatIdentifiers()
+                self.record.source_id = f'{self.record.source}_{source_id}'
+                self.record.identifiers = self.format_identifiers()
 
-        self.record.rights = self.formatRights()
+        self.record.rights = self.format_rights()
 
-    def formatAuthors(self):
+    def format_authors(self):
         authorList = []
 
         if ';' in self.record.authors:
@@ -57,7 +64,7 @@ class UofMMapping(JSONMapping):
             return authorList
         
         
-    def formatIdentifiers(self):
+    def format_identifiers(self):
         if 'isbn' in self.record.identifiers[0]:
             isbnString = self.record.identifiers[0].split('|')[0]
             if ';' in isbnString:
@@ -71,7 +78,7 @@ class UofMMapping(JSONMapping):
                 
         return self.record.identifiers
     
-    def formatSubjects(self):
+    def format_subjects(self):
         subjectList = []
 
         if '|' in self.record.subjects:
@@ -82,7 +89,7 @@ class UofMMapping(JSONMapping):
             subjectList.append(f'{self.record.subjects}||')
             return subjectList
     
-    def formatRights(self):
+    def format_rights(self):
         if not self.record.rights: 
             return None
 
@@ -90,9 +97,9 @@ class UofMMapping(JSONMapping):
         rightsStatus = rightsElements[0]
 
         if rightsStatus == 'in copyright':
-            return 'UofM|{}||{}|'.format('in_copyright', 'In Copyright') 
+            return '{}|{}||{}|'.format('self.record.source', 'in_copyright', 'In Copyright') 
         
         if rightsStatus == 'public domain':
-            return 'UofM|{}||{}|'.format('public_domain', 'Public Domain') 
+            return '{}|{}||{}|'.format('self.record.source', 'public_domain', 'Public Domain') 
         
         return None

--- a/processes/ingest/publisher_backlist.py
+++ b/processes/ingest/publisher_backlist.py
@@ -33,7 +33,6 @@ class PublisherBacklistProcess(CoreProcess):
             else: 
                 logger.warning(f'Unknown Publisher Backlist ingestion process type {self.process}')
                 return
-            raise Exception
             for record in records:
                 self.addDCDWToUpdateList(record)
             

--- a/processes/ingest/publisher_backlist.py
+++ b/processes/ingest/publisher_backlist.py
@@ -33,7 +33,7 @@ class PublisherBacklistProcess(CoreProcess):
             else: 
                 logger.warning(f'Unknown Publisher Backlist ingestion process type {self.process}')
                 return
-        
+            raise Exception
             for record in records:
                 self.addDCDWToUpdateList(record)
             

--- a/services/sources/publisher_backlist_service.py
+++ b/services/sources/publisher_backlist_service.py
@@ -29,7 +29,7 @@ class PublisherBacklistService(SourceService):
         for json_dict in array_json_records:
             for records_value in json_dict['records']:
                 try:
-                    record_metadata_dict = records_value
+                    record_metadata_dict = records_value['fields']
                     record = PublisherBacklistMapping(record_metadata_dict)
                     record.applyMapping()
                 except Exception:

--- a/services/sources/publisher_backlist_service.py
+++ b/services/sources/publisher_backlist_service.py
@@ -96,4 +96,5 @@ class PublisherBacklistService(SourceService):
             pub_backlist_records_response_json = pub_backlist_records_response.json()
             array_json.append(pub_backlist_records_response_json)
 
+        print(len(array_json))
         return array_json

--- a/services/sources/publisher_backlist_service.py
+++ b/services/sources/publisher_backlist_service.py
@@ -89,12 +89,10 @@ class PublisherBacklistService(SourceService):
         pub_backlist_records_response = requests.get(url, headers=headers)
         pub_backlist_records_response_json = pub_backlist_records_response.json()
         array_json = [pub_backlist_records_response_json]
-        
         while 'offset' in pub_backlist_records_response_json:
             next_page_url = url + f"&offset={pub_backlist_records_response_json['offset']}"
             pub_backlist_records_response = requests.get(next_page_url, headers=headers)
             pub_backlist_records_response_json = pub_backlist_records_response.json()
             array_json.append(pub_backlist_records_response_json)
 
-        print(len(array_json))
         return array_json

--- a/services/sources/publisher_backlist_service.py
+++ b/services/sources/publisher_backlist_service.py
@@ -3,10 +3,10 @@ import os
 import requests
 import json
 import urllib.parse
-from typing import Optional, Dict
+from typing import Optional
 
 from logger import create_log
-from mappings.UofM import UofMMapping
+from mappings.publisher_backlist import PublisherBacklistMapping
 from .source_service import SourceService
 
 logger = create_log(__name__)
@@ -23,14 +23,14 @@ class PublisherBacklistService(SourceService):
         start_timestamp: datetime=None,
         offset: Optional[int]=None,
         limit: Optional[int]=None
-    ) -> list[UofMMapping]:
+    ) -> list[PublisherBacklistMapping]:
         array_json_records = self.get_records_json(full_import, start_timestamp, offset, limit)
 
         for json_dict in array_json_records:
             for records_value in json_dict['records']:
                 try:
                     record_metadata_dict = records_value
-                    record = UofMMapping(record_metadata_dict)
+                    record = PublisherBacklistMapping(record_metadata_dict)
                     record.applyMapping()
                 except Exception:
                     logger.exception(f'Failed to process Publisher Backlist record')

--- a/tests/unit/processes/test_pub_backlist_mapping.py
+++ b/tests/unit/processes/test_pub_backlist_mapping.py
@@ -1,0 +1,51 @@
+import pytest
+
+from mappings.publisher_backlist import PublisherBacklistMapping
+
+class TestPublisherBacklistMapping:
+    @pytest.fixture
+    def testMapping(self):
+        class TestPublisherBacklistMapping(PublisherBacklistMapping):
+            def __init__(self):
+                self.mapping = None
+
+        return TestPublisherBacklistMapping()
+
+    @pytest.fixture
+    def testRecordStandard(self, mocker):
+        return mocker.MagicMock(
+            title='testTitle',
+            authors=['testAuthor|||true'],
+            dates=['testDate|publication_date'],
+            publisher=['testPublisher||'],
+            identifiers=['testISBN|isbn', 'testOCLC|oclc'],
+            rights='in copyright||||',
+            contributor=['testContributor|||contributor'],
+            subjects='testSubject',
+            source='UofM Press',
+            publisher_project_source=['University of Michigan']
+        )
+
+    def test_createMapping(self, testMapping):
+        recordMapping = testMapping.createMapping()
+
+        assert list(recordMapping.keys()) == [
+            'title', 'authors', 'dates', 'publisher',
+            'identifiers', 'rights', 'contributors', 'subjects',
+            'source', 'publisher_project_source'
+        ]
+        assert recordMapping['title'] == ('Title', '{0}')
+
+    def test_apply_formatting_standard(self, testMapping, testRecordStandard):
+        testMapping.record = testRecordStandard
+
+        testMapping.apply_formatting()
+
+        assert testMapping.record.has_part == []
+        assert testMapping.record.source == 'UofM'
+        assert testMapping.record.identifiers == ['testISBN|isbn', 'testOCLC|oclc']
+        assert testMapping.record.source_id == 'UofM_testOCLC'
+        assert testMapping.record.publisher == ['testPublisher||']
+        assert testMapping.record.source == 'UofM'
+        assert testMapping.record.publisher_project_source == 'University of Michigan'
+        assert testMapping.record.subjects == ['testSubject||']

--- a/tests/unit/test_pub_backlist_mapping.py
+++ b/tests/unit/test_pub_backlist_mapping.py
@@ -4,7 +4,7 @@ from mappings.publisher_backlist import PublisherBacklistMapping
 
 class TestPublisherBacklistMapping:
     @pytest.fixture
-    def testMapping(self):
+    def test_mapping(self):
         class TestPublisherBacklistMapping(PublisherBacklistMapping):
             def __init__(self):
                 self.mapping = None
@@ -27,25 +27,25 @@ class TestPublisherBacklistMapping:
             publisher_project_source=['University of Michigan Press']
         )
 
-    def test_createMapping(self, testMapping):
-        recordMapping = testMapping.createMapping()
+    def test_createMapping(self, test_mapping):
+        record_mapping = test_mapping.createMapping()
 
-        assert list(recordMapping.keys()) == [
+        assert list(record_mapping.keys()) == [
             'title', 'authors', 'dates', 'publisher',
             'identifiers', 'rights', 'contributors', 'subjects',
             'source', 'source_id', 'publisher_project_source'
         ]
-        assert recordMapping['title'] == ('Title', '{0}')
+        assert record_mapping['title'] == ('Title', '{0}')
 
-    def test_applyFormatting_standard(self, testMapping, testRecordStandard):
-        testMapping.record = testRecordStandard
+    def test_applyFormatting_standard(self, test_mapping, testRecordStandard):
+        test_mapping.record = testRecordStandard
 
-        testMapping.applyFormatting()
+        test_mapping.applyFormatting()
 
-        assert testMapping.record.has_part == []
-        assert testMapping.record.source == 'UofMichigan'
-        assert testMapping.record.identifiers == ['testISBN|isbn', 'testOCLC|oclc']
-        assert testMapping.record.source_id == 'testSourceID'
-        assert testMapping.record.publisher == ['testPublisher||']
-        assert testMapping.record.publisher_project_source == 'University of Michigan Press'
-        assert testMapping.record.subjects == ['testSubject||']
+        assert test_mapping.record.has_part == []
+        assert test_mapping.record.source == 'UofMichigan'
+        assert test_mapping.record.identifiers == ['testISBN|isbn', 'testOCLC|oclc']
+        assert test_mapping.record.source_id == 'testSourceID'
+        assert test_mapping.record.publisher == ['testPublisher||']
+        assert test_mapping.record.publisher_project_source == 'University of Michigan Press'
+        assert test_mapping.record.subjects == ['testSubject||']

--- a/tests/unit/test_pub_backlist_mapping.py
+++ b/tests/unit/test_pub_backlist_mapping.py
@@ -36,10 +36,10 @@ class TestPublisherBacklistMapping:
         ]
         assert recordMapping['title'] == ('Title', '{0}')
 
-    def test_apply_formatting_standard(self, testMapping, testRecordStandard):
+    def test_applyFormatting_standard(self, testMapping, testRecordStandard):
         testMapping.record = testRecordStandard
 
-        testMapping.apply_formatting()
+        testMapping.applyFormatting()
 
         assert testMapping.record.has_part == []
         assert testMapping.record.source == 'UofM'

--- a/tests/unit/test_pub_backlist_mapping.py
+++ b/tests/unit/test_pub_backlist_mapping.py
@@ -22,8 +22,9 @@ class TestPublisherBacklistMapping:
             rights='in copyright||||',
             contributor=['testContributor|||contributor'],
             subjects='testSubject',
-            source='UofM Press',
-            publisher_project_source=['University of Michigan']
+            source=['UofMichigan Backlist'],
+            source_id='testSourceID',
+            publisher_project_source=['University of Michigan Press']
         )
 
     def test_createMapping(self, testMapping):
@@ -32,7 +33,7 @@ class TestPublisherBacklistMapping:
         assert list(recordMapping.keys()) == [
             'title', 'authors', 'dates', 'publisher',
             'identifiers', 'rights', 'contributors', 'subjects',
-            'source', 'publisher_project_source'
+            'source', 'source_id', 'publisher_project_source'
         ]
         assert recordMapping['title'] == ('Title', '{0}')
 
@@ -42,10 +43,9 @@ class TestPublisherBacklistMapping:
         testMapping.applyFormatting()
 
         assert testMapping.record.has_part == []
-        assert testMapping.record.source == 'UofM'
+        assert testMapping.record.source == 'UofMichigan'
         assert testMapping.record.identifiers == ['testISBN|isbn', 'testOCLC|oclc']
-        assert testMapping.record.source_id == 'UofM_testOCLC'
+        assert testMapping.record.source_id == 'testSourceID'
         assert testMapping.record.publisher == ['testPublisher||']
-        assert testMapping.record.source == 'UofM'
-        assert testMapping.record.publisher_project_source == 'University of Michigan'
+        assert testMapping.record.publisher_project_source == 'University of Michigan Press'
         assert testMapping.record.subjects == ['testSubject||']


### PR DESCRIPTION
This PR is focused on creating a unified mapping for the Publisher Backlist Project records. One issue I'm running into is that the 'Projects' field when retrieved from Airtable comes back as a code like this ['recaXuQYVJMiFs6D8'] instead of ['MIT Press']. I would like to receive some help on how to access the actual name of the project instead of the code so I can properly format the source field of these records in the DRB database.