### PR TITLE
Add concurrency in GHA

### DIFF
--- a/.github/workflows/full-ci-cd.yaml
+++ b/.github/workflows/full-ci-cd.yaml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   deploy_to_qa:
     uses: NYPL/drb-etl-pipeline/.github/workflows/build-qa.yaml@main

--- a/.github/workflows/full-ci-cd.yaml
+++ b/.github/workflows/full-ci-cd.yaml
@@ -5,8 +5,8 @@ on:
     branches: [main]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: continuous-deployment
+  cancel-in-progress: false
 
 jobs:
   deploy_to_qa:


### PR DESCRIPTION
This PR does the following

-     adds concurrency in ci/cd on workflow level
-     ensures one instance of the pipeline can run at a time for the main branch
-     new pushes will cancel any in-progress pipeline runs
-     production deployments will complete before new ones start
-     avoids race conditions in deployment processes 