### PR TITLE
NO-REF: Fixing doab ingest limit

### DIFF
--- a/processes/ingest/doab.py
+++ b/processes/ingest/doab.py
@@ -124,7 +124,10 @@ class DOABProcess(CoreProcess):
                 except DOABError as e:
                     logger.error(f'Error parsing DOAB record {record}')
 
-            recordsProcessed += 100
+                recordsProcessed += 1
+                
+                if recordsProcessed >= self.ingestLimit:
+                    break
 
             if not resumptionToken or recordsProcessed >= self.ingestLimit:
                 break

--- a/tests/functional/processes/ingest/test_doab_process.py
+++ b/tests/functional/processes/ingest/test_doab_process.py
@@ -3,7 +3,7 @@ from .assert_ingested_records import assert_ingested_records
 
 
 def test_doab_process():
-    doab_process = DOABProcess('complete', None, None, None, 5, None)
+    doab_process = DOABProcess('complete', None, None, None, 1, None)
 
     doab_process.runProcess()
 


### PR DESCRIPTION
## Description
- Sets functional doab test ingest limit to 1 for speed purposes
- Increments records processed by 1 instead of 100 inside the inner for loop

## Testing
`make functional`