### PR TITLE
SFR-2438: Fix Fulfill URL Manifest Process

### DIFF
--- a/api/utils.py
+++ b/api/utils.py
@@ -41,7 +41,7 @@ class APIUtils():
         'muse': 4,
         'met': 5,
         'isac': 6,
-        'UofM': 7,
+        'UofMichigan': 7,
         'UofSC': 8,
         'hathitrust': 9,
         'oclc': 10,

--- a/api/utils.py
+++ b/api/utils.py
@@ -42,6 +42,7 @@ class APIUtils():
         'met': 5,
         'isac': 6,
         'UofMichigan': 7,
+        'UofM': 7,
         'UofSC': 8,
         'hathitrust': 9,
         'oclc': 10,

--- a/mappings/publisher_backlist.py
+++ b/mappings/publisher_backlist.py
@@ -94,8 +94,8 @@ class PublisherBacklistMapping(JSONMapping):
         rights_status = rights_elements[0]
 
         if rights_status == 'in copyright':
-            return '{}|{}||{}|'.format('self.record.source', 'in_copyright', 'In Copyright') 
+            return '{}|{}||{}|'.format(self.record.source, 'in_copyright', 'In Copyright') 
         elif rights_status == 'public domain':
-            return '{}|{}||{}|'.format('self.record.source', 'public_domain', 'Public Domain') 
+            return '{}|{}||{}|'.format(self.record.source, 'public_domain', 'Public Domain') 
         
         return None

--- a/processes/file/fulfill_url_manifest.py
+++ b/processes/file/fulfill_url_manifest.py
@@ -42,18 +42,18 @@ class FulfillURLManifestProcess(CoreProcess):
 
     def fetch_and_update_manifests(self, start_timestamp=None):
 
-        batches = self.s3_manager.load_batches(self.prefix, self.s3Bucket)
+        batches = self.s3_manager.load_batches(self.prefix, self.s3_bucket)
         if start_timestamp:
             #Using JMESPath to extract keys from the JSON batches
             filtered_batch_keys = batches.search(f"Contents[?to_string(LastModified) > '\"{start_timestamp}\"'].Key")
             for key in filtered_batch_keys:
-                metadata_object = self.s3Client.get_object(Bucket=self.s3Bucket, Key= f'{key}')
+                metadata_object = self.s3_manager.s3Client.get_object(Bucket=self.s3_bucket, Key=f'{key}')
                 self.update_metadata_object(metadata_object, self.s3Bucket, key)
         else:
             for batch in batches:
                 for content in batch['Contents']:
                     key = content['Key']
-                    metadata_object = self.s3Client.get_object(Bucket=self.s3Bucket, Key= f'{key}')
+                    metadata_object = self.s3_manager.s3Client.get_object(Bucket=self.s3_bucket, Key=f'{key}')
                     self.update_metadata_object(metadata_object, self.s3Bucket, key)
 
     def update_metadata_object(self, metadata_object, bucket_name, curr_key):

--- a/processes/file/fulfill_url_manifest.py
+++ b/processes/file/fulfill_url_manifest.py
@@ -48,13 +48,13 @@ class FulfillURLManifestProcess(CoreProcess):
             filtered_batch_keys = batches.search(f"Contents[?to_string(LastModified) > '\"{start_timestamp}\"'].Key")
             for key in filtered_batch_keys:
                 metadata_object = self.s3_manager.s3Client.get_object(Bucket=self.s3_bucket, Key=f'{key}')
-                self.update_metadata_object(metadata_object, self.s3Bucket, key)
+                self.update_metadata_object(metadata_object, self.s3_bucket, key)
         else:
             for batch in batches:
                 for content in batch['Contents']:
                     key = content['Key']
                     metadata_object = self.s3_manager.s3Client.get_object(Bucket=self.s3_bucket, Key=f'{key}')
-                    self.update_metadata_object(metadata_object, self.s3Bucket, key)
+                    self.update_metadata_object(metadata_object, self.s3_bucket, key)
 
     def update_metadata_object(self, metadata_object, bucket_name, curr_key):
 

--- a/processes/file/fulfill_url_manifest.py
+++ b/processes/file/fulfill_url_manifest.py
@@ -54,7 +54,6 @@ class FulfillURLManifestProcess(CoreProcess):
                 self.update_metadata_object(metadata_object, self.s3_bucket, key)
         else:
             for batch in batches:
-                logger.info(batch)
                 if 'Contents' not in batch:
                     continue
 

--- a/processes/file/fulfill_url_manifest.py
+++ b/processes/file/fulfill_url_manifest.py
@@ -47,10 +47,16 @@ class FulfillURLManifestProcess(CoreProcess):
             #Using JMESPath to extract keys from the JSON batches
             filtered_batch_keys = batches.search(f"Contents[?to_string(LastModified) > '\"{start_timestamp}\"'].Key")
             for key in filtered_batch_keys:
+                if not key:
+                    continue
+
                 metadata_object = self.s3_manager.s3Client.get_object(Bucket=self.s3_bucket, Key=f'{key}')
                 self.update_metadata_object(metadata_object, self.s3_bucket, key)
         else:
             for batch in batches:
+                if 'Content' not in batch:
+                    continue
+
                 for content in batch['Contents']:
                     key = content['Key']
                     metadata_object = self.s3_manager.s3Client.get_object(Bucket=self.s3_bucket, Key=f'{key}')

--- a/processes/file/fulfill_url_manifest.py
+++ b/processes/file/fulfill_url_manifest.py
@@ -54,7 +54,8 @@ class FulfillURLManifestProcess(CoreProcess):
                 self.update_metadata_object(metadata_object, self.s3_bucket, key)
         else:
             for batch in batches:
-                if 'Content' not in batch:
+                logger.info(batch)
+                if 'Contents' not in batch:
                     continue
 
                 for content in batch['Contents']:

--- a/tests/unit/processes/file/test_fulfill_manifest_process.py
+++ b/tests/unit/processes/file/test_fulfill_manifest_process.py
@@ -16,7 +16,7 @@ class TestUofMProcess:
     def test_process(self, mocker):
         class TestFulfill(FulfillURLManifestProcess):
             def __init__(self):
-                self.s3Bucket = 'test_aws_bucket'
+                self.s3_bucket = 'test_aws_bucket'
                 self.s3_manager = mocker.MagicMock(s3Client=mocker.MagicMock())
                 self.session = mocker.MagicMock(session='testSession')
                 self.records = mocker.MagicMock(record='testRecord')


### PR DESCRIPTION
## Description
- The Fulfill URL Manifest process was using different incorrect class variables
- This change fixes typos!

## Testing
`python main.py -p FulfillURLManifestProcess -e local -i complete`
`python main.py -p FulfillURLManifestProcess -e local -i daily`
`make unit`