### PR TITLE
NOREF Update add has_part script to exclude us only public domain books

### DIFF
--- a/etl-pipeline/scripts/addHasPartToGRINRecords.py
+++ b/etl-pipeline/scripts/addHasPartToGRINRecords.py
@@ -57,7 +57,7 @@ def main():
             .join(GRINStatus, GRINStatus.record_id == Record.id)
             .filter(
                 Record.source == "grin",
-                func.split_part(Record.rights, '|', 2) == "public_domain",
+                func.split_part(Record.rights, "|", 2) == "public_domain",
                 or_(Record.has_part == "{}", Record.has_part.is_(None)),
                 GRINStatus.state == GRINState.DOWNLOADED.value,
             )


### PR DESCRIPTION
## Describe your changes

- Updates the `addHasPartToGRINRecords` script to only process records with a rights license of "public_domain" (excludes public_domain (us_only) and public_domain (privacy_limited))

## How to test
`python main.py -sc addHasPartToGRINRecords -e local` - will only work if you have GRIN records in local db