### PR TITLE
NO-REF: setting a batch size for deleting works

### DIFF
--- a/scripts/cleanup_duplicate_works.py
+++ b/scripts/cleanup_duplicate_works.py
@@ -46,6 +46,8 @@ def main():
             except NotFoundError: 
                 print(f'No work document found for work uuid {work.uuid}')
 
+            number_of_works_deleted += 1
+
             if number_of_works_deleted % BATCH_SIZE == 0:
                 db_manager.session.commit()
 

--- a/scripts/cleanup_duplicate_works.py
+++ b/scripts/cleanup_duplicate_works.py
@@ -9,6 +9,7 @@ TITLES = [
     'Thoughts and things at home and abroad. By Elihu Burritt ... With a memoir, by Mary Howitt',
     'Legends of the sea. 39 men for one woman: an episode of the colonization of Canada. Tr. from the French of H. Émile Chevalier, by E. I. Sears'
 ]
+BATCH_SIZE = 100
 
 def main():
     db_manager = DBManager()
@@ -28,6 +29,7 @@ def main():
         )
 
         first_work = True
+        number_of_works_deleted = 0
         
         for work in works:
             if first_work:
@@ -43,6 +45,9 @@ def main():
                 )
             except NotFoundError: 
                 print(f'No work document found for work uuid {work.uuid}')
+
+            if number_of_works_deleted % BATCH_SIZE == 0:
+                db_manager.session.commit()
 
         db_manager.session.commit()
 


### PR DESCRIPTION
## Description
- Sets a batch size of 100 when cleaning up duplicate works
- The ECS task ran out of memory!

## Testing
- ran script in QA