### PR TITLE
SFR-2525: Fix Gutenberg rate limit setting

### DIFF
--- a/processes/ingest/gutenberg.py
+++ b/processes/ingest/gutenberg.py
@@ -57,7 +57,7 @@ class GutenbergProcess():
             self.store_epubs(record_mapping)
 
             try:
-                self.add_cover(record_mapping, record_mapping.yaml_file)
+                self.add_cover(record_mapping)
             except Exception:
                 logger.warning(f'Unable to store cover for {record_mapping.record.source_id}')
 
@@ -110,7 +110,12 @@ class GutenbergProcess():
 
         gutenberg_record.record.has_part = epub_parts
 
-    def add_cover(self, gutenberg_record: GutenbergMapping, yaml_file):
+    def add_cover(self, gutenberg_record: GutenbergMapping):
+        yaml_file = gutenberg_record.yaml_file
+
+        if yaml_file is None:
+            return
+
         for cover_data in yaml_file.get('covers', []):
             if cover_data.get('cover_type') == 'generated': 
                 continue

--- a/services/sources/gutenberg_service.py
+++ b/services/sources/gutenberg_service.py
@@ -195,7 +195,7 @@ class GutenbergService(SourceService):
     def wait_until_request_limit_reset(self):
         wait_duration = max(0, self.request_limit_reset - int(time.time()))
 
-        if os.environ.get('ENVIRONMENT') in [ 'qa', 'production']:
+        if os.environ.get('ENVIRONMENT') in ['qa', 'production']:
             logger.info(f'Waiting {wait_duration} seconds to continue Gutenberg ingest')
             time.sleep(wait_duration)
         else:

--- a/services/sources/gutenberg_service.py
+++ b/services/sources/gutenberg_service.py
@@ -145,26 +145,29 @@ class GutenbergService(SourceService):
         rdf_data = repository.get('rdf', {})
         yaml_data = repository.get('yaml', {})
 
-        if rdf_data is None or yaml_data is None:
+        if rdf_data is None:
             return None
         
         rdf_text = rdf_data.get('text') if rdf_data else None
         yaml_text = yaml_data.get('text') if yaml_data else None
 
-        if rdf_text is None or yaml_data is None:
+        if rdf_text is None:
             return None
         
         try:
-            return (self.parse_rdf(rdfText=rdf_text), self.parse_yaml(yamlText=yaml_text))
+            return (self.parse_rdf(rdf_text=rdf_text), self.parse_yaml(yaml_text=yaml_text))
         except (TypeError, etree.XMLSyntaxError):
             logger.error(f'Unable to load metadata files for work {work_id}')
             return None
 
-    def parse_rdf(self, rdfText):
-        return etree.fromstring(rdfText.encode('utf-8'))
+    def parse_rdf(self, rdf_text: str):
+        return etree.fromstring(rdf_text.encode('utf-8'))
 
-    def parse_yaml(self, yamlText):
-        return yaml.full_load(yamlText)
+    def parse_yaml(self, yaml_text: Optional[str]):
+        if yaml_text is None:
+            return None
+
+        return yaml.full_load(yaml_text)
 
     def query_graphql(self, query):
         if self.requests_remaining == 0:
@@ -186,8 +189,8 @@ class GutenbergService(SourceService):
             raise e
         
     def set_rate_limit_fields(self, graphql_response):
-        self.requests_remaining = int(graphql_response.headers.get('X-RateLimit-Remaining'))
-        self.request_limit_reset = int(graphql_response.headers.get('X-RateLimit-Reset'))
+        self.requests_remaining = int(graphql_response.headers.get('X-RateLimit-Remaining', 1))
+        self.request_limit_reset = int(graphql_response.headers.get('X-RateLimit-Reset', time.time() + 3600))
 
     def wait_until_request_limit_reset(self):
         wait_duration = max(0, self.request_limit_reset - int(time.time()))


### PR DESCRIPTION
## Description
- The rate limit headers are sometimes not present, so defaulting to 1 request left and request at to 1 hour in the future
- Also allowing for us to handle records that don't have any yaml text files to add the cover

## Testing 
`python main.py -p GutenbergProcess -e local -i complete -l 100`