### PR TITLE
NO-REF: Update GH Actions Cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,6 +39,7 @@ jobs:
             ${{ runner.os }}-
       - name: Install dependencies
         run: |
+          sudo apt-get update && sudo apt-get install -y build-essential cmake python3-dev
           python -m pip install --upgrade pip wheel
           pip install -r dev-requirements.txt
           pip install -r requirements.txt

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
         with:
           python-version: '3.9'
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,6 @@ jobs:
             ${{ runner.os }}-
       - name: Install dependencies
         run: |
-          sudo apt-get update && sudo apt-get install -y build-essential cmake python3-dev
           python -m pip install --upgrade pip wheel
           pip install -r dev-requirements.txt
           pip install -r requirements.txt

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,6 +37,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
             ${{ runner.os }}-
+      - name: Install GCC 12
+        run: |
+          sudo apt update
+          sudo apt install -y gcc-12 g++-12
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 60
+          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 60
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip wheel

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,9 +41,9 @@ jobs:
             ${{ runner.os }}-
       - name: Install dependencies
         run: |
+          sudo apt-get update && sudo apt-get install -y build-essential cmake python3-dev
           python -m pip install --upgrade pip wheel
           pip install -r dev-requirements.txt
-          pip install fasttext-wheel
           pip install -r requirements.txt
       - name: Run unit tests
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Python 3.9
         uses: actions/setup-python@v2
         with:
-          python-version: "3.9"
+          python-version: "3.11"
       - name: Cache dependencies
         uses: actions/cache@v4
         with:
@@ -41,10 +41,6 @@ jobs:
             ${{ runner.os }}-
       - name: Install dependencies
         run: |
-          sudo apt-get update && sudo apt-get install -y build-essential cmake python3-dev gcc make
-          pip install pybind11
-          pip install fasttext-wheel
-          pip install fasttext==0.9.2
           python -m pip install --upgrade pip wheel
           pip install -r dev-requirements.txt
           pip install -r requirements.txt

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update && sudo apt-get install -y build-essential cmake python3-dev
-          pip install fasttext-wheel
+          pip install pybind11
           python -m pip install --upgrade pip wheel
           pip install -r dev-requirements.txt
           pip install -r requirements.txt

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,9 +41,7 @@ jobs:
             ${{ runner.os }}-
       - name: Install dependencies
         run: |
-          sudo apt-get update && sudo apt-get install -y build-essential cmake python3-dev
-          pip install pybind11
-          pip install fasttext-wheel
+          pip install fasttext==0.9.2
           python -m pip install --upgrade pip wheel
           pip install -r dev-requirements.txt
           pip install -r requirements.txt

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install fasttext-wheel
-          pip install fasttext==0.9.2
+          pip install pybind fasttext==0.9.2
           python -m pip install --upgrade pip wheel
           pip install -r dev-requirements.txt
           pip install -r requirements.txt

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -42,8 +42,9 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update && sudo apt-get install -y build-essential cmake python3-dev gcc make
+          pip install pybind
           pip install fasttext-wheel
-          pip install pybind fasttext==0.9.2
+          pip install fasttext==0.9.2
           python -m pip install --upgrade pip wheel
           pip install -r dev-requirements.txt
           pip install -r requirements.txt

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,19 +3,19 @@ name: ETL Pipeline Tests (Pull Request)
 on:
   pull_request:
     types: [opened, synchronize]
-    paths:
-        - 'api/**'
-        - 'managers/**'
-        - 'mappings/**'
-        - 'model/**'
-        - 'processes/**'
-        - 'services/**'
-        - 'tests/**'
-        - 'utils/**'
-        - 'dev-requirements.txt'
-        - 'requirements.txt'
-        - 'main.py'
-        - 'Makefile' 
+    # paths:
+    #     - 'api/**'
+    #     - 'managers/**'
+    #     - 'mappings/**'
+    #     - 'model/**'
+    #     - 'processes/**'
+    #     - 'services/**'
+    #     - 'tests/**'
+    #     - 'utils/**'
+    #     - 'dev-requirements.txt'
+    #     - 'requirements.txt'
+    #     - 'main.py'
+    #     - 'Makefile' 
 
 jobs:
   test:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -43,6 +43,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip wheel
           pip install -r dev-requirements.txt
+          pip install fasttext-wheel
           pip install -r requirements.txt
       - name: Run unit tests
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update && sudo apt-get install -y build-essential cmake python3-dev gcc make
-          pip install pybind
+          pip install pybind11
           pip install fasttext-wheel
           pip install fasttext==0.9.2
           python -m pip install --upgrade pip wheel

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Python 3.9
         uses: actions/setup-python@v2
         with:
-          python-version: "3.11"
+          python-version: "3.9"
       - name: Cache dependencies
         uses: actions/cache@v4
         with:
@@ -41,7 +41,7 @@ jobs:
             ${{ runner.os }}-
       - name: Install dependencies
         run: |
-          echo "${{ gcc --version }}"
+          gcc --version
           python -m pip install --upgrade pip wheel
           pip install -r dev-requirements.txt
           pip install -r requirements.txt

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,7 +41,6 @@ jobs:
             ${{ runner.os }}-
       - name: Install dependencies
         run: |
-          sudo apt-get install -y gcc-c++
           python -m pip install --upgrade pip wheel
           pip install -r dev-requirements.txt
           pip install -r requirements.txt

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -39,6 +39,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
             ${{ runner.os }}-
+      - name: Install GCC 12
+        run: |
+          sudo apt update
+          sudo apt install -y gcc-12 g++-12
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 60
+          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 60
       - name: Install dependencies
         run: |
           gcc --version

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,6 +41,7 @@ jobs:
             ${{ runner.os }}-
       - name: Install dependencies
         run: |
+          sudo apt-get update && sudo apt-get install -y build-essential cmake python3-dev gcc make
           pip install fasttext-wheel
           pip install pybind fasttext==0.9.2
           python -m pip install --upgrade pip wheel

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,19 +3,19 @@ name: ETL Pipeline Tests (Pull Request)
 on:
   pull_request:
     types: [opened, synchronize]
-    # paths:
-    #     - 'api/**'
-    #     - 'managers/**'
-    #     - 'mappings/**'
-    #     - 'model/**'
-    #     - 'processes/**'
-    #     - 'services/**'
-    #     - 'tests/**'
-    #     - 'utils/**'
-    #     - 'dev-requirements.txt'
-    #     - 'requirements.txt'
-    #     - 'main.py'
-    #     - 'Makefile' 
+    paths:
+        - 'api/**'
+        - 'managers/**'
+        - 'mappings/**'
+        - 'model/**'
+        - 'processes/**'
+        - 'services/**'
+        - 'tests/**'
+        - 'utils/**'
+        - 'dev-requirements.txt'
+        - 'requirements.txt'
+        - 'main.py'
+        - 'Makefile' 
 
 jobs:
   test:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,8 +41,8 @@ jobs:
             ${{ runner.os }}-
       - name: Install dependencies
         run: |
-          python -m pip install fasttext-wheel
-          python -m pip install pybind fasttext==0.9.2
+          pip install fasttext-wheel
+          pip install pybind fasttext==0.9.2
           python -m pip install --upgrade pip wheel
           pip install -r dev-requirements.txt
           pip install -r requirements.txt

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,6 +41,7 @@ jobs:
             ${{ runner.os }}-
       - name: Install dependencies
         run: |
+          echo "${{ gcc --version }}"
           python -m pip install --upgrade pip wheel
           pip install -r dev-requirements.txt
           pip install -r requirements.txt

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -43,6 +43,7 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get install -y build-essential cmake python3-dev
           pip install pybind11
+          pip install fasttext-wheel
           python -m pip install --upgrade pip wheel
           pip install -r dev-requirements.txt
           pip install -r requirements.txt

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,7 +41,7 @@ jobs:
             ${{ runner.os }}-
       - name: Install dependencies
         run: |
-          sudo apt-get update && sudo apt-get install -y build-essential cmake python3-dev
+          pip install fasttext-wheel
           python -m pip install --upgrade pip wheel
           pip install -r dev-requirements.txt
           pip install -r requirements.txt

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,7 +41,7 @@ jobs:
             ${{ runner.os }}-
       - name: Install dependencies
         run: |
-          sudo apt-get install -y gcc
+          sudo apt-get install -y gcc-c++
           python -m pip install --upgrade pip wheel
           pip install -r dev-requirements.txt
           pip install -r requirements.txt

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,6 +41,7 @@ jobs:
             ${{ runner.os }}-
       - name: Install dependencies
         run: |
+          sudo apt-get update && sudo apt-get install -y build-essential cmake python3-dev
           pip install fasttext-wheel
           python -m pip install --upgrade pip wheel
           pip install -r dev-requirements.txt

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,7 +32,7 @@ jobs:
         with:
           python-version: "3.9"
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,6 +41,7 @@ jobs:
             ${{ runner.os }}-
       - name: Install dependencies
         run: |
+          pip install fasttext-wheel
           pip install fasttext==0.9.2
           python -m pip install --upgrade pip wheel
           pip install -r dev-requirements.txt

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,6 +41,7 @@ jobs:
             ${{ runner.os }}-
       - name: Install dependencies
         run: |
+          sudo apt-get install -y gcc
           python -m pip install --upgrade pip wheel
           pip install -r dev-requirements.txt
           pip install -r requirements.txt

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,8 +41,8 @@ jobs:
             ${{ runner.os }}-
       - name: Install dependencies
         run: |
-          pip install fasttext-wheel
-          pip install pybind fasttext==0.9.2
+          python -m pip install fasttext-wheel
+          python -m pip install pybind fasttext==0.9.2
           python -m pip install --upgrade pip wheel
           pip install -r dev-requirements.txt
           pip install -r requirements.txt

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -47,7 +47,6 @@ jobs:
           sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 60
       - name: Install dependencies
         run: |
-          gcc --version
           python -m pip install --upgrade pip wheel
           pip install -r dev-requirements.txt
           pip install -r requirements.txt


### PR DESCRIPTION
## Description
- actions/cache@v2 is deprecated as of February 1st, 2025
- upgrades to v4