### PR TITLE
SFR-2690: Add an optional "storage_class" argument to the put_object method

### DIFF
--- a/etl-pipeline/managers/s3.py
+++ b/etl-pipeline/managers/s3.py
@@ -98,7 +98,12 @@ class S3Manager:
         return manifest.toJson()
 
     def put_object(
-        self, object, key: str, bucket: str, bucket_permissions: str = "public-read"
+        self,
+        object,
+        key: str,
+        bucket: str,
+        bucket_permissions: str = "public-read",
+        storage_class: str = "STANDARD",
     ):
         object_md5 = S3Manager.get_md5_hash(object)
         object_extension = key[-4:].lower()
@@ -130,6 +135,7 @@ class S3Manager:
                 ContentMD5=object_md5,
                 ContentType=object_type,
                 Metadata={"md5Checksum": object_md5},
+                StorageClass=storage_class,
                 **(
                     {"ACL": bucket_permissions}
                     if bucket_permissions is not None

--- a/etl-pipeline/tests/unit/test_s3_manager.py
+++ b/etl-pipeline/tests/unit/test_s3_manager.py
@@ -44,6 +44,7 @@ class TestS3Manager:
             ContentType="application/epub+zip",
             ContentMD5="testMd5Hash",
             Metadata={"md5Checksum": "testMd5Hash"},
+            StorageClass="STANDARD",
         )
 
     def test_put_object_existing_outdated(self, test_instance: S3Manager, mocker):
@@ -81,6 +82,7 @@ class TestS3Manager:
             ContentType="application/epub+zip",
             ContentMD5="testMd5Hash",
             Metadata={"md5Checksum": "testMd5Hash"},
+            StorageClass="STANDARD",
         )
 
     def test_put_object_existing_unmodified(self, test_instance: S3Manager, mocker):


### PR DESCRIPTION
## Describe your changes
Adds an optional "storage_class" argument to the `put_object` method so that the GRIN script can choose a different storage class option (glacier IR)

## How to test
Run the unit test `make unit`
