### PR TITLE
NOREF: Update expected QA VRA API key

### DIFF
--- a/etl-pipeline/config/.env.qa.secrets
+++ b/etl-pipeline/config/.env.qa.secrets
@@ -36,7 +36,7 @@ POSTGRES_USER=arn:aws:ssm:us-east-1:946183545209:parameter/drb/qa/postgres/user
 
 GOOGLE_API_KEY=arn:aws:ssm:us-east-1:946183545209:parameter/drb/qa/google-ai-api-key
 
-API_KEY=arn:aws:ssm:us-east-1:946183545209:parameter/drb/qa/api-key
+VRA_API_KEY=arn:aws:ssm:us-east-1:946183545209:parameter/drb/qa/api-key
 
 GRIN_ACCESS_KEY=arn:aws:ssm:us-east-1:946183545209:parameter/drb/qa/grin-access-key
 GRIN_AUTH=arn:aws:ssm:us-east-1:946183545209:parameter/drb/qa/grin-auth


### PR DESCRIPTION
## Describe your changes
Updates the expected API key envar for authorizing /chat requests from `API_KEY` to `VRA_API_KEY` in the qa config to align with the new naming convention introduced by #1025.

## How to test
Merge to main then attempt /chat requests using the QA API following the QA deploy.