### PR TITLE
SFR-2537 Pointing the QA stack to the new QA database

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -55,7 +55,7 @@ jobs:
           make unit
       - name: Start Docker containers
         run: |
-          docker compose up
+          docker compose up -d
       - name: Wait for docker containers to be ready
         run: |
           echo "Waiting for docker container..."

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -55,7 +55,7 @@ jobs:
           make unit
       - name: Start Docker containers
         run: |
-          docker compose up -d
+          docker compose up
       - name: Wait for docker containers to be ready
         run: |
           echo "Waiting for docker container..."

--- a/config/qa.yaml
+++ b/config/qa.yaml
@@ -5,7 +5,7 @@ LOG_LEVEL: info
 
 # POSTGRES CONNECTION DETAILS
 # POSTGRES_USER, POSTGRES_PSWD, POSTGRES_ADMIN_USER and POSTGRES_ADMIN_PSWD must be configured in secrets file
-POSTGRES_HOST: sfr-new-metadata-production-cluster.cluster-cvy7z512hcjg.us-east-1.rds.amazonaws.com
+POSTGRES_HOST: sfr-new-metadata-qa-cluster.cluster-cvy7z512hcjg.us-east-1.rds.amazonaws.com
 POSTGRES_NAME: dcdw_qa
 POSTGRES_PORT: '5432'
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     container_name: drb_local_db
     volumes:
       - drb_local_dbdata:/var/lib/postgresql/data
-    image: postgres:13.8
+    image: postgres:16.3
     ports:
       - 5432:5432
     environment:

--- a/managers/oclc_catalog.py
+++ b/managers/oclc_catalog.py
@@ -17,7 +17,6 @@ class OCLCCatalogManager:
     LIMIT = 50
     MAX_NUMBER_OF_RECORDS = 100
     BEST_MATCH = 'bestMatch'
-    OK_STATUS_CODES = [200, 206]
 
     def query_catalog(self, oclc_no):
         catalog_query = self.METADATA_BIB_URL.format(oclc_no)
@@ -101,11 +100,9 @@ class OCLCCatalogManager:
                 }
             )
 
-            status_code = other_editions_response.status_code
-
-            if other_editions_response.status_code not in self.OK_STATUS_CODES:
+            if not other_editions_response.ok:
                 logger.warning(
-                    f'OCLC other editions request for OCLC number {oclc_number} failed with status: {status_code} '
+                    f'OCLC other editions request for OCLC number {oclc_number} failed with status: {other_editions_response.status_code} '
                     f'due to: {self._get_error_detail(other_editions_response)}'
                 )
 
@@ -166,11 +163,9 @@ class OCLCCatalogManager:
                 }
             )
 
-            status_code = bibs_response.status_code
-
-            if status_code not in self.OK_STATUS_CODES:
+            if not bibs_response.ok:
                 logger.warning(
-                    f'OCLC search bibs request for query {query} failed with status: {status_code} '
+                    f'OCLC search bibs request for query {query} failed with status: {bibs_response.status_code} '
                     f'due to: {self._get_error_detail(bibs_response)}'
                 )
                 

--- a/managers/oclc_catalog.py
+++ b/managers/oclc_catalog.py
@@ -17,6 +17,7 @@ class OCLCCatalogManager:
     LIMIT = 50
     MAX_NUMBER_OF_RECORDS = 100
     BEST_MATCH = 'bestMatch'
+    OK_STATUS_CODES = [200, 206]
 
     def query_catalog(self, oclc_no):
         catalog_query = self.METADATA_BIB_URL.format(oclc_no)
@@ -102,7 +103,7 @@ class OCLCCatalogManager:
 
             status_code = other_editions_response.status_code
 
-            if other_editions_response.status_code != 200:
+            if other_editions_response.status_code not in self.OK_STATUS_CODES:
                 logger.warning(
                     f'OCLC other editions request for OCLC number {oclc_number} failed with status: {status_code} '
                     f'due to: {self._get_error_detail(other_editions_response)}'
@@ -167,7 +168,7 @@ class OCLCCatalogManager:
 
             status_code = bibs_response.status_code
 
-            if status_code != 200:
+            if status_code not in self.OK_STATUS_CODES:
                 logger.warning(
                     f'OCLC search bibs request for query {query} failed with status: {status_code} '
                     f'due to: {self._get_error_detail(bibs_response)}'

--- a/processes/local_development/local_development_setup.py
+++ b/processes/local_development/local_development_setup.py
@@ -71,7 +71,7 @@ class LocalDevelopmentSetupProcess(CoreProcess):
         database = os.environ.get('POSTGRES_NAME')
 
         try:
-            db_connection.execute(sa.text(f'CREATE USER {postgres_user} WITH PASSWORD {postgres_pswd}'))            
+            db_connection.execute(sa.text(f"CREATE USER {postgres_user} WITH PASSWORD '{postgres_pswd}'"))            
         except ProgrammingError:
             pass
         except Exception as e:

--- a/processes/local_development/local_development_setup.py
+++ b/processes/local_development/local_development_setup.py
@@ -25,11 +25,7 @@ class LocalDevelopmentSetupProcess(CoreProcess):
             self.generateEngine()
             self.createSession()
             
-            try:
-                self.initializeDatabase()
-            except Exception as e:
-                logger.error(e)
-                raise e
+            self.initializeDatabase()
 
             self.elastic_search_manager.createElasticConnection()
             self.wait_for_elastic_search()

--- a/processes/local_development/local_development_setup.py
+++ b/processes/local_development/local_development_setup.py
@@ -24,8 +24,12 @@ class LocalDevelopmentSetupProcess(CoreProcess):
 
             self.generateEngine()
             self.createSession()
-
-            self.initializeDatabase()
+            
+            try:
+                self.initializeDatabase()
+            except Exception as e:
+                logger.error(e)
+                raise e
 
             self.elastic_search_manager.createElasticConnection()
             self.wait_for_elastic_search()
@@ -66,24 +70,20 @@ class LocalDevelopmentSetupProcess(CoreProcess):
             raise e
 
     def create_database_user(self, db_connection):
+        postgres_user = os.environ.get('POSTGRES_USER')
+        postgres_pswd = os.environ.get('POSTGRES_PSWD')
+        database = os.environ.get('POSTGRES_NAME')
+
         try:
-            db_connection.execute(
-                sa.text(
-                    f"CREATE USER {os.environ['POSTGRES_USER']} "
-                    f"WITH PASSWORD '{os.environ['POSTGRES_PSWD']}'",
-                ),
-            )
-            db_connection.execute(
-                sa.text(
-                    f"GRANT ALL PRIVILEGES ON DATABASE {os.environ['POSTGRES_NAME']} "
-                    f"TO {os.environ['POSTGRES_USER']}",
-                ),
-            )
+            db_connection.execute(sa.text(f'CREATE USER {postgres_user} WITH PASSWORD {postgres_pswd}'))            
         except ProgrammingError:
             pass
         except Exception as e:
             logger.exception('Failed to create database user')
             raise e
+        
+        db_connection.execute(sa.text(f'GRANT ALL ON DATABASE {database} TO {postgres_user}'))
+        db_connection.execute(sa.text(f'ALTER DATABASE {database} OWNER TO {postgres_user}'))
         
     def wait_for_elastic_search(self):
         increment = 5

--- a/tests/functional/processes/frbr/test_frbr_process.py
+++ b/tests/functional/processes/frbr/test_frbr_process.py
@@ -1,4 +1,3 @@
-from datetime import datetime, timedelta, timezone
 from processes import ClassifyProcess, CatalogProcess
 from managers import RedisManager
 from model import Record
@@ -10,12 +9,7 @@ def test_frbr_process(db_manager, unfrbrized_record_uuid, unfrbrized_title):
     redis_manager.createRedisClient()
     redis_manager.clear_cache()
 
-    classify_process = ClassifyProcess(
-        'custom',
-        None,
-        datetime.now(timezone.utc) - timedelta(minutes=5),
-        None
-    )
+    classify_process = ClassifyProcess(None, None, None, unfrbrized_record_uuid)
 
     classify_process.runProcess()
 


### PR DESCRIPTION
## Description
- https://newyorkpubliclibrary.atlassian.net/browse/DOPS-1112 Devops needs to upgrade the postgres version to 16 since 12 is no longer supported. 
- We decided it was time to create a separate database cluster altogether for QA 
- This change points the QA stack to the new database cluster via modifying the config. 
- Once we have tested that everything looks good in QA we can upgrade the production database cluster version. 

## Local Dev Changes
- The postgres volume's files will no longer be compatible with the postgres docker container
- Each developer must delete their volume and rerun the local developer setup process to reinitialize the database. 

## Testing 
`python main.py -p CLACSOProcess -e local-qa -i complete -l 1`