### PR TITLE
SFR-2384: Fulfill Manifest Pub Backlist S3 Bucket

### DIFF
--- a/processes/file/fulfill_url_manifest.py
+++ b/processes/file/fulfill_url_manifest.py
@@ -16,15 +16,15 @@ class FulfillURLManifestProcess(CoreProcess):
     def __init__(self, *args):
         super(FulfillURLManifestProcess, self).__init__(*args[:4])
 
-        self.fullImport = self.process == 'complete' 
+        self.full_import = self.process == 'complete' 
         self.start_timestamp = None
 
         self.generateEngine()
         self.createSession()
 
-        self.s3Bucket = os.environ['FILE_BUCKET']
+        self.s3_bucket = os.environ['FILE_BUCKET']
         self.host = os.environ['DRB_API_HOST']
-        self.prefix = 'manifests/UofM/'
+        self.prefix = 'manifests/pubBacklist/'
         self.s3_manager = S3Manager()
         self.s3_manager.createS3Client()
 
@@ -73,10 +73,8 @@ class FulfillURLManifestProcess(CoreProcess):
             metadata_json, counter = self.reading_order_fulfill(metadata_json, counter)
             metadata_json, counter = self.resource_fulfill(metadata_json, counter)
             metadata_json, counter = self.toc_fulfill(metadata_json, counter)
-        except (Exception, IndexError) as e:
-            logger.error(e)
-        except:
-            logger.error('One of the Link fulfill methods failed')  
+        except Exception as e:
+            logger.exception(e)
 
         if counter >= 4: 
             for link in metadata_json['links']:

--- a/processes/file/fulfill_url_manifest.py
+++ b/processes/file/fulfill_url_manifest.py
@@ -24,7 +24,7 @@ class FulfillURLManifestProcess(CoreProcess):
 
         self.s3_bucket = os.environ['FILE_BUCKET']
         self.host = os.environ['DRB_API_HOST']
-        self.prefix = 'manifests/pubBacklist/'
+        self.prefix = 'manifests/publisher_backlist/'
         self.s3_manager = S3Manager()
         self.s3_manager.createS3Client()
 

--- a/services/sources/publisher_backlist_service.py
+++ b/services/sources/publisher_backlist_service.py
@@ -19,6 +19,7 @@ class PublisherBacklistService(SourceService):
         self.s3_manager = S3Manager()
         self.s3_manager.createS3Client()
         self.s3_bucket = os.environ['FILE_BUCKET']
+        self.prefix = 'manifests/publisher_backlist'
         
         self.airtable_auth_token = os.environ.get('AIRTABLE_KEY', None)
 
@@ -133,7 +134,7 @@ class PublisherBacklistService(SourceService):
 
             if media_type == 'application/pdf':
                 record_id = record.identifiers[0].split('|')[0]
-                manifest_path = 'manifests/pubBacklist/{}/{}.json'.format(source, record_id)
+                manifest_path = f'{self.prefix}/{source}/{record_id}.json'
                 manifest_url = 'https://{}.s3.amazonaws.com/{}'.format(
                     self.s3_bucket, manifest_path
                 )

--- a/services/sources/publisher_backlist_service.py
+++ b/services/sources/publisher_backlist_service.py
@@ -133,9 +133,9 @@ class PublisherBacklistService(SourceService):
 
             if media_type == 'application/pdf':
                 record_id = record.identifiers[0].split('|')[0]
-                manifest_path = 'manifests/{}/{}.json'.format(source, record_id)
+                manifest_path = 'manifests/pubBacklist/{}/{}.json'.format(source, record_id)
                 manifest_url = 'https://{}.s3.amazonaws.com/{}'.format(
-                    self.s3Bucket, manifest_path
+                    self.s3_bucket, manifest_path
                 )
 
                 manifest_json = self.generate_manifest(record, url, manifest_url)


### PR DESCRIPTION
With this PR I modified the `store_pdf_manifest` method and the prefix attribute of the `FulfillManifestProcess` object to incorporate a new S3 folder called pubBacklist that will include all the manifests from the publisher backlist project such as UofM and UofSC. [https://us-east-1.console.aws.amazon.com/s3/buckets/drb-files-qa?prefix=manifests/&region=us-east-1&bucketType=general](url)