### PR TITLE
SFR-2414: Migrate work endpoint to use plural noun

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -9,7 +9,7 @@ from waitress import serve
 
 from logger import create_log
 from .blueprints import (
-    search, work, info, edition, editions, utils, link, opds, collection, collections, citation, fulfill
+    search, work, works, info, edition, editions, utils, link, opds, collection, collections, citation, fulfill
 )
 from .utils import APIUtils
 
@@ -30,6 +30,7 @@ class FlaskAPI:
         self.app.register_blueprint(info)
         self.app.register_blueprint(search)
         self.app.register_blueprint(work)
+        self.app.register_blueprint(works)
         self.app.register_blueprint(edition)
         self.app.register_blueprint(editions)
         self.app.register_blueprint(utils)

--- a/api/blueprints/__init__.py
+++ b/api/blueprints/__init__.py
@@ -6,5 +6,5 @@ from .drbLink import link
 from .drbOPDS2 import opds
 from .drbSearch import search
 from .drbUtils import utils
-from .drbWork import work
+from .drbWork import work, works
 from .drbFulfill import fulfill

--- a/api/blueprints/drbWork.py
+++ b/api/blueprints/drbWork.py
@@ -7,8 +7,10 @@ from logger import create_log
 logger = create_log(__name__)
 
 work = Blueprint('work', __name__, url_prefix='/work')
+works = Blueprint('works', __name__, url_prefix='/works')
 
 @work.route('/<uuid>', methods=['GET'])
+@works.route('/<uuid>', methods=['GET'])
 def get_work(uuid):
     logger.info(f'Getting work with id {uuid}')
     response_type = 'singleWork'

--- a/swagger.v4.json
+++ b/swagger.v4.json
@@ -112,7 +112,7 @@
                 }
             }
         },
-        "/work/{uuid}": {
+        "/works/{uuid}": {
            "get": {
                 "tags": ["digital-research-books"],
                 "summary": "v4 Get Single Work",
@@ -697,6 +697,54 @@
                         }
                     }
                 }
+            },
+            "get": {
+                "tags": ["digital-research-books"],
+                "summary": "Return list of DRB Collections",
+                "description": "Returns list of collections in DRB",
+                "parameters": [
+                    {
+                        "name": "sort",
+                        "in": "query",
+                        "description": "Method of sorting collections. Either title or creator",
+                        "type": "string",
+                        "required": false
+                    },
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "description": "Page of collections to load",
+                        "type": "integer",
+                        "required": false
+                    },
+                    {
+                        "name": "perPage",
+                        "in": "query",
+                        "description": "Number of collections to load per page",
+                        "type": "integer",
+                        "required": false
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "A basic OPDS2 feed response",
+                        "schema": {
+                            "$ref": "#/definitions/OPDSFeedResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "default": {
+                        "description": "Unexpected Error",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
             }
         },
         "/collections/{uuid}": {
@@ -1013,56 +1061,6 @@
                             "$ref": "#/definitions/ErrorResponse"
                         }
                     } 
-                }
-            }
-        },
-        "/collections/list": {
-            "get": {
-                "tags": ["digital-research-books"],
-                "summary": "Return list of DRB Collections",
-                "description": "Returns list of collections in DRB",
-                "parameters": [
-                    {
-                        "name": "sort",
-                        "in": "query",
-                        "description": "Method of sorting collections. Either title or creator",
-                        "type": "string",
-                        "required": false
-                    },
-                    {
-                        "name": "page",
-                        "in": "query",
-                        "description": "Page of collections to load",
-                        "type": "integer",
-                        "required": false
-                    },
-                    {
-                        "name": "perPage",
-                        "in": "query",
-                        "description": "Number of collections to load per page",
-                        "type": "integer",
-                        "required": false
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "A basic OPDS2 feed response",
-                        "schema": {
-                            "$ref": "#/definitions/OPDSFeedResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/ErrorResponse"
-                        }
-                    },
-                    "default": {
-                        "description": "Unexpected Error",
-                        "schema": {
-                            "$ref": "#/definitions/ErrorResponse"
-                        }
-                    }
                 }
             }
         }


### PR DESCRIPTION
# Description
- Migrates work endpoint to use plural noun
- Moves /collections/list GET method to /collections in swagger
# Testing
`docker compose up` and hit the endpoint /works