### PR TITLE
Vector indexing end-to-end

### DIFF
--- a/etl-pipeline/main.py
+++ b/etl-pipeline/main.py
@@ -51,7 +51,12 @@ def main(args):
         logger.exception(f"Failed to initialize process {process} in {environment}")
         return
 
-    if process in ("APIProcess", "DevelopmentSetupProcess", "MigrationProcess"):
+    if process in (
+        "APIProcess",
+        "DevelopmentSetupProcess",
+        "MigrationProcess",
+        "VectorIndexingProcess",
+    ):
         process_instance.run()
     else:
         # Configure a separate scope for logs of this process in New Relic UI

--- a/etl-pipeline/processes/__init__.py
+++ b/etl-pipeline/processes/__init__.py
@@ -14,3 +14,4 @@ from .record_pipeline import RecordPipelineProcess
 from .local_development.seed_local_data import SeedLocalDataProcess
 from .grin.conversion import GRINConversion
 from .grin.ingest import GRINIngestProcess
+from .vector_indexing_process import VectorIndexingProcess

--- a/etl-pipeline/processes/vector_indexing_process.py
+++ b/etl-pipeline/processes/vector_indexing_process.py
@@ -1,0 +1,15 @@
+import os
+
+from logger import create_log
+from vector_indexing.pipeline.orchestrator import main
+
+logger = create_log(__name__)
+
+
+class VectorIndexingProcess:
+    def __init__(self, *args):
+        self.barcodes = args[-1]  # options is the last argument
+
+    def run(self):
+        print(self.barcodes)
+        main(barcodes=self.barcodes)

--- a/etl-pipeline/processes/vector_indexing_process.py
+++ b/etl-pipeline/processes/vector_indexing_process.py
@@ -1,5 +1,3 @@
-import os
-
 from logger import create_log
 from vector_indexing.pipeline.orchestrator import main
 
@@ -11,5 +9,5 @@ class VectorIndexingProcess:
         self.barcodes = args[-1]  # options is the last argument
 
     def run(self):
-        print(self.barcodes)
+        logger.info(f"Starting Vector Indexing Process with barcodes: {self.barcodes}")
         main(barcodes=self.barcodes)

--- a/etl-pipeline/vector_indexing/components/backends/turbopuffer.py
+++ b/etl-pipeline/vector_indexing/components/backends/turbopuffer.py
@@ -7,12 +7,12 @@ Provides a thin wrapper around the turbopuffer SDK.
 from __future__ import annotations
 
 import json
-import logging
 from pathlib import Path
 from typing import Iterator, Optional, TYPE_CHECKING
 
 import turbopuffer as tpuf
 
+from logger import create_log
 from vector_indexing.core.utils import format_bytes, TimerSet
 from vector_indexing.core.types import BookMetadata, ChunkDocument, InsertResult
 from vector_indexing.core.config import get_config, GlobalConfig, VECTOR_INDEXING_ROOT
@@ -21,7 +21,7 @@ from vector_indexing.components.backends.base import IndexBackend
 if TYPE_CHECKING:
     pass
 
-logger = logging.getLogger(__name__)
+logger = create_log(__name__)
 
 
 def _load_schema() -> dict:
@@ -139,15 +139,11 @@ class TurbopufferBackend(IndexBackend):
         self._config = config or get_config()
         self._index_name = index_name
 
-        if (
-            hasattr(self._config, "turbopuffer_api_key")
-            and self._config.turbopuffer_api_key
-        ):
-            tpuf.api_key = self._config.turbopuffer_api_key
-
         self._client = tpuf.Turbopuffer(
-            timeout=600
-        )  # 10 minute timeout for large uploads
+            api_key=self._config.turbopuffer_api_key or None,
+            region=self._config.turbopuffer_region or None,
+            timeout=600,  # 10 minute timeout for large uploads
+        )
         self._ns = self._client.namespace(index_name)
 
         self._timers = TimerSet()
@@ -563,10 +559,12 @@ def delete_test_namespace(
         )
 
     config = config or get_config()
-    if hasattr(config, "turbopuffer_api_key") and config.turbopuffer_api_key:
-        tpuf.api_key = config.turbopuffer_api_key
 
-    client = tpuf.Turbopuffer(timeout=60)
+    client = tpuf.Turbopuffer(
+        api_key=config.turbopuffer_api_key or None,
+        region=config.turbopuffer_region or None,
+        timeout=60,
+    )
     ns = client.namespace(namespace_name)
 
     try:

--- a/etl-pipeline/vector_indexing/core/config.py
+++ b/etl-pipeline/vector_indexing/core/config.py
@@ -35,7 +35,7 @@ VECTOR_INDEXING_ROOT = Path(__file__).resolve().parent.parent
 
 # Config paths - using existing etl-pipeline conventions
 CONFIG_DIR = PROJECT_ROOT / "config"
-DATA_DIR = PROJECT_ROOT / "data"
+DATA_DIR = VECTOR_INDEXING_ROOT / "data"
 
 
 @dataclass(frozen=True)
@@ -79,7 +79,7 @@ class GlobalConfig:
     pg_database: str = "vra"
 
     # Embedding settings
-    embedding_model: str = "text-embedding-004"
+    embedding_model: str = "gemini-embedding-001"
     embedding_batch_size: int = 100
     embedding_dimensions: int = 768
 

--- a/etl-pipeline/vector_indexing/pipeline/orchestrator.py
+++ b/etl-pipeline/vector_indexing/pipeline/orchestrator.py
@@ -2,13 +2,12 @@
 
 from __future__ import annotations
 
-import os
-import sys
 from dataclasses import dataclass, field
-from typing import Callable, TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable
 
 from logger import create_log
-from vector_indexing.core.types import Book, BookMetadata, ChunkDocument, InsertResult
+
+from vector_indexing.core.types import Book, BookMetadata, ChunkDocument
 
 logger = create_log(__name__)
 
@@ -283,12 +282,12 @@ def main(barcodes: list[str] | None = None) -> BatchResult:
     """Run the indexing pipeline with default components. Takes in a list of barcodes to index.
     Returns a BatchResult with indexing outcomes.
     """
-    from vector_indexing.core.config import GlobalConfig
     from vector_indexing.components.backends.turbopuffer import TurbopufferBackend
     from vector_indexing.components.chunkers.sentence import SentenceSplitterChunker
     from vector_indexing.components.embedders.google import GoogleEmbedder
     from vector_indexing.components.loaders.s3 import CachedS3BookLoader
     from vector_indexing.components.metadata.provider import MetadataProvider
+    from vector_indexing.core.config import GlobalConfig
 
     if barcodes is None:
         return

--- a/etl-pipeline/vector_indexing/pipeline/orchestrator.py
+++ b/etl-pipeline/vector_indexing/pipeline/orchestrator.py
@@ -3,14 +3,15 @@
 from __future__ import annotations
 
 import os
+import sys
 import logging
 from dataclasses import dataclass, field
 from typing import Callable, TYPE_CHECKING
 
 from vector_indexing.core.types import Book, BookMetadata, ChunkDocument, InsertResult
+from logger import create_log
 
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
+logger = create_log(__name__)
 
 if TYPE_CHECKING:
     from vector_indexing.components.backends.base import IndexBackend
@@ -237,7 +238,6 @@ class Pipeline:
             book = books[barcode]
             try:
                 insert_result = self._backend.insert(chunks)
-
                 result = IndexingResult(
                     barcode=barcode,
                     book_id=book.book_id,
@@ -259,6 +259,8 @@ class Pipeline:
             batch_result.results.append(result)
             if on_progress:
                 on_progress(result)
+
+        logger.info(f"Stage 5 (Insert): {len(book_errors)} errors")
 
         # Add results for books that failed earlier
         for barcode, error in book_errors.items():
@@ -282,27 +284,29 @@ def main(barcodes: list[str] | None = None) -> BatchResult:
     """Run the indexing pipeline with default components. Takes in a list of barcodes to index.
     Returns a BatchResult with indexing outcomes.
     """
-    from dotenv import load_dotenv
-    from vector_indexing.core.config import GlobalConfig, DOT_ENV_FILE
-    from vector_indexing.components.backends.elasticsearch import ElasticsearchBackend
+    from vector_indexing.core.config import GlobalConfig
+    from vector_indexing.components.backends.turbopuffer import TurbopufferBackend
     from vector_indexing.components.chunkers.sentence import SentenceSplitterChunker
-    from vector_indexing.components.embedders.qwen import QwenEmbedder
+    from vector_indexing.components.embedders.google import GoogleEmbedder
     from vector_indexing.components.loaders.s3 import CachedS3BookLoader
     from vector_indexing.components.metadata.provider import MetadataProvider
 
     if barcodes is None:
         return
 
-    load_dotenv(DOT_ENV_FILE)
     config = GlobalConfig.for_environment()
 
     pipeline = Pipeline(
         loader=CachedS3BookLoader(config=config),
         chunker=SentenceSplitterChunker(config=config),
-        embedder=QwenEmbedder(config=config),
+        embedder=GoogleEmbedder(
+            model=config.embedding_model,
+            dimensions=config.embedding_dimensions,
+            batch_size=config.embedding_batch_size,
+        ),
         metadata_provider=MetadataProvider(config=config),
-        backend=ElasticsearchBackend.from_config(
-            index_name="qwen-test-index", config=config
+        backend=TurbopufferBackend.from_config(
+            index_name="test_kn_03232026", config=config
         ),
     )
 
@@ -316,5 +320,6 @@ def main(barcodes: list[str] | None = None) -> BatchResult:
 
 if __name__ == "__main__":
     # Test using a few very small books
-    main(["33433000136972", "33433006239176"])
-    main(["33433071108306", "33433009163845"])
+    # main(["33433000136972", "33433006239176"])
+    # main(["33433071108306", "33433009163845"])
+    pass

--- a/etl-pipeline/vector_indexing/pipeline/orchestrator.py
+++ b/etl-pipeline/vector_indexing/pipeline/orchestrator.py
@@ -4,12 +4,11 @@ from __future__ import annotations
 
 import os
 import sys
-import logging
 from dataclasses import dataclass, field
 from typing import Callable, TYPE_CHECKING
 
-from vector_indexing.core.types import Book, BookMetadata, ChunkDocument, InsertResult
 from logger import create_log
+from vector_indexing.core.types import Book, BookMetadata, ChunkDocument, InsertResult
 
 logger = create_log(__name__)
 

--- a/etl-pipeline/vector_indexing/pipeline/orchestrator.py
+++ b/etl-pipeline/vector_indexing/pipeline/orchestrator.py
@@ -305,7 +305,7 @@ def main(barcodes: list[str] | None = None) -> BatchResult:
         ),
         metadata_provider=MetadataProvider(config=config),
         backend=TurbopufferBackend.from_config(
-            index_name="test_kn_03232026", config=config
+            index_name="vra-dev-test", config=config
         ),
     )
 


### PR DESCRIPTION
Includes:
 - Add a process to main.py to run the vector indexing pipeline the same way we run etl-pipeline
 - Some minor fixes

Ultimately we'll be doing the actual orchestration for processing differently, but this allows us to at least generate the data for some books on a target index as needed. You can run this via: 

```
STAGE="development" LOG_LEVEL="debug" DRB_API_HOST=localhost uv run python main.py -p VectorIndexingProcess -e production <barcodes>
```