### PR TITLE
NO-REF: Reverting back to CLACSO download only

### DIFF
--- a/processes/ingest/clacso.py
+++ b/processes/ingest/clacso.py
@@ -82,7 +82,7 @@ class CLACSOProcess():
                     url=manifest_uri,
                     source=source,
                     file_type='application/webpub+json',
-                    flags=json.dumps(dataclasses.asdict(FileFlags(reader=True)))
+                    flags=json.dumps(dataclasses.asdict(FileFlags()))
                 ).to_string()
 
                 record.has_part.insert(0, link_string)


### PR DESCRIPTION
## Description
- Reverting back to CLACSO download only flags
- We will circle back if we have time this quarter to see if we can improve the reader performance and ensure we are able to proxy or download the files