### PR TITLE
SFR-2485: Handle clustering records with no dates:

### DIFF
--- a/managers/sfrRecord.py
+++ b/managers/sfrRecord.py
@@ -600,6 +600,10 @@ class SFRRecordManager:
 
     def normalizeDates(self, dates):
         outDates = set()
+
+        if dates is None:
+            return outDates
+
         for date in dates:
             try:
                 dateValue, dateType = tuple(date.split('|'))


### PR DESCRIPTION
## Description: 
There are cases where the dates are null in a record. We usually handle this frontend by saying that the edition year is unknown. 

Adding a quick if check to see if the dates are none and if so return an empty list of dates.