### PR TITLE
SFR-2563: Fix db mismatch issue

### DIFF
--- a/processes/record_pipeline.py
+++ b/processes/record_pipeline.py
@@ -63,9 +63,9 @@ class RecordPipelineProcess:
                 
             self.rabbitmq_manager.acknowledgeMessageProcessed(message_props.delivery_tag)
         except Exception:
-            logger.exception(f'Failed to process record with source_id: {source_id} and source: {source}')            
+            logger.exception(f'Failed to process record with source_id: {source_id} and source: {source}')
+            self.rabbitmq_manager.reject_message(delivery_tag=message_props.delivery_tag)         
         finally:
-            self.rabbitmq_manager.reject_message(delivery_tag=message_props.delivery_tag)
             if self.db_manager.session: 
                 self.db_manager.session.close()
 


### PR DESCRIPTION
# Description

- Fixes issue where the record fails to cluster due to stale data.
- Both `_create_work_from_editions` and `_delete_stale_works` may modify the same rows in the `Editons` or `Works` tables, so we need to commit after each transaction