### PR TITLE
NO-REF: set secret env param only if it's not null

### DIFF
--- a/load_env.py
+++ b/load_env.py
@@ -73,4 +73,7 @@ def load_secrets():
 
     for env_var, param_name in ENV_VAR_TO_SSM_NAME.items():
         if os.environ.get(env_var, None) is None:
-            os.environ[env_var] = ssm_service.get_parameter(param_name)
+            param = ssm_service.get_parameter(param_name)
+
+            if param is not None:
+                os.environ[env_var] = param


### PR DESCRIPTION
## Description
- This change only sets the env var secret if the parameter retrieved from SSM is not null