### PR TITLE
SFR-2484: Adding ability to cluster records by source

### DIFF
--- a/main.py
+++ b/main.py
@@ -35,6 +35,7 @@ def main(args):
     single_record = args.singleRecord
     limit = args.limit
     offset = args.offset
+    source = args.source
     options = args.options
 
     logger.info(f'Starting process {process} in {environment}')
@@ -44,7 +45,7 @@ def main(args):
     try:
         process_class = available_processes[process]
         
-        process_instance = process_class(process_type, custom_file, start_date, single_record, limit, offset, options)
+        process_instance = process_class(process_type, custom_file, start_date, single_record, limit, offset, source, options)
     except:
         logger.exception(f'Failed to initialize process {process} in {environment}')
         return
@@ -95,6 +96,7 @@ def create_arg_parser():
     parser.add_argument('-l', '--limit', help='Set overall limit for number of records imported in this process')
     parser.add_argument('-o', '--offset', help='Set start offset for current processed (for batched import process)')
     parser.add_argument('-r', '--singleRecord', help='Single record ID for ingesting an individual record')
+    parser.add_argument('-src', '--source', help='Run a process against records from a specified source')
     parser.add_argument('options', nargs='*', help='Additional arguments')
 
     return parser

--- a/processes/cluster.py
+++ b/processes/cluster.py
@@ -58,7 +58,7 @@ class ClusterProcess(CoreProcess):
             self.close_connection()
 
     def cluster_records(self, start_datetime=None, record_uuid=None, source=None):
-        filters = [
+        query_filters = [
             Record.frbr_status == 'complete',
             Record.cluster_status == False,
             Record.source.notin_(['oclcClassify', 'oclcCatalog']),
@@ -66,15 +66,15 @@ class ClusterProcess(CoreProcess):
         ]
 
         if start_datetime:
-            filters.append(Record.date_modified > start_datetime)
+            query_filters.append(Record.date_modified > start_datetime)
 
         if record_uuid:
-            filters.append(Record.uuid == record_uuid)
+            query_filters.append(Record.uuid == record_uuid)
 
         if source:
-            filters.append(Record.source == source)
+            query_filters.append(Record.source == source)
 
-        get_unclustered_records_query = self.session.query(Record).filter(*filters)
+        get_unclustered_records_query = self.session.query(Record).filter(*query_filters)
 
         works_to_index = []
         work_ids_to_delete = set()


### PR DESCRIPTION
## Description
- Adds ability to cluster records by source
- Cleanups the process logic so that we move away from process types - customer/complete.

## Testing
`make unit`
`python main.py -p ClusterProcess -e local-qa -src loc -l 1`