### PR TITLE
SFR-2539: Adding issued date when determining publication date

### DIFF
--- a/managers/kMeans.py
+++ b/managers/kMeans.py
@@ -175,7 +175,7 @@ class KMeansManager:
             except (ValueError, AttributeError, IndexError) as e:
                 logger.warning('Unable to parse date {}'.format(d))
 
-        for datePref in ['copyright_date', 'publication_date']:
+        for datePref in ['copyright_date', 'publication_date', 'issued']:
             if datePref in pubYears.keys():
                 return pubYears[datePref]
         


### PR DESCRIPTION
## Description 
- Some records, such as Gutenberg, will only have the issued date. 
- This change adds the issued date when determining the publication date during clustering. 