### PR TITLE
SFR-2386 Remove empty related bib warning log

### DIFF
--- a/processes/frbr/classify.py
+++ b/processes/frbr/classify.py
@@ -116,9 +116,6 @@ class ClassifyProcess(CoreProcess):
 
         related_oclc_bibs = self.oclc_catalog_manager.query_bibs(search_query)
 
-        if not len(related_oclc_bibs):
-            logger.warning(f'No OCLC bibs returned for query {search_query}')
-
         for related_oclc_bib in related_oclc_bibs:
             oclc_number = related_oclc_bib.get('identifier', {}).get('oclcNumber')
             owi_number = related_oclc_bib.get('work', {}).get('id')


### PR DESCRIPTION
## Description
- This change removes the empty related bib warning log which is quite noisy and also normal in the majority of cases

