### PR TITLE
Sfr 2374 access parameter store

### DIFF
--- a/processes/frbr/classify.py
+++ b/processes/frbr/classify.py
@@ -116,9 +116,6 @@ class ClassifyProcess(CoreProcess):
 
         related_oclc_bibs = self.oclc_catalog_manager.query_bibs(search_query)
 
-        if not len(related_oclc_bibs):
-            logger.warning(f'No OCLC bibs returned for query {search_query}')
-
         for related_oclc_bib in related_oclc_bibs:
             oclc_number = related_oclc_bib.get('identifier', {}).get('oclcNumber')
             owi_number = related_oclc_bib.get('work', {}).get('id')

--- a/services/ssm_service.py
+++ b/services/ssm_service.py
@@ -1,0 +1,26 @@
+import os
+import boto3
+from typing import Optional
+
+from logger import create_log
+
+logger = create_log(__name__)
+
+ssm_client = boto3.client('ssm',
+            aws_access_key_id=os.environ.get('AWS_ACCESS', None),
+            aws_secret_access_key=os.environ.get('AWS_SECRET', None),
+            region_name=os.environ.get('AWS_REGION', None)
+        )
+
+def get_parameter(parameter_name: str) -> Optional[dict]:
+    try:
+        response = ssm_client.get_parameter(
+            Name=parameter_name,
+            WithDecryption=True
+        )
+
+    except Exception as err:
+        logger.exception(f"Parameter store retrieval failed")
+        return None
+
+    return response

--- a/services/ssm_service.py
+++ b/services/ssm_service.py
@@ -6,7 +6,8 @@ from logger import create_log
 
 logger = create_log(__name__)
 
-ssm_client = boto3.client('ssm',
+ssm_client = boto3.client(
+            'ssm',
             aws_access_key_id=os.environ.get('AWS_ACCESS', None),
             aws_secret_access_key=os.environ.get('AWS_SECRET', None),
             region_name=os.environ.get('AWS_REGION', None)
@@ -18,9 +19,8 @@ def get_parameter(parameter_name: str) -> Optional[dict]:
             Name=parameter_name,
             WithDecryption=True
         )
+        return response
 
     except Exception as err:
-        logger.exception(f"Parameter store retrieval failed")
+        logger.exception(f"Parameter store retrieval for {parameter_name} failed")
         return None
-
-    return response

--- a/tests/integration/test_ssm_service.py
+++ b/tests/integration/test_ssm_service.py
@@ -1,0 +1,11 @@
+import os
+from load_env import load_env_file
+
+from services.ssm_service import get_parameter
+
+TEST_FILE_ID = 'arn:aws:ssm:us-east-1:946183545209:parameter/drb/qa/nypl-api/public-key'
+
+def test_get_parameter():
+    value = get_parameter(TEST_FILE_ID)
+
+    assert value != None

--- a/tests/integration/test_ssm_service.py
+++ b/tests/integration/test_ssm_service.py
@@ -3,9 +3,9 @@ from load_env import load_env_file
 
 from services.ssm_service import get_parameter
 
-TEST_FILE_ID = 'arn:aws:ssm:us-east-1:946183545209:parameter/drb/qa/nypl-api/public-key'
+TEST_PARAM = 'arn:aws:ssm:us-east-1:946183545209:parameter/drb/qa/nypl-api/public-key'
 
 def test_get_parameter():
-    value = get_parameter(TEST_FILE_ID)
+    value = get_parameter(TEST_PARAM)
 
     assert value != None


### PR DESCRIPTION
Adds method for using SSM service to retrieve parameters directly instead of adding them each to Terraform file and/or a local development file.