### PR TITLE
SFR-2382: Incoporate Ready To Ingest Field from Airtable

### DIFF
--- a/services/sources/publisher_backlist_service.py
+++ b/services/sources/publisher_backlist_service.py
@@ -63,7 +63,7 @@ class PublisherBacklistService(SourceService):
         if not start_timestamp:
             start_timestamp = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(hours=24)
 
-        if_ready_to_ingest_is_true_filter = f"%20IF(%7BNext%20step%20(from%20Project%20steps)%7D%20%3D%20%22Ready%20to%20ingest%22,%20TRUE(),%20FALSE())"
+        if_ready_to_ingest_is_true_filter = f"%20IF(%7BDRB_Ready%20to%20ingest%7D%20%3D%20TRUE(),%20TRUE(),%20FALSE())"
 
         if full_import:
             filter_by_formula = f'&filterByFormula={if_ready_to_ingest_is_true_filter}'


### PR DESCRIPTION
This PR focuses on replacing the use of the Next Steps Airtable field with the DRB_Ready To Ingest field to represent the status of a Publisher Backlist record that is ready to be ingested.