### PR TITLE
NO-REF: Test that MET process saves manifest for each record 

### DIFF
--- a/model/__init__.py
+++ b/model/__init__.py
@@ -1,5 +1,5 @@
 from .postgres.base import Base, Core
-from .postgres.record import Record
+from .postgres.record import Record, Part
 from .postgres.work import Work
 from .postgres.edition import Edition
 from .postgres.item import Item

--- a/model/postgres/record.py
+++ b/model/postgres/record.py
@@ -90,7 +90,7 @@ class Record(Base, Core):
             yield attr, getattr(self, attr)
 
 
-    def get_parts(self):
+    def get_parts(self) -> list[Part]:
         parts = []
 
         for part in self.has_part:

--- a/model/postgres/record.py
+++ b/model/postgres/record.py
@@ -1,9 +1,37 @@
+from dataclasses import dataclass
 from sqlalchemy import Column, DateTime, Integer, Unicode, Boolean, Index
 from sqlalchemy.dialects.postgresql import ARRAY, UUID, ENUM
 from sqlalchemy.ext.hybrid import hybrid_property
 from model.utilities.extractDailyEdition import extract
+from typing import Optional
+from urllib.parse import urlparse
 
 from .base import Base, Core
+
+
+@dataclass
+class Part:
+    index: int
+    url: str
+    source: str
+    file_type: str
+    flags: dict
+
+    def get_file_bucket(self) -> Optional[str]:
+        parsed_url = urlparse(self.url)
+
+        if 's3' not in parsed_url.hostname:
+            return None
+        
+        return parsed_url.hostname.split('.')[0]
+
+    def get_file_key(self) -> Optional[str]:
+        parsed_url = urlparse(self.url)
+
+        if 's3' not in parsed_url.hostname:
+            return None
+        
+        return parsed_url.path[1:]
 
 
 class Record(Base, Core):
@@ -60,6 +88,17 @@ class Record(Base, Core):
     def __iter__(self):
         for attr in dir(self):
             yield attr, getattr(self, attr)
+
+
+    def get_parts(self):
+        parts = []
+
+        for part in self.has_part:
+            index, file_url, source, file_type, flags = part.split('|')
+
+            parts.append(Part(index, file_url, source, file_type, flags))
+
+        return parts
 
     @hybrid_property
     def has_version(self):

--- a/tests/functional/processes/ingest/test_met_process.py
+++ b/tests/functional/processes/ingest/test_met_process.py
@@ -1,17 +1,26 @@
 from processes import METProcess
 from .assert_ingested_records import assert_ingested_records
+from managers.s3 import S3Manager, S3Error
 
 
 def test_met_process():
+
     met_process = METProcess('complete', None, None, None, 5, None)
 
     met_process.runProcess()
-
     records = assert_ingested_records(source_name='met')
 
-    # assert that for each record there exists a PDF manifest in S3
     
-    # run the S3 process
+    s3_manager = S3Manager()
+    s3_manager.createS3Client() 
 
-    # assert that for each record, we have saved the PDF in S3
+    s3_bucket_name = 'drb-files-local'
+    for record in records:
+        pdf_key = f"manifests/{record.id}.pdf"
 
+        try:
+            s3_manager.getObjectFromBucket(pdf_key, s3_bucket_name)
+        except S3Error as e:
+            assert False, f"PDF manifest for record {record.id} does not exist in S3: {e.message}"
+        except Exception as e:
+            assert False, f"An error occurred while checking for the PDF manifest: {str(e)}"

--- a/tests/functional/processes/ingest/test_met_process.py
+++ b/tests/functional/processes/ingest/test_met_process.py
@@ -1,4 +1,3 @@
-from model import Part
 from processes import METProcess
 from .assert_ingested_records import assert_ingested_records
 from managers.s3 import S3Manager

--- a/tests/functional/processes/ingest/test_met_process.py
+++ b/tests/functional/processes/ingest/test_met_process.py
@@ -16,7 +16,7 @@ def test_met_process():
     for record in records:
         parts= record.get_parts()
 
-        manifest_part: Part = next(part for part in parts if part.file_type == 'application/webpub+json')
+        manifest_part = next(part for part in parts if part.file_type == 'application/webpub+json')
 
         manifest_head_response = s3_manager.s3Client.head_object(Key=manifest_part.get_file_key(), Bucket=manifest_part.get_file_bucket())
 

--- a/tests/functional/processes/ingest/test_met_process.py
+++ b/tests/functional/processes/ingest/test_met_process.py
@@ -9,7 +9,6 @@ def test_met_process():
 
     met_process.runProcess()
     records = assert_ingested_records(source_name='met')
-
     
     s3_manager = S3Manager()
     s3_manager.createS3Client() 

--- a/tests/functional/processes/ingest/test_met_process.py
+++ b/tests/functional/processes/ingest/test_met_process.py
@@ -14,7 +14,7 @@ def test_met_process():
     s3_manager.createS3Client() 
 
     for record in records:
-        parts = record.get_parts()
+        parts= record.get_parts()
 
         manifest_part: Part = next(part for part in parts if part.file_type == 'application/webpub+json')
 

--- a/tests/functional/processes/ingest/test_met_process.py
+++ b/tests/functional/processes/ingest/test_met_process.py
@@ -19,6 +19,6 @@ def test_met_process():
 
         manifest_part: Part = next(part for part in parts if part.file_type == 'application/webpub+json')
 
-        manifest = s3_manager.getObjectFromBucket(manifest_part.get_file_key(), manifest_part.get_file_bucket())
+        manifest_head_response = s3_manager.s3Client.head_object(Key=manifest_part.get_file_key(), Bucket=manifest_part.get_file_bucket())
 
-        assert manifest is not None
+        assert manifest_head_response is not None


### PR DESCRIPTION
## Description
- Tests that the MET Process saves manifest for each record
- Adds a Part dataclass to be able to get the manifest easier

## Testing
```
pytest tests/functional/processes/ingest/test_met_process.py -s
```