### PR TITLE
SFR-2478: Make webpub pdf profile a constant

### DIFF
--- a/config/example.yaml
+++ b/config/example.yaml
@@ -68,9 +68,6 @@ DOAB_OAI_URL: xxx
 # ePub-to-Webpub Conversion Service
 WEBPUB_CONVERSION_URL: xxx
 
-# Webpub PDF Profile
-WEBPUB_PDF_PROFILE: http://librarysimplified.org/terms/profiles/pdf
-
 # Allowed sources of CORS requests to proxy endpoint
 API_PROXY_CORS_ALLOWED: (?:Source1:Source2)
 

--- a/config/production.yaml
+++ b/config/production.yaml
@@ -89,9 +89,6 @@ DEFAULT_COVER_URL: https://drb-files-qa.s3.amazonaws.com/covers/default/defaultC
 # ePub-to-Webpub Conversion Service
 WEBPUB_CONVERSION_URL: https://epub-to-webpub.vercel.app
 
-# Webpub PDF Profile
-WEBPUB_PDF_PROFILE: http://librarysimplified.org/terms/profiles/pdf
-
 # Allowed sources of CORS requests to proxy endpoint
 API_PROXY_CORS_ALLOWED: http[s]?://.*nypl.org
 

--- a/config/qa.yaml
+++ b/config/qa.yaml
@@ -89,9 +89,6 @@ DEFAULT_COVER_URL: https://drb-files-qa.s3.amazonaws.com/covers/default/defaultC
 # ePub-to-Webpub Conversion Service
 WEBPUB_CONVERSION_URL: https://epub-to-webpub.vercel.app
 
-# Webpub PDF Profile
-WEBPUB_PDF_PROFILE: http://librarysimplified.org/terms/profiles/pdf
-
 # Allowed sources of CORS requests to proxy endpoint
 API_PROXY_CORS_ALLOWED: (?:http[s]?:\/\/.*nypl.org|https:\/\/.*(?:nypl|sfr).*vercel.app|http[s]?:\/\/.*tugboat.qa)
 

--- a/config/sample-compose.yaml
+++ b/config/sample-compose.yaml
@@ -74,9 +74,6 @@ DRB_API_PORT: '5050'
 # Bardo CCE API URL
 BARDO_CCE_API: http://sfr-bardo-copyright-development.us-east-1.elasticbeanstalk.com/search
 
-# Webpub PDF Profile
-WEBPUB_PDF_PROFILE: http://librarysimplified.org/terms/profiles/pdf
-
 # Allowed sources of CORS requests to proxy endpoint
 API_PROXY_CORS_ALLOWED: '*'
 

--- a/managers/muse.py
+++ b/managers/muse.py
@@ -100,9 +100,7 @@ class MUSEManager:
 
     def constructWebpubManifest(self):
         pdfManifest = WebpubManifest(self.link, self.mediaType)
-        pdfManifest.addMetadata(
-            self.record.record, conformsTo=os.environ['WEBPUB_PDF_PROFILE']
-        )
+        pdfManifest.addMetadata(self.record.record)
 
         chapterTable = self.museSoup.find(id='available_items_list_wrap')
 

--- a/managers/parsers/abstractParser.py
+++ b/managers/parsers/abstractParser.py
@@ -37,9 +37,7 @@ class AbstractParser(ABC):
     def generateManifest(self, sourceURI, manifestURI):
         manifest = WebpubManifest(sourceURI, 'application/pdf')
 
-        manifest.addMetadata(
-            self.record, conformsTo=os.environ['WEBPUB_PDF_PROFILE']
-        )
+        manifest.addMetadata(self.record)
 
         manifest.addChapter(sourceURI, self.record.title)
 

--- a/managers/webpubManifest.py
+++ b/managers/webpubManifest.py
@@ -4,6 +4,9 @@ from typing import NoReturn
 
 
 class WebpubManifest:
+    # TODO: change - the library simplified PDF profile no longer exists
+    WEBPUB_PDF_PROFILE = 'http://librarysimplified.org/terms/profiles/pdf'
+
     def __init__(self, source, sourceType):
         self.metadata: dict = {'@type': 'https://schema.org/Book'}
         self.links: list = [{'href': source, 'type': sourceType, 'rel': 'alternate'}]
@@ -14,7 +17,7 @@ class WebpubManifest:
         self.openSection = None
 
     # TODO validate kwargs against schema.org/Book
-    def addMetadata(self, dcdwRecord: object, conformsTo=None) -> None:
+    def addMetadata(self, dcdwRecord: object, conformsTo: str=WEBPUB_PDF_PROFILE) -> None:
         self.metadata['title'] = dcdwRecord.title
 
         if len(dcdwRecord.authors) > 0:

--- a/processes/ingest/chicago_isac.py
+++ b/processes/ingest/chicago_isac.py
@@ -87,10 +87,7 @@ class ChicagoISACProcess(CoreProcess):
     def generate_manifest(record, source_url, manifest_url):
         manifest = WebpubManifest(source_url, 'application/pdf')
 
-        manifest.addMetadata(
-            record,
-            conformsTo=os.environ['WEBPUB_PDF_PROFILE']
-        )
+        manifest.addMetadata(record)
         
         manifest.addChapter(source_url, record.title)
 

--- a/processes/ingest/loc.py
+++ b/processes/ingest/loc.py
@@ -266,10 +266,7 @@ class LOCProcess(CoreProcess):
     def generateManifest(record, sourceURI, manifestURI):
         manifest = WebpubManifest(sourceURI, 'application/pdf')
 
-        manifest.addMetadata(
-            record,
-            conformsTo=os.environ['WEBPUB_PDF_PROFILE']
-        )
+        manifest.addMetadata(record)
         
         manifest.addChapter(sourceURI, record.title)
 

--- a/processes/ingest/met.py
+++ b/processes/ingest/met.py
@@ -191,10 +191,7 @@ class METProcess(CoreProcess):
     def generateManifest(record, sourceURI, manifestURI):
         manifest = WebpubManifest(sourceURI, 'application/pdf')
 
-        manifest.addMetadata(
-            record,
-            conformsTo=os.environ['WEBPUB_PDF_PROFILE']
-        )
+        manifest.addMetadata(record)
 
         manifest.addChapter(sourceURI, record.title)
 

--- a/services/sources/publisher_backlist_service.py
+++ b/services/sources/publisher_backlist_service.py
@@ -281,10 +281,7 @@ class PublisherBacklistService(SourceService):
     def generate_manifest(record, source_url, manifest_url):
         manifest = WebpubManifest(source_url, 'application/pdf')
 
-        manifest.addMetadata(
-            record,
-            conformsTo=os.environ['WEBPUB_PDF_PROFILE']
-        )
+        manifest.addMetadata(record)
         
         manifest.addChapter(source_url, record.title)
 

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -48,7 +48,6 @@ class TestHelpers:
         'MUSE_CSV_URL': 'test_muse_csv',
         'DOAB_OAI_URL': 'test_doab_url',
         'WEBPUB_CONVERSION_URL': 'test_conversion_url',
-        'WEBPUB_PDF_PROFILE': 'test_profile_uri',
         'ENVIRONMENT': 'test'
     }
 

--- a/tests/unit/processes/ingest/test_chicago_isac_process.py
+++ b/tests/unit/processes/ingest/test_chicago_isac_process.py
@@ -92,5 +92,5 @@ class TestChicagoISACProcess:
         assert test_manifest == 'test_json'
         assert mock_manifest.links[0] == {'rel': 'self', 'href': 'manifest_url', 'type': 'application/webpub+json'}
 
-        mock_manifest.addMetadata.assert_called_once_with(mock_record, conformsTo='test_profile_uri')
+        mock_manifest.addMetadata.assert_called_once_with(mock_record)
         mock_manifest.addChapter.assert_called_once_with('source_url', 'test_title')

--- a/tests/unit/processes/ingest/test_loc_process.py
+++ b/tests/unit/processes/ingest/test_loc_process.py
@@ -140,5 +140,5 @@ class TestLOCProcess:
         assert testManifest == 'testJSON'
         assert mockManifest.links[0] == {'rel': 'self', 'href': 'manifestURI', 'type': 'application/webpub+json'}
 
-        mockManifest.addMetadata.assert_called_once_with(mockRecord, conformsTo='test_profile_uri')
+        mockManifest.addMetadata.assert_called_once_with(mockRecord)
         mockManifest.addChapter.assert_called_once_with('sourceURI', 'testTitle')

--- a/tests/unit/processes/ingest/test_met_process.py
+++ b/tests/unit/processes/ingest/test_met_process.py
@@ -206,7 +206,7 @@ class TestMetProcess:
         assert testManifest == 'testJSON'
         assert mockManifest.links[0] == {'rel': 'self', 'href': 'manifestURI', 'type': 'application/webpub+json'}
 
-        mockManifest.addMetadata.assert_called_once_with(mockRecord, conformsTo='test_profile_uri')
+        mockManifest.addMetadata.assert_called_once_with(mockRecord)
         mockManifest.addChapter.assert_called_once_with('sourceURI', 'Test')
 
     def test_queryMetAPI_success_non_head(self, mocker):

--- a/tests/unit/test_muse_manager.py
+++ b/tests/unit/test_muse_manager.py
@@ -167,9 +167,7 @@ class TestMUSEManager:
         assert testManager.pdfWebpubManifest == mockManifest
 
         mockManifestConstructor.assert_called_once_with('testLink', 'testType')
-        mockManifest.addMetadata.assert_called_once_with(
-            'testRecord', conformsTo='test_profile_uri'
-        )
+        mockManifest.addMetadata.assert_called_once_with('testRecord')
 
         mockManifest.addSection.assert_has_calls([
             mocker.call('Part One. Reading Reading Historically', ''),

--- a/tests/unit/test_parser_abstract.py
+++ b/tests/unit/test_parser_abstract.py
@@ -58,7 +58,7 @@ class TestAbstractParser:
         assert testManifest == 'jsonManifest'
         assert mockManifest.links == [{'rel': 'self', 'href': 'manifestURI', 'type': 'application/webpub+json'}]
         mockManifestManager.assert_called_once_with('sourceURI', 'application/pdf')
-        mockManifest.addMetadata.assert_called_once_with(testParser.record, conformsTo='test_profile_uri')
+        mockManifest.addMetadata.assert_called_once_with(testParser.record)
         mockManifest.addChapter.assert_called_once_with('sourceURI', 'testRecord')
         mockManifest.toJson.assert_called_once()
 


### PR DESCRIPTION
## Description
- The webpub pdf profile is constant across all envs - making constant
- @Apophenia we may want to include the conformsTo metadata in the data audit since the link leads to a 404