### PR TITLE
SFR-2426: Increasing OCLC query catalog timeout to 5 seconds

### DIFF
--- a/managers/oclc_catalog.py
+++ b/managers/oclc_catalog.py
@@ -26,7 +26,7 @@ class OCLCCatalogManager:
                 token = OCLCAuthManager.get_metadata_token()
                 headers = { 'Authorization': f'Bearer {token}' }
 
-                catalog_response = requests.get(catalog_query, headers=headers, timeout=3)
+                catalog_response = requests.get(catalog_query, headers=headers, timeout=5)
 
                 if catalog_response.status_code != 200:
                     logger.warning(f'OCLC catalog request failed with status {catalog_response.status_code}')

--- a/tests/unit/test_oclcCatalog_manager.py
+++ b/tests/unit/test_oclcCatalog_manager.py
@@ -27,7 +27,7 @@ class TestOCLCCatalogManager:
         mockRequest.get.assert_called_once_with(
             'https://metadata.api.oclc.org/worldcat/manage/bibs/1',
             headers={'Authorization': 'Bearer foo'},
-            timeout=3
+            timeout=5
         )
 
     def test_query_catalog_error(self, testInstance, mocker):
@@ -47,7 +47,7 @@ class TestOCLCCatalogManager:
         mockRequest.get.assert_called_once_with(
             'https://metadata.api.oclc.org/worldcat/manage/bibs/1',
             headers={'Authorization': 'Bearer foo'},
-            timeout=3
+            timeout=5
         )
 
     def test_query_catalog_single_retry_then_success(self, testInstance, mocker):
@@ -65,7 +65,7 @@ class TestOCLCCatalogManager:
 
         assert testResponse == 'testClassifyRecord'
         mockRequest.get.assert_has_calls(
-            [mocker.call('https://metadata.api.oclc.org/worldcat/manage/bibs/1', timeout=3, headers={'Authorization': 'Bearer foo'})] * 2
+            [mocker.call('https://metadata.api.oclc.org/worldcat/manage/bibs/1', timeout=5, headers={'Authorization': 'Bearer foo'})] * 2
         )
 
     def test_query_catalog_exhaust_retries(self, testInstance, mocker):
@@ -83,7 +83,7 @@ class TestOCLCCatalogManager:
 
         assert testResponse == None
         mockRequest.get.assert_has_calls(
-            [mocker.call('https://metadata.api.oclc.org/worldcat/manage/bibs/1', timeout=3, headers={'Authorization': 'Bearer foo'})] * 3
+            [mocker.call('https://metadata.api.oclc.org/worldcat/manage/bibs/1', timeout=5, headers={'Authorization': 'Bearer foo'})] * 3
         )
 
     def test_generate_search_query_w_identifier(self, testInstance):


### PR DESCRIPTION
## Description
- We are seeing some timeouts with the new endpoint to query the OCLC catalog
- Bumps the timeout to 5 seconds!