### PR TITLE
Change logging in GRIN scrape script

### DIFF
--- a/etl-pipeline/scripts/GRIN_initial_scrape.py
+++ b/etl-pipeline/scripts/GRIN_initial_scrape.py
@@ -10,6 +10,7 @@ import argparse
 
 logger = create_log(__name__)
 
+
 def main(batch_limit=1000):
     grin_client = GRINClient()
     with DBManager() as db_manager:


### PR DESCRIPTION
## Describe your changes
Instead of logging errors to a file, let's log them directly to the logger. This will help with tracing errors as we run this script in QA + Prod

## How to test
Run `python3 -m scripts.GRIN_initial_scrape --ba_limit=1500` (that parameter is correctly incorrectly to test) in your terminal, and the errors should appear in the logger in your terminal instead of writing to a file
