### PR TITLE
NO-REF: Removing CoreProcess from PublisherBacklistProcess

### DIFF
--- a/processes/ingest/publisher_backlist.py
+++ b/processes/ingest/publisher_backlist.py
@@ -42,7 +42,7 @@ class PublisherBacklistProcess():
             
             self.record_buffer.flush()
 
-            logger.info(f'Ingested {len(self.record_buffer.ingest_count)} Publisher Backlist records')
+            logger.info(f'Ingested {self.record_buffer.ingest_count} Publisher Backlist records')
         except Exception as e:
             logger.exception('Failed to run Publisher Backlist process')
             raise e   

--- a/processes/ingest/publisher_backlist.py
+++ b/processes/ingest/publisher_backlist.py
@@ -1,18 +1,25 @@
 import os
 from services import PublisherBacklistService
 
-from ..core import CoreProcess
 from logger import create_log
-from managers import S3Manager
+from managers import DBManager, S3Manager
+from ..record_buffer import RecordBuffer
+from .. import utils
 
 logger = create_log(__name__)
 
-class PublisherBacklistProcess(CoreProcess):
+class PublisherBacklistProcess():
     def __init__(self, *args):
-        super(PublisherBacklistProcess, self).__init__(*args[:4])
+        self.process = args[1]
+        self.ingest_period = args[2]
 
         self.limit = (len(args) >= 5 and args[4] and int(args[4]) <= 100) or None
         self.offset = (len(args) >= 6 and args[5]) or None
+
+        self.db_manager = DBManager()
+        self.db_manager.createSession()
+
+        self.record_buffer = RecordBuffer(db_manager=self.db_manager)
 
         self.s3_bucket = os.environ['FILE_BUCKET']
         self.s3_manager = S3Manager()
@@ -21,30 +28,23 @@ class PublisherBacklistProcess(CoreProcess):
         
     def runProcess(self):
         try:
-            self.generateEngine()
-            self.createSession()
-
+            start_datetime = utils.get_start_datetime(process_type=self.process, ingest_period=self.ingest_period)
             self.publisher_backlist_service.delete_records()
 
-            if self.process == 'daily':
-                records = self.publisher_backlist_service.get_records(offset=self.offset, limit=self.limit)
-            elif self.process == 'complete':
-                records = self.publisher_backlist_service.get_records(full_import=True)
-            elif self.process == 'custom':
-                records = self.publisher_backlist_service.get_records(start_timestamp=self.ingestPeriod, offset=self.offset, limit=self.limit)
-            else: 
-                logger.warning(f'Unknown Publisher Backlist ingestion process type {self.process}')
-                return
-            for record in records:
-                self.addDCDWToUpdateList(record)
+            records = self.publisher_backlist_service.get_records(
+                start_timestamp=start_datetime,
+                offset=self.offset,
+                limit=self.limit
+            )
             
-            self.saveRecords()
-            self.commitChanges()
+            for record_mapping in records:
+                self.record_buffer.add(record_mapping.record)
+            
+            self.record_buffer.flush()
 
             logger.info(f'Ingested {len(self.records)} Publisher Backlist records')
-
         except Exception as e:
             logger.exception('Failed to run Publisher Backlist process')
             raise e   
         finally:
-            self.close_connection()
+            self.db_manager.close_connection()

--- a/processes/ingest/publisher_backlist.py
+++ b/processes/ingest/publisher_backlist.py
@@ -10,7 +10,7 @@ logger = create_log(__name__)
 
 class PublisherBacklistProcess():
     def __init__(self, *args):
-        self.process = args[1]
+        self.process = args[0]
         self.ingest_period = args[2]
 
         self.limit = (len(args) >= 5 and args[4] and int(args[4]) <= 100) or None
@@ -42,7 +42,7 @@ class PublisherBacklistProcess():
             
             self.record_buffer.flush()
 
-            logger.info(f'Ingested {len(self.records)} Publisher Backlist records')
+            logger.info(f'Ingested {len(self.record_buffer.ingest_count)} Publisher Backlist records')
         except Exception as e:
             logger.exception('Failed to run Publisher Backlist process')
             raise e   

--- a/tests/unit/processes/ingest/test_pub_backlist_process.py
+++ b/tests/unit/processes/ingest/test_pub_backlist_process.py
@@ -1,4 +1,5 @@
 import pytest
+from unittest.mock import ANY
 
 from tests.helper import TestHelpers
 from processes import PublisherBacklistProcess
@@ -18,6 +19,9 @@ class TestPublisherBacklistProcess:
         class TestPublisherBacklistProcess(PublisherBacklistProcess):
             def __init__(self, *args):
                 self.publisher_backlist_service = mocker.MagicMock()
+                self.db_manager = mocker.MagicMock()
+                self.record_buffer = mocker.MagicMock()
+                self.ingest_period = None
                 self.offset = None
                 self.limit = None
                 self.ingestPeriod = None
@@ -26,71 +30,40 @@ class TestPublisherBacklistProcess:
         return TestPublisherBacklistProcess('TestProcess', 'testFile', 'testDate')
     
     @pytest.fixture
-    def mocks(self, mocker):
-        return {
-            'generate_engine': mocker.patch.object(PublisherBacklistProcess, 'generateEngine'),
-            'create_session': mocker.patch.object(PublisherBacklistProcess, 'createSession'),
-            'save': mocker.patch.object(PublisherBacklistProcess, 'saveRecords'),
-            'commit': mocker.patch.object(PublisherBacklistProcess, 'commitChanges'),
-            'close': mocker.patch.object(PublisherBacklistProcess, 'close_connection'),
-            'add_record': mocker.patch.object(PublisherBacklistProcess, 'addDCDWToUpdateList')
-        }
-    
-    @pytest.fixture
     def record_mappings(self, mocker):
         return [mocker.MagicMock()]
     
-    def assert_common_expectations(self, mocks):
-        mocks['generate_engine'].assert_called_once()
-        mocks['create_session'].assert_called_once()
-        mocks['save'].assert_called_once()
-        mocks['commit'].assert_called_once()
-        mocks['close'].assert_called_once()
-    
-    def test_runProcess_daily(self, test_instance: PublisherBacklistProcess, record_mappings, mocks):
+    def test_runProcess_daily(self, test_instance: PublisherBacklistProcess, record_mappings):
         test_instance.publisher_backlist_service.get_records.return_value = record_mappings
 
         test_instance.process = 'daily'
         test_instance.runProcess()
 
-        test_instance.publisher_backlist_service.get_records.assert_called_once_with(offset=None, limit=None)
-        self.assert_common_expectations(mocks)
-        assert mocks['add_record'].call_count == len(record_mappings)
+        test_instance.publisher_backlist_service.get_records.assert_called_once_with(start_timestamp=ANY, offset=None, limit=None)
+        test_instance.record_buffer.add.call_count = len(record_mappings)
+        test_instance.db_manager.close_connection.assert_called_once()
 
-    def test_runProcess_complete(self, test_instance: PublisherBacklistProcess, record_mappings, mocks):
+    def test_runProcess_complete(self, test_instance: PublisherBacklistProcess, record_mappings):
         test_instance.publisher_backlist_service.get_records.return_value = record_mappings
 
         test_instance.process = 'complete'
         test_instance.runProcess()
 
-        test_instance.publisher_backlist_service.get_records.assert_called_once_with(full_import=True)
-        self.assert_common_expectations(mocks)
-        assert mocks['add_record'].call_count == len(record_mappings)
+        test_instance.publisher_backlist_service.get_records.assert_called_once_with(start_timestamp=None, offset=None, limit=None)
+        test_instance.record_buffer.add.call_count = len(record_mappings)
+        test_instance.db_manager.close_connection.assert_called_once()
 
-    def test_runProcess_custom(self, test_instance: PublisherBacklistProcess, record_mappings, mocks):
+    def test_runProcess_custom(self, test_instance: PublisherBacklistProcess, record_mappings):
         test_instance.publisher_backlist_service.get_records.return_value = record_mappings
         
         test_instance.process = 'custom'
         test_instance.runProcess()
 
         test_instance.publisher_backlist_service.get_records.assert_called_once_with(start_timestamp=None, offset=None, limit=None)
-        self.assert_common_expectations(mocks)
-        assert mocks['add_record'].call_count == len(record_mappings)
+        test_instance.record_buffer.add.call_count = len(record_mappings)
+        test_instance.db_manager.close_connection.assert_called_once()
 
-    def test_runProcess_unknown(self, test_instance: PublisherBacklistProcess, mocks):
-        test_instance.process = 'unknown'
-        test_instance.runProcess()
-        
-        test_instance.publisher_backlist_service.get_records.assert_not_called()
-
-        mocks['generate_engine'].assert_called_once()
-        mocks['create_session'].assert_called_once()
-        mocks['commit'].assert_not_called()
-        mocks['save'].assert_not_called()
-        mocks['add_record'].assert_not_called()
-        mocks['close'].assert_called_once()
-
-    def test_runProcess_error(self, test_instance: PublisherBacklistProcess, mocks):
+    def test_runProcess_error(self, test_instance: PublisherBacklistProcess):
         test_instance.publisher_backlist_service.get_records.side_effect = Exception()
 
         test_instance.process = 'daily'
@@ -98,9 +71,5 @@ class TestPublisherBacklistProcess:
         with pytest.raises(Exception):
             test_instance.runProcess()
 
-        mocks['generate_engine'].assert_called_once()
-        mocks['create_session'].assert_called_once()
-        mocks['commit'].assert_not_called()
-        mocks['save'].assert_not_called()
-        mocks['add_record'].assert_not_called()
-        mocks['close'].assert_called_once()
+        test_instance.db_manager.close_connection.assert_called_once()
+        test_instance.record_buffer.add.assert_not_called()


### PR DESCRIPTION
## Description
- Removes the CoreProcess
- Uses record buffer
- Removes full import field and instead relies on start_datetime!

## Testing 
`make unit`