### PR TITLE
SFR-2537: Switching back to production cluster

### DIFF
--- a/config/qa.yaml
+++ b/config/qa.yaml
@@ -5,7 +5,7 @@ LOG_LEVEL: info
 
 # POSTGRES CONNECTION DETAILS
 # POSTGRES_USER, POSTGRES_PSWD, POSTGRES_ADMIN_USER and POSTGRES_ADMIN_PSWD must be configured in secrets file
-POSTGRES_HOST: sfr-new-metadata-qa-cluster.cluster-cvy7z512hcjg.us-east-1.rds.amazonaws.com
+POSTGRES_HOST: sfr-new-metadata-production-cluster.cluster-cvy7z512hcjg.us-east-1.rds.amazonaws.com
 POSTGRES_NAME: dcdw_qa
 POSTGRES_PORT: '5432'
 


### PR DESCRIPTION
## Description
- Integration tests are not passing
- Switching back to the production cluster in QA to roll forward


