### PR TITLE
NOREF: Enable New Relic AI monitoring

### DIFF
--- a/etl-pipeline/api/blueprints/chat.py
+++ b/etl-pipeline/api/blueprints/chat.py
@@ -169,9 +169,11 @@ def chat(user, session_id):
     if edition_id is not None:
         log_context["edition_id"] = edition_id
 
-    # Add custom attributes to transaction in New Relic
+    # New Relic custom attributes and AI monitoring conversation grouping
     for k, v in log_context.items():
         newrelic.agent.add_custom_attribute(k, v)
+    if session_id:
+        newrelic.agent.add_custom_attribute("llm.conversation_id", session_id)
 
     with LogContextVars(get_app_logger(), context=log_context):
         return _chat_handler(user, session_id, conversation_type, message, edition_id)

--- a/etl-pipeline/newrelic.ini
+++ b/etl-pipeline/newrelic.ini
@@ -222,6 +222,8 @@ app_name = DRB ETL Pipeline (DEV/PROD)
 [newrelic:qa]
 monitor_mode = true
 app_name = DRB ETL Pipeline (QA)
+ai_monitoring.enabled = true
+ai_monitoring.record_content.enabled = true
 
 [newrelic:production]
 monitor_mode = true

--- a/etl-pipeline/newrelic.ini
+++ b/etl-pipeline/newrelic.ini
@@ -228,5 +228,7 @@ ai_monitoring.record_content.enabled = true
 [newrelic:production]
 monitor_mode = true
 app_name = DRB ETL Pipeline (PROD)
+ai_monitoring.enabled = false
+ai_monitoring.record_content.enabled = false
 
 # ---------------------------------------------------------------------------

--- a/etl-pipeline/newrelic.ini
+++ b/etl-pipeline/newrelic.ini
@@ -195,7 +195,7 @@ distributed_tracing.enabled = true
 custom_insights_events.enabled = true
 
 # Event harvest configuration to ensure custom events are sent
-event_harvest_config.harvest_limits.custom_event_data = 10000
+custom_insights_events.max_samples_stored = 10000
 
 # ---------------------------------------------------------------------------
 

--- a/etl-pipeline/requirements.txt
+++ b/etl-pipeline/requirements.txt
@@ -18,7 +18,7 @@ google-auth==2.36.0
 google-genai==1.45.0
 llama-index-core==0.14.6
 lxml==4.9.2
-newrelic==10.9.0
+newrelic==12.1.0
 numpy==1.24.2
 ocrmypdf==14.1.0
 openai-agents==0.9.1


### PR DESCRIPTION
## Changes summary
Enables New Relic AI monitoring to provide observability into interactions with the AI assistant (in the QA environment only). 

In addition to enabling the relevant settings, the chat controller was updated so that conversations in New Relic are grouped by session ID.

### IMPORTANT: Conversation tracking
The contents of user messages and agent responses are tracked and recorded in New Relic by these changes. While conversation storage has been allowed for the upcoming internal testing phase, note what New Relic [states](https://docs.newrelic.com/docs/apm/agents/python-agent/configuration/python-agent-configuration/#ai-monitoring-record-content) regarding the enabling of this feature:
>When enabled, AI monitoring records a streaming copy of inputs and outputs sent to and from the models you choose to monitor, including any personal information contained therein. You're responsible for obtaining consent from your model users that their interactions may be recorded by a third party (New Relic) for the purpose of providing the AI monitoring feature.

If/when we decide to disable the tracking of conversations, AI monitoring can still be used to calculate and track token expenditure by [implementing](https://docs.newrelic.com/docs/apm/agents/python-agent/python-agent-api/setllmtokencountcallback-python-agent-api/) a callback function `set_llm_token_count_callback` along with capturing request metadata like model version, latency, TTFT, and more (just not any conversation text).

### Python agent upgrade
The New Relic Python agent was upgraded to its latest version (12.1.0). The version it was on prior (10.9.0) lacks the specific code required to hook into the GenAI SDK currently in use. 

Along with the agent upgrade, the deprecated `event_harvest_config.harvest_limits.custom_event_data` configuration key for event throttling has been replaced with the suggested `custom_insights_events.max_samples_stored` key.

## How to test
I've considered spinning up a local build with a New Relic QA configuration to test out the features, but don't want to pollute the dashboard with potentially bad data. Thus as long as it's okay with the reviewers and CI check pass, merge these changes to main then interact with the assistant after the deploy to QA completes while exploring the [AI Monitoring dashboard](https://one.newrelic.com/mlops-llm?account=121334&state=58e8df32-47bc-0a20-4d1c-b6effb8dea7e).

I've confirmed that besides the aforementioned deprecated key, there is little to no risk in the agent upgrade.

While no data is sent to New Relic in local builds by default, ensure they're up to date anyway by running a `pip install -r requirements.txt` after this is merged to main.