### PR TITLE
[SCHOL-110] GRIN Conversion: Add step to convert failed barcodes and send converted barcodes to download

### DIFF
--- a/etl-pipeline/processes/grin/conversion.py
+++ b/etl-pipeline/processes/grin/conversion.py
@@ -133,11 +133,7 @@ class GRINConversion:
 
             self.logger.info(f"Converting {len(failed_barcodes)} failed conversions")
             converting_barcodes, _ = self._convert_barcodes(failed_barcodes)
-            self._update_grin_state(
-                converting_barcodes,
-                old_state=GRINState.CONVERTING,
-                new_state=GRINState.CONVERTING,
-            )
+            self._update_grin_date_modified(converting_barcodes)
 
     def _sync_converted_books(self) -> set:
         converted_filenames = self.client.converted_filenames()
@@ -312,4 +308,22 @@ class GRINConversion:
             self.db_manager.session.rollback()
             self.logger.exception(
                 f"Failed to update {len(barcodes)} barcodes from {old_state.value} to {new_state.value}"
+            )
+
+    def _update_grin_date_modified(self, barcodes):
+        try:
+            update_results = self.db_manager.session.execute(
+                update(GRINStatus)
+                .filter(GRINStatus.barcode.in_(barcodes))
+                .values(date_modified=datetime.now(timezone.utc))
+            )
+            self.db_manager.commit_changes()
+
+            self.logger.info(
+                f"Updated {update_results.rowcount} barcodes date modified"
+            )
+        except Exception:
+            self.db_manager.session.rollback()
+            self.logger.exception(
+                f"Failed to update {len(barcodes)} barcodes date modified"
             )


### PR DESCRIPTION
[SCHOL-110](https://newyorkpubliclibrary.atlassian.net/browse/SCHOL-110)

## Describe your changes
- Adds step to retry converting failed barcodes (`/_failed` on GRIN) during the scheduled daily task. The condition to re-run the conversion is for the GRINStatus of a barcode to be modified at least 2 weeks from the time the task is run.
- Sends converted barcodes to the GRIN ingest queue for download in daily task.

**Note**: The additional step will retry all failed barcodes, but not all failed conversions have a "Convert Failed Info" message to retry conversion. I am unsure if there are query params that can be used to retrieve and filter the message info.

[SCHOL-110]: https://newyorkpubliclibrary.atlassian.net/browse/SCHOL-110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ