### PR TITLE
SFR-2415: Migrate link endpoint to use plural noun

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -9,7 +9,7 @@ from waitress import serve
 
 from logger import create_log
 from .blueprints import (
-    search, work, info, edition, editions, utils, link, opds, collection, collections, citation, fulfill
+    search, work, info, edition, editions, utils, link, links, opds, collection, collections, citation, fulfill
 )
 from .utils import APIUtils
 
@@ -34,6 +34,7 @@ class FlaskAPI:
         self.app.register_blueprint(editions)
         self.app.register_blueprint(utils)
         self.app.register_blueprint(link)
+        self.app.register_blueprint(links)
         self.app.register_blueprint(opds)
         self.app.register_blueprint(collection)
         self.app.register_blueprint(collections)

--- a/api/blueprints/__init__.py
+++ b/api/blueprints/__init__.py
@@ -2,7 +2,7 @@ from .drbCitation import citation
 from .drbCollection import collection, collections
 from .drbEdition import edition, editions
 from .drbInfo import info
-from .drbLink import link
+from .drbLink import link, links
 from .drbOPDS2 import opds
 from .drbSearch import search
 from .drbUtils import utils

--- a/api/blueprints/drbLink.py
+++ b/api/blueprints/drbLink.py
@@ -7,8 +7,10 @@ from logger import create_log
 logger = create_log(__name__)
 
 link = Blueprint('link', __name__, url_prefix='/link')
+links = Blueprint('links', __name__, url_prefix='/links')
 
 @link.route('/<link_id>', methods=['GET'])
+@links.route('/<link_id>', methods=['GET'])
 def get_link(link_id):
     logger.info(f'Getting link with id {link_id}')
     response_type = 'singleLink'

--- a/swagger.v4.json
+++ b/swagger.v4.json
@@ -246,7 +246,7 @@
                 }
             }
         },
-        "/link/{id}": {
+        "/links/{id}": {
             "get": {
                 "tags": ["digital-research-books"],
                 "summary": "v4 Get Single Link",


### PR DESCRIPTION
# Description
- Migrates link endpoint to use plural noun
# Testing
`docker compose up` and hit the endpoint /links