### PR TITLE
NOREF: Add manual trigger to Playwright workflow

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,6 +1,13 @@
 name: Playwright Tests for DRB Web
 
 on:
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: "Base URL for environment"
+        default: "http://local.nypl.org:3000/"
+        required: false
+        type: string
   workflow_call:
     inputs:
       base_url:


### PR DESCRIPTION
Adds support for manually triggering the Playwright test workflow, which provides the flexibility to run the E2E suite on-demand without requiring a code commit.