### PR TITLE
NO-REF: Fix local elastic search index creation

### DIFF
--- a/managers/elasticsearch.py
+++ b/managers/elasticsearch.py
@@ -171,13 +171,10 @@ class ElasticsearchManager:
         )
 
     def createElasticSearchIndex(self):
-        esIndex = Index(self.index)
-        if esIndex.exists() is False:
-            ESWork.init()
-        else:
-            logger.info(
-                'ElasticSearch index {} already exists'.format(self.index)
-            )
+        es_index = Index(self.index)
+        
+        if es_index.exists() is False:
+            ESWork.init(index=self.index)
 
     @staticmethod
     def constructLanguagePipeline(client, id, description, prefix='', field=''):


### PR DESCRIPTION
## Description
- Ok so the Index inner class name field is set before the os environment variables are set. Therefore, the index is none if we try to create it at that point. 
- This change just passes in the index from the elastic search manager when initializing the ESWork. 