### PR TITLE
SFr-2478: Setting github api url as a constant

### DIFF
--- a/config/example.yaml
+++ b/config/example.yaml
@@ -54,7 +54,6 @@ NYPL_API_CLIENT_TOKEN_URL: xxx
 
 # GITHUB API Credentials
 GITHUB_API_KEY: xxx
-GITHUB_API_ROOT: https://api.github.com/graphql
 
 # Bardo CCE API URL
 BARDO_CCE_API: xxx

--- a/config/production.yaml
+++ b/config/production.yaml
@@ -65,7 +65,6 @@ DRB_API_PORT: '80'
 
 # GITHUB API Credentials
 # GITHUB_API_KEY must be configured in secrets file
-GITHUB_API_ROOT: https://api.github.com/graphql
 
 # Bardo CCE API URL
 BARDO_CCE_API: http://sfr-c-ecsal-14v3injrieoy5-258691445.us-east-1.elb.amazonaws.com/search/

--- a/config/qa.yaml
+++ b/config/qa.yaml
@@ -65,7 +65,6 @@ DRB_API_PORT: '80'
 
 # GITHUB API Credentials
 # GITHUB_API_KEY must be configured in secrets file
-GITHUB_API_ROOT: https://api.github.com/graphql
 
 # Bardo CCE API URL
 BARDO_CCE_API: http://sfr-c-ecsal-14v3injrieoy5-258691445.us-east-1.elb.amazonaws.com/search/

--- a/managers/gutenberg.py
+++ b/managers/gutenberg.py
@@ -17,7 +17,7 @@ class GutenbergManager:
         self.startTime = startTime or None
         self.pageSize = pageSize or 100
         self.githubAPIKey = os.environ['GITHUB_API_KEY']
-        self.githubAPIRoot = os.environ['GITHUB_API_ROOT']
+        self.githubAPIRoot = 'https://api.github.com/graphql'
 
         self.cursor = None
         self.repos = []

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -42,7 +42,6 @@ class TestHelpers:
         'NYPL_API_CLIENT_SECRET': 'test_api_secret',
         'NYPL_API_CLIENT_TOKEN_URL': 'test_api_token_url',
         'GITHUB_API_KEY': 'test_github_key',
-        'GITHUB_API_ROOT': 'test_github_url',
         'BARDO_CCE_API': 'test_cce_url',
         'MUSE_MARC_URL': 'test_muse_url',
         'MUSE_CSV_URL': 'test_muse_csv',

--- a/tests/unit/test_gutenberg_manager.py
+++ b/tests/unit/test_gutenberg_manager.py
@@ -58,7 +58,6 @@ class TestGutenbergManager:
         assert testInstance.startTime is None
         assert testInstance.pageSize == 100
         assert testInstance.githubAPIKey == 'test_github_key'
-        assert testInstance.githubAPIRoot == 'test_github_url'
         assert testInstance.cursor is None
         assert testInstance.repos == []
         assert testInstance.dataFiles == []
@@ -209,7 +208,7 @@ class TestGutenbergManager:
 
         assert testResponse == 'testResponse'
         mockPost.assert_called_once_with(
-            'test_github_url',
+            testInstance.githubAPIRoot,
             json={'query': 'testQuery'},
             headers={'Authorization': 'bearer test_github_key'}
         )


### PR DESCRIPTION
## Description
- https://api.github.com/graphql is constant across environments, so setting as a constant!