### PR TITLE
NOREF: VRA response for LangChain 1.0.0+

### DIFF
--- a/etl-pipeline/api/research_assistant.py
+++ b/etl-pipeline/api/research_assistant.py
@@ -167,6 +167,8 @@ class ResearchAssistant:
     def get_chat_completion(self, messages):
         parsed_messages = self._parse_messages(messages)
         response = self.agent.invoke({"messages": parsed_messages})
+
+        answer = ""
         results = None
 
         for message in response["messages"]:
@@ -175,8 +177,13 @@ class ResearchAssistant:
             if isinstance(message, ToolMessage):
                 results = json.loads(message.content)
 
+        last_content = response["messages"][-1].content
+        answer = "".join(
+            block["text"] for block in last_content if block.get("type") == "text"
+        )
+
         return {
-            "answer": response["messages"][-1].content,
+            "answer": answer,
             "results": results,
             "messages": messages_to_dict(parsed_messages),
         }


### PR DESCRIPTION
> [!NOTE]
> This is a temporary fix to get the chat interface in QA environment working. Further modifications to the API response type will be made after the FE <> BE contract has been finalized.

## Describe your changes

Following the upgrade to `langchain==1.0.0` (https://github.com/NYPL/digital-research-books/pull/870), the backend API response format broke for the frontend. This PR is a hotfix to patch this.

* Previous behavior (langchain 0.3.x): `agent.invoke` returned a simple string for the answer. `response["messages"][-1].content` was a `string`.
* New behavior: The agent now returns a complex `AIMessage` where the content is a list of dictionaries (e.g., `[{ "type": "text", "text": "..." }]`).

As a result, Next.js frontend crashes trying to render the chat response.

```
Error: Objects are not valid as a React child (found: object with keys {extras, text, type}). If you meant to render a collection of children, use an array instead.
```

## How to test

1. Update the backend dependencies:

```bash
$ cd etl-pipeline
$ pip install -r requirements.txt
```

2. Start the API server:

```
$ python main.py -p APIProcess -e local-qa
```

3. Run Next.js dev server and access http://localhost:3000/research-assistant. Ensure the chat response from BE is rendered as expeceted.