### PR TITLE
NO-REF: Add book medium in Spanish and Portuguese

### DIFF
--- a/mappings/clacso.py
+++ b/mappings/clacso.py
@@ -93,7 +93,7 @@ class CLACSOMapping(BaseMapping):
         for medium in record.xpath('./dc:type/text()', namespaces=namespaces):
             medium_value = medium.split('/')[-1].lower()
             
-            if medium_value == 'book':
+            if medium_value == 'book' or medium_value == 'libro' or medium_value == 'livro':
                 return medium_value
 
     def _get_identifiers(self, record, namespaces):


### PR DESCRIPTION
This hotfix adds the Spanish and Portuguese word for 'book' as one of the possible medium types that a CLACSO record mapping should have.