### PR TITLE
SFR-2288 Querying by OCLC Number uses metadata API MARCXML endpoint

### DIFF
--- a/managers/oclc_auth.py
+++ b/managers/oclc_auth.py
@@ -16,7 +16,7 @@ class OCLCAuthManager:
     _metadata_token = None
     _metadata_token_expires_at = None
     OCLC_SEARCH_AUTH_URL = 'https://oauth.oclc.org/token?scope=wcapi&grant_type=client_credentials'
-    OCLC_METADATA_AUTH_URL = 'https://oauth.oclc.org/token?scope=WorldCatMetadataAPI&grant_type=client_credentials'
+    OCLC_METADATA_AUTH_URL = 'https://oauth.oclc.org/token?scope=WorldCatMetadataAPI:view_marc_bib&grant_type=client_credentials'
 
     TIME_TO_REFRESH_IN_SECONDS = 60
 

--- a/managers/oclc_catalog.py
+++ b/managers/oclc_catalog.py
@@ -11,7 +11,6 @@ logger = create_log(__name__)
 
 
 class OCLCCatalogManager:
-    CATALOG_URL = 'http://www.worldcat.org/webservices/catalog/content/{}?wskey={}'
     METADATA_BIB_URL = 'https://metadata.api.oclc.org/worldcat/manage/bibs/{}'
     OCLC_SEARCH_URL = 'https://americas.discovery.api.oclc.org/worldcat/search/v2/'
     ITEM_TYPES = ['archv', 'audiobook', 'book', 'encyc', 'jrnl']
@@ -20,16 +19,16 @@ class OCLCCatalogManager:
     BEST_MATCH = 'bestMatch'
 
     def __init__(self):
-        self.oclc_key = os.environ['OCLC_API_KEY']
+        pass
 
-    def query_catalog_v2(self, oclc_no):
-        catalog_query = self.CATALOG_URL.format(oclc_no, self.oclc_key)
+    def query_catalog(self, oclc_no):
+        catalog_query = self.METADATA_BIB_URL.format(oclc_no)
 
         for _ in range(0, 3):
             try:
                 token = OCLCAuthManager.get_metadata_token()
                 headers = { 'Authorization': f'Bearer {token}' }
-                
+
                 catalog_response = requests.get(catalog_query, headers=headers, timeout=3)
 
                 if catalog_response.status_code != 200:
@@ -42,27 +41,7 @@ class OCLCCatalogManager:
             except Exception as e:
                 logger.error(f'Failed to query catalog with query {catalog_query} due to {e}')
                 return None
-            
-        return None
 
-    def query_catalog(self, oclc_no):
-        catalog_query = self.CATALOG_URL.format(oclc_no, self.oclc_key)
-
-        for _ in range(0, 3):
-            try:
-                catalog_response = requests.get(catalog_query, timeout=3)
-
-                if catalog_response.status_code != 200:
-                    logger.warning(f'OCLC catalog request failed with status {catalog_response.status_code}')
-                    return None
-
-                return catalog_response.text
-            except (Timeout, ConnectionError):
-                logger.warning(f'Could not connect to {catalog_query} or timed out')
-            except Exception as e:
-                logger.error(f'Failed to query catalog with query {catalog_query} due to {e}')
-                return None
-            
         return None
 
     def get_related_oclc_numbers(self, oclc_number: int) -> list[int]:

--- a/managers/oclc_catalog.py
+++ b/managers/oclc_catalog.py
@@ -18,9 +18,6 @@ class OCLCCatalogManager:
     MAX_NUMBER_OF_RECORDS = 100
     BEST_MATCH = 'bestMatch'
 
-    def __init__(self):
-        pass
-
     def query_catalog(self, oclc_no):
         catalog_query = self.METADATA_BIB_URL.format(oclc_no)
 

--- a/mappings/oclcCatalog.py
+++ b/mappings/oclcCatalog.py
@@ -20,6 +20,9 @@ class CatalogMapping(XMLMapping):
         super(CatalogMapping, self).__init__(source, namespace, constants)
         self.mapping = self.createMapping()
 
+    def remove_oclc_prefixes(self, oclc_id):
+        return oclc_id.removeprefix('(OCoLC)').removeprefix('on').removeprefix('ocn').removeprefix('ocm')
+
     def createMapping(self):
         return {
             'title': ('//oclc:datafield[@tag=\'245\']/oclc:subfield[@code=\'a\' or @code=\'b\']/text()', '{0} {1}'),
@@ -158,12 +161,13 @@ class CatalogMapping(XMLMapping):
 
     def applyFormatting(self):
         self.record.source = 'oclcCatalog'
+        self.record.identifiers[0] = self.remove_oclc_prefixes(self.record.identifiers[0])
         self.record.source_id = self.record.identifiers[0]
         self.record.frbr_status = 'complete'
-        
+
         _, _, lang_3, *_ = tuple(self.record.languages[0].split('|'))
         self.record.languages = [('||{}'.format(lang_3[35:38]))]
-        
+
         self.record.has_part = self.record.has_part[:10]
 
         self.record.has_part = list(filter(None, [

--- a/mappings/oclcCatalog.py
+++ b/mappings/oclcCatalog.py
@@ -16,12 +16,17 @@ class CatalogMapping(XMLMapping):
         'hathitrust': r'catalog.hathitrust.org\/api\/volumes\/([a-z]{3,6}\/[a-zA-Z0-9]+)\.html'
     }
 
+    OCLC_PREFIXES = ['(OCoLC)', 'on', 'ocn', 'ocm']
+
     def __init__(self, source, namespace, constants):
         super(CatalogMapping, self).__init__(source, namespace, constants)
         self.mapping = self.createMapping()
 
     def remove_oclc_prefixes(self, oclc_id):
-        return oclc_id.removeprefix('(OCoLC)').removeprefix('on').removeprefix('ocn').removeprefix('ocm')
+        for prefix in self.OCLC_PREFIXES:
+            oclc_id = oclc_id.removeprefix(prefix)
+        return oclc_id
+
 
     def createMapping(self):
         return {

--- a/tests/unit/test_oclcCatalog_mapping.py
+++ b/tests/unit/test_oclcCatalog_mapping.py
@@ -28,6 +28,12 @@ class TestCatalogMapping:
             has_part=['1|uri|test|text/html|{}', '1|uri|bad|text/html|{}']
         )
 
+    def test_remove_oclc_prefixes(self, testMapping):
+        assert testMapping.remove_oclc_prefixes('on48542660') == '48542660'
+        assert testMapping.remove_oclc_prefixes('ocm48542660') == '48542660'
+        assert testMapping.remove_oclc_prefixes('(OCoLC)on48542660') == '48542660'
+        assert testMapping.remove_oclc_prefixes('foo48542660') == 'foo48542660'
+
     def test_createMapping(self, testMapping):
         recordMapping = testMapping.createMapping()
 


### PR DESCRIPTION
- Removes search v1 endpoint and instead uses metadata v2
- Requests key with reduced scope (this is now required, since key no longer has access to full read/write API actions)
- Strips OCLC prefixes from OCLC control numbers when applying mapping: there are a few thousand records in QA that are prefixed, from various sources. However, the great majority of OCLC numbers are not prefixed and I created a function to remove the prefixes, as we do for e.g. Project MUSE

Tested with the SeedLocalData process and fields were manually compared -- after removing OCLC control number prefixes, they now look comparable at a glance.