### PR TITLE
SFR-2393: Delete Publisher Backlist Editions

### DIFF
--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -14,3 +14,4 @@ from .updatePubLocationAndLinks import main as updateLocationAndLinks
 from .countCABooks import main as countCA
 from .nyplLoginFlags import main as nyplFlags
 from .deleteUMPManifestLinks import main as deleteUMPManifests
+from .deleteProblemWorks import main as deleteWorks

--- a/services/sources/publisher_backlist_service.py
+++ b/services/sources/publisher_backlist_service.py
@@ -11,7 +11,7 @@ from mappings.publisher_backlist import PublisherBacklistMapping
 from managers import S3Manager, WebpubManifest
 from .source_service import SourceService
 from managers import DBManager, ElasticsearchManager
-from elasticsearch_dsl import Search
+from elasticsearch_dsl import Search, Q
 
 logger = create_log(__name__)
 
@@ -50,7 +50,7 @@ class PublisherBacklistService(SourceService):
     def delete_manifest(self, record_metadata_dict):
         self.db_manager.createSession()
         try:
-            record = self.session.query(Record).filter(Record.source_id == record_metadata_dict['DRB Record_ID']).first()
+            record = self.db_manager.session.query(Record).filter(Record.source_id == record_metadata_dict['DRB Record_ID']).first()
             if record:
                 key_name = self.get_metadata_file_name(record, record_metadata_dict)
                 self.s3_manager.s3Client.delete_object(Bucket= self.s3_bucket, Key= key_name)
@@ -68,7 +68,7 @@ class PublisherBacklistService(SourceService):
                 record_uuid_str = str(record.uuid)
                 edition =  self.db_manager.session.query(Edition).filter(Edition.dcdw_uuids.contains([record_uuid_str])).first()
                 work = self.db_manager.session.query(Work).filter(Work.id == edition.work_id).first()
-                if self.checkAllEditionsRelatedToRecord(record_uuid_str, work) == True:
+                if self.has_only_one_edition(work):
                     work_uuid_str = str(work.uuid)
                     es_work_resp = Search(index=os.environ['ELASTICSEARCH_INDEX']).query('match', uuid=work_uuid_str)
                     self.db_manager.session.query(Work).filter(Work.id == edition.work_id).delete()
@@ -81,20 +81,22 @@ class PublisherBacklistService(SourceService):
         finally:
             self.db_manager.session.close()
 
-    def checkAllEditionsRelatedToRecord(self, record_uuid_str, work):
-        for edition in self.db_manager.session.query(Edition).filter(Edition.work_id == work.id).all():
-            if record_uuid_str not in edition.dcdw_uuids:
-                return False
+    def has_only_one_edition(self, work):
+        if len(work.editions) > 1:
+            return False
         return True
             
     def delete_pub_backlist_edition_only(self, record_uuid_str, work):
-        for edition in self.db_manager.session.query(Edition) \
+        edition = self.db_manager.session.query(Edition) \
             .filter(Edition.work_id == work.id) \
             .filter(Edition.dcdw_uuids.contains([record_uuid_str])) \
-            .all():
-                self.db_manager.session.delete(edition)
-                # es_edition_resp = Search(index=os.environ['ELASTICSEARCH_INDEX']).query('match', uuid=uuid)
-                # es_edition_esp.delete()
+            .first()
+        self.db_manager.session.delete(edition)
+        es_work_resp = Search(index=os.environ['ELASTICSEARCH_INDEX']).query('match', uuid=str(work.uuid))
+        for work_hit in es_work_resp:
+            for edition_hit in work_hit:
+                edition_es_response = Search(index=os.environ['ELASTICSEARCH_INDEX']).query('nested', path='editions', query=Q('match', **{'editions.edition_id': edition_hit['edition_id']}))
+                edition_es_response.delete()
             
     def get_metadata_file_name(self, record, record_metadata_dict):
         key_format = f"{self.prefix}{record.source}"

--- a/services/sources/publisher_backlist_service.py
+++ b/services/sources/publisher_backlist_service.py
@@ -68,7 +68,7 @@ class PublisherBacklistService(SourceService):
                 record_uuid_str = str(record.uuid)
                 edition =  self.db_manager.session.query(Edition).filter(Edition.dcdw_uuids.contains([record_uuid_str])).first()
                 work = self.db_manager.session.query(Work).filter(Work.id == edition.work_id).first()
-                if self.has_only_one_edition(work):
+                if len(work.editions) == 1:
                     work_uuid_str = str(work.uuid)
                     es_work_resp = Search(index=os.environ['ELASTICSEARCH_INDEX']).query('match', uuid=work_uuid_str)
                     self.db_manager.session.query(Work).filter(Work.id == edition.work_id).delete()
@@ -80,11 +80,6 @@ class PublisherBacklistService(SourceService):
             logger.exception('Work/Edition does not exist or failed to delete work: {work.id}')
         finally:
             self.db_manager.session.close()
-
-    def has_only_one_edition(self, work):
-        if len(work.editions) > 1:
-            return False
-        return True
             
     def delete_pub_backlist_edition_only(self, record_uuid_str, work):
         edition = self.db_manager.session.query(Edition) \


### PR DESCRIPTION
This PR focuses on the automated deleted edge case for when a Publisher Backlist record produces a new edition with an already existing work that has other editions during the ingestion process. The PSQL deletion has been enacted but the deletion of the same edition in ES is commented out since the fields for editions are not as clear with how to search for it compared finding the same work in the PSQL and ES databases. That will be my focus with future commits.