### PR TITLE
Configure Vercel preview deployments in GH Actions

### DIFF
--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -7,8 +7,8 @@ env:
 on:
   pull_request:
     types: [opened, synchronize]
-    paths:
-      - "web/**"
+    # paths:
+    #   - "web/**"
 
 jobs:
   Deploy-Preview:

--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -1,0 +1,33 @@
+name: Vercel Preview Deployment
+
+env:
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - "web/**"
+
+jobs:
+  Deploy-Preview:
+    runs-on: ubuntu-latest
+    environment: preview
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+
+      - name: Pull Vercel Environment Information
+        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Build Project Artifacts
+        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Deploy Project Artifacts to Vercel
+        id: deploy
+        run: |
+          deployment_url=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})
+          echo "deployment_url=$deployment_url" >> $GITHUB_OUTPUT

--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -36,7 +36,19 @@ jobs:
           deployment_url=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})
           echo "deployment_url=$deployment_url" >> $GITHUB_OUTPUT
 
-      - name: Update GitHub Job Summary
-        run: |
-          echo "## Vercel Preview Deployment" >> $GITHUB_STEP_SUMMARY
-          echo "Preview URL: ${{ steps.deploy.outputs.deployment_url }}" >> $GITHUB_STEP_SUMMARY
+      - name: Create GitHub Deployment
+        uses: chrnorm/deployment-action@v2
+        id: deployment
+        with:
+          token: ${{ github.token }}
+          environment-url: ${{ steps.deploy.outputs.deployment_url }}
+          environment: Preview
+          ref: ${{ github.head_ref }}
+
+      - name: Update Deployment Status
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: ${{ github.token }}
+          environment-url: ${{ steps.deploy.outputs.deployment_url }}
+          state: "success"
+          deployment-id: ${{ steps.deployment.outputs.deployment_id }}

--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -35,3 +35,8 @@ jobs:
         run: |
           deployment_url=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})
           echo "deployment_url=$deployment_url" >> $GITHUB_OUTPUT
+
+      - name: Update GitHub Job Summary
+        run: |
+          echo "## Vercel Preview Deployment" >> $GITHUB_STEP_SUMMARY
+          echo "Preview URL: ${{ steps.deploy.outputs.deployment_url }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -13,7 +13,8 @@ on:
 jobs:
   Deploy-Preview:
     runs-on: ubuntu-latest
-    environment: preview
+    outputs:
+      url: ${{ steps.deploy.outputs.deployment_url }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -21,12 +21,15 @@ jobs:
         run: npm install --global vercel@latest
 
       - name: Pull Vercel Environment Information
+        working-directory: ./web
         run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Build Project Artifacts
+        working-directory: ./web
         run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Deploy Project Artifacts to Vercel
+        working-directory: ./web
         id: deploy
         run: |
           deployment_url=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})

--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -13,6 +13,9 @@ on:
 jobs:
   Deploy-Preview:
     runs-on: ubuntu-latest
+    environment:
+      name: preview
+      url: ${{ steps.deploy.outputs.deployment_url }}
     outputs:
       url: ${{ steps.deploy.outputs.deployment_url }}
     steps:
@@ -35,20 +38,3 @@ jobs:
         run: |
           deployment_url=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})
           echo "deployment_url=$deployment_url" >> $GITHUB_OUTPUT
-
-      - name: Create GitHub Deployment
-        uses: chrnorm/deployment-action@v2
-        id: deployment
-        with:
-          token: ${{ github.token }}
-          environment-url: ${{ steps.deploy.outputs.deployment_url }}
-          environment: Preview
-          ref: ${{ github.head_ref }}
-
-      - name: Update Deployment Status
-        uses: chrnorm/deployment-status@v2
-        with:
-          token: ${{ github.token }}
-          environment-url: ${{ steps.deploy.outputs.deployment_url }}
-          state: "success"
-          deployment-id: ${{ steps.deployment.outputs.deployment_id }}

--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -7,16 +7,14 @@ env:
 on:
   pull_request:
     types: [opened, synchronize]
-    # paths:
-    #   - "web/**"
+    paths:
+      - "web/**"
 
 jobs:
   Deploy-Preview:
     runs-on: ubuntu-latest
     environment:
       name: preview
-      url: ${{ steps.deploy.outputs.deployment_url }}
-    outputs:
       url: ${{ steps.deploy.outputs.deployment_url }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
- When web code is changed and a PR is created, it's oftentimes useful to generate a preview deployment with Vercel so that devs, qa, designers, and product folks can do review on these links.
- This was previously configured via Vercel/Git integration in https://github.com/NYPL/sfr-bookfinder-front-end but now that we've moved the web code to this repo, we need to configure it here
- We're doing this using GH Actions instead of the Vercel/Git integration because this allows us to use a personal VERCEL_TOKEN (in this case, @samanthaandrews' token) which means all Preview deployments will build, even if someone without a paid Vercel seat makes changes to the code