### PR TITLE
NOREF: Add VRA integration test user password to qa config

### DIFF
--- a/etl-pipeline/config/.env.qa.secrets
+++ b/etl-pipeline/config/.env.qa.secrets
@@ -49,5 +49,7 @@ COHERE_API_KEY=arn:aws:ssm:us-east-1:946183545209:parameter/drb/qa/vra/cohere/ap
 
 TURBOPUFFER_API_KEY=arn:aws:ssm:us-east-1:946183545209:parameter/drb/qa/vra/turbopuffer/api-key
 
+VRA_TEST_PASSWORD=arn:aws:ssm:us-east-1:946183545209:parameter/drb/qa/vra/test_user_password
+
 SESSION_JWT_PRIVATE_KEY=arn:aws:ssm:us-east-1:946183545209:parameter/drb/qa/session-jwt/private-key
 SESSION_JWT_PUBLIC_KEY=arn:aws:ssm:us-east-1:946183545209:parameter/drb/qa/session-jwt/public-key


### PR DESCRIPTION
## Describe your changes
Adds the VRA integration test user password envar to the qa config to fix failed [check](https://github.com/NYPL/digital-research-books/actions/runs/24433002697/job/71381405317) following QA deploy.

## How to test
Merge to main and ensure tests against QA environment pass in [ETL Pipeline Full CI/CD](https://github.com/NYPL/digital-research-books/actions/workflows/etl-pipeline-full-ci-cd.yaml).