### PR TITLE
NOREF: Retrieve & use Airtable parameters directly

### DIFF
--- a/services/google_drive_service.py
+++ b/services/google_drive_service.py
@@ -1,6 +1,7 @@
 from io import BytesIO
 import json
 import os
+from typing import Optional
 from googleapiclient.discovery import build
 from googleapiclient.http import MediaIoBaseDownload
 from googleapiclient.errors import HttpError

--- a/services/sources/publisher_backlist_service.py
+++ b/services/sources/publisher_backlist_service.py
@@ -24,8 +24,7 @@ class PublisherBacklistService(SourceService):
         self.prefix = 'manifests/publisher_backlist'
 
         if os.environ['ENVIRONMENT'] == 'production':
-            # self.airtable_auth_token = get_parameter
-            pass
+            self.airtable_auth_token = get_parameter('arn:aws:ssm:us-east-1:946183545209:parameter/drb/production/airtable/pub-backlist/api-key')
         else:
             self.airtable_auth_token = get_parameter('arn:aws:ssm:us-east-1:946183545209:parameter/drb/qa/airtable/pub-backlist/api-key')
 

--- a/services/sources/publisher_backlist_service.py
+++ b/services/sources/publisher_backlist_service.py
@@ -8,6 +8,7 @@ from typing import Optional
 from logger import create_log
 from mappings.publisher_backlist import PublisherBacklistMapping
 from managers import S3Manager, WebpubManifest
+from services.ssm_service import get_parameter
 from .source_service import SourceService
 
 logger = create_log(__name__)
@@ -20,8 +21,12 @@ class PublisherBacklistService(SourceService):
         self.s3_manager.createS3Client()
         self.s3_bucket = os.environ['FILE_BUCKET']
         self.prefix = 'manifests/publisher_backlist'
-        
-        self.airtable_auth_token = os.environ.get('AIRTABLE_KEY', None)
+
+        if os.environ['ENVIRONMENT'] == 'production':
+            # self.airtable_auth_token = get_parameter
+            pass
+        else:
+            self.airtable_auth_token = get_parameter('arn:aws:ssm:us-east-1:946183545209:parameter/drb/qa/airtable/pub-backlist/api-key')
 
     def get_records(
         self,

--- a/services/ssm_service.py
+++ b/services/ssm_service.py
@@ -19,7 +19,7 @@ def get_parameter(parameter_name: str) -> Optional[dict]:
             Name=parameter_name,
             WithDecryption=True
         )
-        return response
+        return response['Parameter']['Value']
 
     except Exception as err:
         logger.exception(f"Parameter store retrieval for {parameter_name} failed")


### PR DESCRIPTION
Changing the SSM service to return the parameter value only - I don't think there's a lot of value in what comes back with the rest of the object and my instinct is that it should more closely resemble the API for grabbing the parameter as an environment variable.