### PR TITLE
NOREF addHasPartToGRINRecords replace yield per with windowed query

### DIFF
--- a/etl-pipeline/managers/db.py
+++ b/etl-pipeline/managers/db.py
@@ -91,23 +91,23 @@ class DBManager:
             else:
                 logger.warning("Already retried batch, dropping")
 
-    def windowed_query(self, session, stmt, column, windowsize):
+    def windowed_query(self, stmt, id_column, windowsize):
         """
         Yields all records from stmt, fetching `windowsize` records at a time into memory.
         `column` must contain strictly unique values (non-null)
         Safe to call session.commit() while iterating.
         see: https://github.com/sqlalchemy/sqlalchemy/wiki/RangeQuery-and-WindowedRangeQuery
         """
-        stmt = stmt.add_columns(column).order_by(column)
+        stmt = stmt.add_columns(id_column).order_by(id_column)
         last_id = None
 
         while True:
             subq = stmt
 
             if last_id is not None:
-                subq = subq.filter(column > last_id)
+                subq = subq.filter(id_column > last_id)
 
-            result = session.execute(subq.limit(windowsize))
+            result = self.session.execute(subq.limit(windowsize))
             chunk = result.all()
 
             if not chunk:

--- a/etl-pipeline/scripts/addHasPartToGRINRecords.py
+++ b/etl-pipeline/scripts/addHasPartToGRINRecords.py
@@ -73,9 +73,7 @@ def main():
         total_has_first_page = 0
         batch_count = 0
 
-        for record in db_manager.windowed_query(
-            db_manager.session, stmt, Record.id, BATCH_SIZE
-        ):
+        for record in db_manager.windowed_query(stmt, Record.id, BATCH_SIZE):
             try:
                 logger.info(f"Processing record with source_id {record.source_id}")
                 barcode = record.source_id.split("|")[0]


### PR DESCRIPTION
## Describe your changes

- The server-side cursor that is used by `yield_per` becomes invalid after committing within the loop. Updates the approach to batch commits using a windowed query based on the [SQLAlchemy wiki example](https://github.com/sqlalchemy/sqlalchemy/wiki/RangeQuery-and-WindowedRangeQuery).
- Updates the DBManager windowed_query (not used elsewhere) to use SQLAlchemy 2.0 patterns.

## How to test
```
docker compose up
python main.py -sc addHasPartToGRINRecords -e local
```
