### PR TITLE
SFR-2562: Creating separate session for each record pipeline message

### DIFF
--- a/processes/record_clusterer.py
+++ b/processes/record_clusterer.py
@@ -29,7 +29,13 @@ class RecordClusterer:
         try:
             work, stale_work_ids, records = self._get_clustered_work_and_records(record)
             self._delete_stale_works(stale_work_ids)
-            self.db_manager.commitChanges()
+
+            try:
+                self.db_manager.commitChanges()
+            except Exception as e:
+                self.db_manager.session.rollback()
+                raise e
+            
             logger.info(f'Clustered record: {record}')
 
             self._update_elastic_search(work_to_index=work, works_to_delete=stale_work_ids)

--- a/processes/record_pipeline.py
+++ b/processes/record_pipeline.py
@@ -62,7 +62,7 @@ class RecordPipelineProcess:
             self.link_fulfiller.fulfill_records_links(clustered_records)
                 
             self.rabbitmq_manager.acknowledgeMessageProcessed(message_props.delivery_tag)
-        except Exception as e:
+        except Exception:
             logger.exception(f'Failed to process record with source_id: {source_id} and source: {source}')            
         finally:
             self.rabbitmq_manager.reject_message(delivery_tag=message_props.delivery_tag)

--- a/processes/record_pipeline.py
+++ b/processes/record_pipeline.py
@@ -16,8 +16,6 @@ class RecordPipelineProcess:
 
     def __init__(self, *args):
         self.db_manager = DBManager()
-        self.db_manager.generateEngine()
-        self.db_manager.createSession()
 
         self.record_queue = os.environ['RECORD_PIPELINE_QUEUE']
         self.record_route = os.environ['RECORD_PIPELINE_ROUTING_KEY']
@@ -42,11 +40,14 @@ class RecordPipelineProcess:
         except Exception:
             logger.exception('Failed to run record pipeline process')
         finally:
-            self.db_manager.close_connection()
             self.rabbitmq_manager.closeRabbitConnection()
+            if self.db_manager.engine: 
+                self.db_manager.engine.dispose()
     
     def _process_message(self, message):
         try:
+            self.db_manager.createSession()
+
             message_props, _, message_body = message
             source_id, source = self._parse_message(message_body=message_body)
 
@@ -61,9 +62,12 @@ class RecordPipelineProcess:
             self.link_fulfiller.fulfill_records_links(clustered_records)
                 
             self.rabbitmq_manager.acknowledgeMessageProcessed(message_props.delivery_tag)
-        except Exception:
+        except Exception as e:
             logger.exception(f'Failed to process record with source_id: {source_id} and source: {source}')            
+        finally:
             self.rabbitmq_manager.reject_message(delivery_tag=message_props.delivery_tag)
+            if self.db_manager.session: 
+                self.db_manager.session.close()
 
     def _parse_message(self, message_body) -> tuple:
         message = json.loads(message_body)


### PR DESCRIPTION
## Description
- Previous sessions were causing issues with subsequent db transactions. 
- Ensures that we rollback the changes if we fail to commit 
- Creates a new session per message and closes that session after
- Disposes the db engine after processing all messages 

## Testing
`make functional`