### PR TITLE
SFR-2533: Update oclc cat api param to narrow results

### DIFF
--- a/managers/oclc_catalog.py
+++ b/managers/oclc_catalog.py
@@ -13,7 +13,7 @@ logger = create_log(__name__)
 class OCLCCatalogManager:
     METADATA_BIB_URL = 'https://metadata.api.oclc.org/worldcat/manage/bibs/{}'
     OCLC_SEARCH_URL = 'https://americas.discovery.api.oclc.org/worldcat/search/v2/'
-    ITEM_TYPES = ['archv', 'audiobook', 'book', 'encyc', 'jrnl']
+    ITEM_SUB_TYPE = ['book-digital']
     LIMIT = 50
     MAX_NUMBER_OF_RECORDS = 100
     BEST_MATCH = 'bestMatch'
@@ -96,7 +96,7 @@ class OCLCCatalogManager:
                     'offset': offset or None,
                     'limit': self.LIMIT,
                     'orderBy': self.BEST_MATCH,
-                    'itemTypes': self.ITEM_TYPES
+                    'itemSubType': self.ITEM_SUB_TYPE
                 }
             )
 
@@ -161,7 +161,7 @@ class OCLCCatalogManager:
                     'offset': offset or None,
                     'limit': self.LIMIT,
                     'orderBy': self.BEST_MATCH,
-                    'itemType': self.ITEM_TYPES
+                    'itemSubType': self.ITEM_SUB_TYPE
                 }
             )
 


### PR DESCRIPTION
# Description

Updates the OCLC catalog API params to narrow down results only to include digital books.

Reasoning for replacing `itemType` with `itemSubType`:

When both `itemType` and `itemSubType` parameters are provided in the query, the `itemType` will take precedence and limit the results based on the top-level facet type (book). As a result, the `itemSubType` will not affect the results, as it is overridden by the `itemType`. The `itemSubType` of 'book-digital' refines the results within the 'book' category.

This reduced the results of the API call in the `test_frbr_process.py` catalog process test from 8 records to 3.

# Testing 
make functional
