### PR TITLE
NOREF - Fix type hint error

### DIFF
--- a/services/google_drive_service.py
+++ b/services/google_drive_service.py
@@ -1,6 +1,7 @@
 from io import BytesIO
 import json
 import os
+from typing import Optional
 from googleapiclient.discovery import build
 from googleapiclient.http import MediaIoBaseDownload
 from googleapiclient.errors import HttpError


### PR DESCRIPTION
Type hinting is throwing an error during certain integration tests due to Optional being used without being imported