### PR TITLE
NOREF: Fix GRIN ingest process methods

### DIFF
--- a/etl-pipeline/processes/grin/ingest.py
+++ b/etl-pipeline/processes/grin/ingest.py
@@ -2,8 +2,8 @@ import io
 import json
 import os
 import re
+import datetime
 
-from datetime import datetime
 from logger import create_log
 from .download import GRINDownloadService
 from managers import SQSManager, S3Manager


### PR DESCRIPTION
## Describe your changes

- Adds missing `self` arg to GRIN ingest methods

## How to test
`python main.py -p GRINIngestProcess -e local`