### PR TITLE
 NO-REF: Test DB connection in pytest fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,7 +40,7 @@ def db_manager():
         db_manager.session.execute(text('SELECT 1')) # Test the db connection
 
         yield db_manager
-    
+        
         db_manager.close_connection()
     except:
         yield None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,13 +38,12 @@ def db_manager():
     try:
         db_manager.createSession()
         db_manager.session.execute(text('SELECT 1')) # Test the db connection
+
+        yield db_manager
+    
+        db_manager.close_connection()
     except:
         yield None
-        return
-
-    yield db_manager
-    
-    db_manager.close_connection()
 
 
 @pytest.fixture(scope='module')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,7 +34,7 @@ def setup_env(pytestconfig, request):
 @pytest.fixture(scope='module')
 def db_manager():
     db_manager = DBManager()
-
+    
     try:
         db_manager.createSession()
         db_manager.session.execute(text('SELECT 1')) # Test the db connection

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,12 +2,15 @@ import os
 import pytest
 from datetime import datetime, timezone
 import json
+from sqlalchemy import text
 from uuid import uuid4
+
 from processes import ClusterProcess
 from model import Record, Item
 from logger import create_log
 from managers import DBManager
 from load_env import load_env_file
+
 
 logger = create_log(__name__)
 
@@ -27,19 +30,22 @@ def setup_env(pytestconfig, request):
     if not running_unit_tests and environment in ['local', 'local-qa', 'qa']:
         load_env_file(environment, file_string=f'config/{environment}.yaml')
 
+
 @pytest.fixture(scope='module')
 def db_manager():
     db_manager = DBManager()
-    
+
     try:
         db_manager.createSession()
-
-        yield db_manager
-        
-        db_manager.close_connection()
+        db_manager.session.execute(text('SELECT 1')) # Test the db connection
     except:
         yield None
+        return
+
+    yield db_manager
     
+    db_manager.close_connection()
+
 
 @pytest.fixture(scope='module')
 def seed_test_data(db_manager):


### PR DESCRIPTION
## Description
- Tests to ensure we can connect to the DB in the pytest fixture

## Testing
` pytest tests/integration/api/test_get_edition.py --env=local-qa`