### PR TITLE
NO-REF: Implement Schomburg ingest

### DIFF
--- a/api/utils.py
+++ b/api/utils.py
@@ -35,19 +35,20 @@ class APIUtils():
     }
 
     SOURCE_PRIORITY = {
-        'gutenberg': 1,
-        'doab': 2,
-        'loc': 3,
-        'muse': 4,
-        'met': 5,
-        'isac': 6,
-        'UofMichigan Backlist': 7,
-        'UofMichigan': 7,
-        'UofM': 7,
-        'UofSC': 8,
-        'hathitrust': 9,
-        'oclc': 10,
-        'nypl': 11
+        'SCH Collection/Hathi files': 1,
+        'gutenberg': 2,
+        'doab': 3,
+        'loc': 4,
+        'muse': 5,
+        'met': 6,
+        'isac': 7,
+        'UofMichigan Backlist': 8,
+        'UofMichigan': 8,
+        'UofM': 8,
+        'UofSC': 9,
+        'hathitrust': 10,
+        'oclc': 11,
+        'nypl': 12
     }
 
     DEFAULT_PRIORITY = 100

--- a/config/local.yaml
+++ b/config/local.yaml
@@ -56,3 +56,6 @@ DRB_API_HOST: http://localhost:5050
 DRB_API_URL: http://localhost:5050
 
 DEFAULT_COVER_URL: https://drb-files-qa.s3.amazonaws.com/covers/default/defaultCover.png
+
+#PDF Pipeline Creds
+PDF_BUCKET: pdf-pipeline-store-qa

--- a/mappings/publisher_backlist.py
+++ b/mappings/publisher_backlist.py
@@ -13,7 +13,8 @@ class PublisherBacklistMapping(JSONMapping):
             'publisher': ('Publisher (from Project)', '{0}||'),
             'identifiers': [
                 ('ISBN', '{0}|isbn'),
-                ('OCLC', '{0}|oclc')
+                ('OCLC', '{0}|oclc'),
+                ('Hathi ID', '{0}|hathi')
             ],
             'rights': ('DRB Rights Classification', '{0}||||'),
             'contributors': [('Contributors', '{0}|||contributor')],

--- a/services/sources/publisher_backlist_service.py
+++ b/services/sources/publisher_backlist_service.py
@@ -199,6 +199,7 @@ class PublisherBacklistService(SourceService):
                 try:
                     self.s3_manager.s3Client.head_object(Bucket=aws_file_bucket, Key=f'titles/publisher_backlist/Schomburg/{hathi_id}/{hathi_id}.pdf')
                 except Exception:
+                    logger.exception(f'PDF already exists at key: titles/publisher_backlist/Schomburg/{hathi_id}/{hathi_id}.pdf')
                     return None
                 
                 try:

--- a/services/sources/publisher_backlist_service.py
+++ b/services/sources/publisher_backlist_service.py
@@ -186,6 +186,7 @@ class PublisherBacklistService(SourceService):
     
     def download_file_from_location(self, record_metadata: dict, record_permissions: dict, record: Record) -> str:
         file_location = record_metadata.get('DRB_File Location')
+        aws_file_bucket = os.environ.get("FILE_BUCKET", "drb-files-local")
 
         if not file_location:
             hath_identifier = next((identifier for identifier in record.identifiers if identifier.endswith('hathi')), None)
@@ -205,15 +206,13 @@ class PublisherBacklistService(SourceService):
                 try:
                     s3.copy(
                         source_bucket_key,
-                        Bucket='drb-files-qa',
+                        Bucket=aws_file_bucket,
                         Key=f'titles/publisher_backlist/Schomburg/{hathi_id}/{hathi_id}.pdf'
                     )
                 except Exception:
                     logger.exception("Error during copy response")
 
-                # TODO - move converted PDFs over to drb-files S3 buckets
-                # TODO - ensure these files are publicly accessible
-                return f'https://pdf-pipeline-store-qa.s3.amazonaws.com/tagged-pdfs/{hathi_id}.pdf'
+                return f'https://{aws_file_bucket}.s3.us-east-1.amazonaws.com/titles/publisher_backlist/Schomburg/{hathi_id}/{hathi_id}.pdf'
                 
             raise Exception(f'Unable to get file for {record}')
 

--- a/services/sources/publisher_backlist_service.py
+++ b/services/sources/publisher_backlist_service.py
@@ -219,7 +219,8 @@ class PublisherBacklistService(SourceService):
                 except Exception:
                     logger.exception("Error during copy response")
 
-                return f'https://{aws_file_bucket}.s3.us-east-1.amazonaws.com/titles/publisher_backlist/Schomburg/{hathi_id}/{hathi_id}.pdf'
+                manifest_url = get_stored_file_url(storage_name=aws_file_bucket, file_path=f'titles/publisher_backlist/Schomburg/{hathi_id}/{hathi_id}.pdf')
+                return manifest_url
                 
             raise Exception(f'Unable to get file for {record}')
 

--- a/services/sources/publisher_backlist_service.py
+++ b/services/sources/publisher_backlist_service.py
@@ -1,5 +1,4 @@
-from datetime import datetime, timedelta, timezone
-import json
+from datetime import datetime
 import os
 import requests
 import urllib.parse
@@ -8,6 +7,7 @@ from typing import Optional
 from model import Record, Work, Edition, Item
 from sqlalchemy.orm import joinedload
 
+from digital_assets import get_stored_file_url
 from logger import create_log
 from mappings.publisher_backlist import PublisherBacklistMapping
 from managers import S3Manager
@@ -15,7 +15,7 @@ from services.ssm_service import SSMService
 from services.google_drive_service import GoogleDriveService
 from .source_service import SourceService
 from managers import DBManager, ElasticsearchManager
-from model import FileFlags
+from model import FileFlags, Part
 
 logger = create_log(__name__)
 
@@ -158,41 +158,58 @@ class PublisherBacklistService(SourceService):
         for record in records:
             try:
                 record_metadata = record.get('fields')
-                try:
-                    file_id = f'{self.drive_service.id_from_url(record_metadata.get("DRB_File Location"))}'
-                except Exception:
-                    logger.error(f'Could not extract a Drive identifier from {record_metadata.get("DRB_Record ID")}')
-                    continue
-                file_name = self.drive_service.get_file_metadata(file_id).get('name')
-                file = self.drive_service.get_drive_file(file_id)
-                
-                if not file:
-                    logger.error(f'Failed to retrieve file for {record_metadata.get("DRB_Record ID")} from Google Drive')
-                    continue
-
                 record_permissions = self.parse_permissions(record_metadata.get('Access type in DRB (from Access types)')[0])
-                bucket = self.file_bucket if not record_permissions['requires_login'] else self.limited_file_bucket
-                s3_path = f'{self.title_prefix}/{record_metadata[SOURCE_FIELD][0]}/{file_name}'
-                s3_response = self.s3_manager.putObjectInBucket(file.getvalue(), s3_path, bucket)
-                
-                if not s3_response.get('ResponseMetadata').get('HTTPStatusCode') == 200:
-                    logger.error(f'Failed to upload file for {record_metadata.get("DRB_Record ID")} to S3')
-                    continue
-
-                s3_url = f'https://{bucket}.s3.amazonaws.com/{s3_path}'
                 
                 publisher_backlist_record = PublisherBacklistMapping(record_metadata)
                 publisher_backlist_record.applyMapping()
                 
-                webpub_flags=FileFlags(reader=True, limited_access=True)
-                self.add_has_part_mapping(s3_url, publisher_backlist_record.record, record_permissions['is_downloadable'], record_permissions['requires_login'])
-                self.s3_manager.store_pdf_manifest(publisher_backlist_record.record, self.file_bucket, flags=webpub_flags, path='/publisher_backlist')
+                try:
+                    file_url = self.download_file_from_location(record_metadata, record_permissions, publisher_backlist_record.record)
+                except Exception:
+                    logger.exception(f'Failed to download file for {record}')
                 
+                publisher_backlist_record.record.has_part.append(str(Part(
+                    index=1,
+                    url=file_url,
+                    source=publisher_backlist_record.record.source,
+                    file_type='application/pdf',
+                    flags=str(FileFlags(download=record_permissions['is_downloadable'], nypl_login=record_permissions['requires_login']))
+                )))
+                self.s3_manager.store_pdf_manifest(publisher_backlist_record.record, self.file_bucket, flags=FileFlags(reader=True, nypl_login=record_permissions['requires_login']), path='publisher_backlist')
                 mapped_records.append(publisher_backlist_record)
             except Exception:
                 logger.exception(f'Failed to process Publisher Backlist record: {record_metadata}')
         
         return mapped_records
+    
+    def download_file_from_location(self, record_metadata: dict, record_permissions: dict, record: Record) -> str:
+        file_location = record_metadata.get('DRB_File Location')
+
+        if not file_location:
+            hath_identifier = next((identifier for identifier in record.identifiers if identifier.endswith('hathi')), None)
+
+            if hath_identifier is not None:
+                hathi_id = hath_identifier.split('|')[0]
+
+                # TODO - move converted PDFs over to drb-files S3 buckets
+                # TODO - ensure these files are publicly accessible
+                return f'https://pdf-pipeline-store-qa.s3.amazonaws.com/tagged-pdfs/{hathi_id}.pdf'
+                
+            raise Exception(f'Unable to get file for {record}')
+
+        
+        file_id = f'{self.drive_service.id_from_url(file_location)}'
+        file_name = self.drive_service.get_file_metadata(file_id).get('name')
+        file = self.drive_service.get_drive_file(file_id)
+        
+        if not file:
+            raise Exception(f'Unable to get file for: {record}')
+
+        bucket = self.file_bucket if not record_permissions['requires_login'] else self.limited_file_bucket
+        file_path = f'{self.title_prefix}/{record_metadata[SOURCE_FIELD][0]}/{file_name}'
+        self.s3_manager.putObjectInBucket(file.getvalue(), file_path, bucket)
+
+        return get_stored_file_url(storage_name=bucket, file_path=file_path)
         
     def build_filter_by_formula_parameter(self, deleted=None, start_timestamp: Optional[datetime]=None) -> str:
         if deleted:
@@ -236,19 +253,6 @@ class PublisherBacklistService(SourceService):
 
             publisher_backlist_records.extend(records_response_json.get('records', []))
         return publisher_backlist_records
-
-    def add_has_part_mapping(self, s3_url: str, record: Record, is_downloadable: bool, requires_login: bool):
-        item_no = '1'
-        media_type = 'application/pdf'
-        flags = {
-            'catalog': False,
-            'download': is_downloadable,
-            'reader': False,
-            'embed': False,
-            'nypl_login': requires_login,
-        }
-
-        record.has_part.append('|'.join([item_no, s3_url, record.source, media_type, json.dumps(flags)]))
 
     @staticmethod
     def parse_permissions(permissions: str) -> dict:


### PR DESCRIPTION
## Description
- Implements Schomburg ingest 
- Adds pdf url from pdf pipeline bucket if there is a Hathi ID
- TODO - make sure files are moved over to the drb-files buckets and make sure they are publicly accessible 

## Testing
- Marked a record as ready to ingest in Airtable: https://airtable.com/appBoLf4lMofecGPU/tblXzsYyX9ZNrmP0H/viwifoeLgCJgZWzUu?blocks=hide
`python main.py -p PublisherBacklistProcess -e local`
`python main.py -p RedriveRecordsProcess -e local`
`python main.py -p RecordPipelineProcess -e local`

- Ensured that the record was properly clustered and available on frontend:
![Screenshot 2025-03-27 at 17 42 37](https://github.com/user-attachments/assets/9467fadb-05da-4a87-a2a8-faea828793b4)

