### PR TITLE
NO-REF: Fixing Gutenberg service limit comparison bug

### DIFF
--- a/services/sources/gutenberg_service.py
+++ b/services/sources/gutenberg_service.py
@@ -73,7 +73,7 @@ class GutenbergService(SourceService):
                 else:
                     yield gutenberg_record
 
-            if current_position >= limit: 
+            if limit is not None and current_position >= limit: 
                 break
 
     def get_repositories(self, 


### PR DESCRIPTION
## Description
- There's a small Gutenberg service limit comparison bug when the limit is not set
- Just adding a check beforehand