### PR TITLE
NO-REF: Update DOABProcess to use RecordBuffer

### DIFF
--- a/processes/ingest/doab.py
+++ b/processes/ingest/doab.py
@@ -66,6 +66,8 @@ class DOABProcess():
         except Exception as e:
             logger.exception('Failed to run DOAB process')
             raise e
+        finally:
+            self.db_manager.close_connection()
 
     def manage_links(self, record):
         linkManager = DOABLinkManager(record.record)

--- a/processes/ingest/doab.py
+++ b/processes/ingest/doab.py
@@ -1,19 +1,26 @@
 import os
 from services import DSpaceService
-from ..core import CoreProcess
 from logger import create_log
 from mappings.doab import DOABMapping
-from managers import DOABLinkManager, S3Manager, RabbitMQManager
+from managers import DBManager, DOABLinkManager, S3Manager, RabbitMQManager
 from model import get_file_message
+from .record_buffer import RecordBuffer
 
 logger = create_log(__name__)
 
-class DOABProcess(CoreProcess):
+class DOABProcess():
     DOAB_BASE_URL = 'https://directory.doabooks.org/oai/request?'
     DOAB_IDENTIFIER = 'oai:directory.doabooks.org'
 
     def __init__(self, *args):
-        super(DOABProcess, self).__init__(*args[:4])
+        self.process = args[0]
+        self.ingest_period = args[2]
+        self.single_record = args[3]
+
+        self.db_manager = DBManager()
+        self.db_manager.createSession()
+
+        self.record_buffer = RecordBuffer(self.db_manager)
 
         self.s3_manager = S3Manager()
         self.s3_manager.createS3Client()
@@ -34,9 +41,6 @@ class DOABProcess(CoreProcess):
 
     def runProcess(self):
         try:
-            self.generateEngine()
-            self.createSession()
-
             records = []
 
             if self.process == 'daily':
@@ -44,25 +48,24 @@ class DOABProcess(CoreProcess):
             elif self.process == 'complete':
                 records = self.dspace_service.get_records(full_import=True, offset=self.offset, limit=self.limit)
             elif self.process == 'custom':
-                records = self.dspace_service.get_records(start_timestamp=self.ingestPeriod, offset=self.offset, limit=self.limit)
-            elif self.singleRecord:
-                record = self.dspace_service.get_single_record(record_id=self.singleRecord, source_identifier=self.DOAB_IDENTIFIER)
+                records = self.dspace_service.get_records(start_timestamp=self.ingest_period, offset=self.offset, limit=self.limit)
+            elif self.single_record:
+                record = self.dspace_service.get_single_record(record_id=self.single_record, source_identifier=self.DOAB_IDENTIFIER)
                 self.manage_links(record)
+                self.record_buffer.add(record.record)
 
             if records:
                 for record in records:
                     self.manage_links(record)
+                    self.record_buffer.add(record.record)
+            
+            self.record_buffer.flush()
 
-            self.saveRecords()
-            self.commitChanges()
-
-            logger.info(f'Ingested {len(self.records) if records else 1} DOAB records')
+            logger.info(f'Ingested {self.record_buffer.ingest_count} DOAB records')
 
         except Exception as e:
             logger.exception('Failed to run DOAB process')
             raise e
-        finally:
-            self.close_connection()
 
     def manage_links(self, record):
         linkManager = DOABLinkManager(record.record)
@@ -77,5 +80,3 @@ class DOABProcess(CoreProcess):
         for epubLink in linkManager.ePubLinks:
             ePubPath, ePubURI = epubLink
             self.rabbitmq_manager.sendMessageToQueue(self.file_queue, self.file_route, get_file_message(ePubURI, ePubPath))
-
-        self.addDCDWToUpdateList(record)

--- a/tests/unit/processes/ingest/test_doab_process.py
+++ b/tests/unit/processes/ingest/test_doab_process.py
@@ -17,6 +17,11 @@ class TestDOABProcess:
     def test_instance(self, mocker):
         class TestDOAB(DOABProcess):
             def __init__(self):
+                self.process = 'test_process'
+                self.ingest_period = None
+                self.single_record = 0
+                self.db_manager = mocker.MagicMock()
+                self.record_buffer = mocker.MagicMock()
                 self.s3_manager = mocker.MagicMock(s3Client=mocker.MagicMock())
                 self.s3_bucket = 'test_aws_bucket'
                 self.file_queue = 'test_file_queue'
@@ -24,7 +29,6 @@ class TestDOABProcess:
                 self.rabbitmq_manager = mocker.MagicMock()
                 self.offset = 0
                 self.limit = 10000
-                self.ingestPeriod = None
                 self.records = []
                 self.dspace_service = mocker.MagicMock()
 
@@ -41,20 +45,8 @@ class TestDOABProcess:
     @pytest.fixture
     def mocks(self, mocker):
         return {
-            'generate_engine': mocker.patch.object(DOABProcess, 'generateEngine'),
-            'create_session': mocker.patch.object(DOABProcess, 'createSession'),
-            'save': mocker.patch.object(DOABProcess, 'saveRecords'),
-            'commit': mocker.patch.object(DOABProcess, 'commitChanges'),
-            'close': mocker.patch.object(DOABProcess, 'close_connection'),
             'manage_links': mocker.patch.object(DOABProcess, 'manage_links'),
         }
-
-    def assert_common_expectations(self, mocks):
-        mocks['generate_engine'].assert_called_once()
-        mocks['create_session'].assert_called_once()
-        mocks['save'].assert_called_once()
-        mocks['commit'].assert_called_once()
-        mocks['close'].assert_called_once()
 
     def test_runProcess_daily(self, test_instance: DOABProcess, record_mappings, mocks):
         test_instance.dspace_service.get_records.return_value = record_mappings
@@ -64,7 +56,6 @@ class TestDOABProcess:
 
         test_instance.dspace_service.get_records.assert_called_once_with(offset=0, limit=10000)
         assert mocks['manage_links'].call_count == len(record_mappings)
-        self.assert_common_expectations(mocks)
 
     def test_runProcess_complete(self, test_instance: DOABProcess, record_mappings, mocks):
         test_instance.dspace_service.get_records.return_value = record_mappings
@@ -74,7 +65,6 @@ class TestDOABProcess:
 
         test_instance.dspace_service.get_records.assert_called_once_with(full_import=True, offset=0, limit=10000)
         assert mocks['manage_links'].call_count == len(record_mappings)
-        self.assert_common_expectations(mocks)
 
     def test_runProcess_custom(self, test_instance: DOABProcess, record_mappings, mocks):
         test_instance.dspace_service.get_records.return_value = record_mappings
@@ -84,18 +74,16 @@ class TestDOABProcess:
 
         test_instance.dspace_service.get_records.assert_called_once_with(start_timestamp=None, offset=0, limit=10000)
         assert mocks['manage_links'].call_count == len(record_mappings)
-        self.assert_common_expectations(mocks)
 
     def test_runProcess_single(self, test_instance: DOABProcess, single_record_mapping, mocks):
         test_instance.dspace_service.get_single_record.return_value = single_record_mapping
         
         test_instance.process = 'single'
-        test_instance.singleRecord = 1
+        test_instance.single_record = 1
         test_instance.runProcess()
 
         test_instance.dspace_service.get_single_record.assert_called_once_with(record_id=1, source_identifier='oai:directory.doabooks.org')
         assert mocks['manage_links'].call_count == 1
-        self.assert_common_expectations(mocks)
 
 
     def test_manage_links_success(self, test_instance: DOABProcess, mocker):
@@ -108,8 +96,6 @@ class TestDOABProcess:
         mock_link_manager = mocker.patch('processes.ingest.doab.DOABLinkManager')
         mock_link_manager.return_value = mock_manager
 
-        process_mocks = mocker.patch.multiple(DOABProcess, addDCDWToUpdateList=mocker.DEFAULT)
-
         test_instance.manage_links(mock_record)
 
         mock_manager.parseLinks.assert_called_once()
@@ -119,4 +105,3 @@ class TestDOABProcess:
             test_instance.file_route, 
             get_file_message('epubURI', 'epubPath')
         )
-        process_mocks['addDCDWToUpdateList'].assert_called_once()


### PR DESCRIPTION
# Description
Updates the DOABProcess to use RecordBuffer instead of inheriting from the CoreProcess class.

# Testing
Ran unit, integration, and functional tests