### PR TITLE
NOREF: Fix broken web E2E tests job after QA deploy

### DIFF
--- a/.github/workflows/web-full-ci-cd.yml
+++ b/.github/workflows/web-full-ci-cd.yml
@@ -16,7 +16,7 @@ jobs:
   # Job to run e2e tests on the QA environment after deployment
   run_e2e_tests:
     needs: deploy_to_qa
-    uses: ./.github/workflows/playwright.yml
+    uses: ./.github/workflows/web-playwright-tests.yml
     with:
       base_url: "https://drb-qa.nypl.org/"
     secrets: inherit

--- a/web/README.md
+++ b/web/README.md
@@ -150,7 +150,7 @@ If no version number is returned, install Playwright manually:
 npm install playwright
 ```
 
-ℹ️&nbsp;&nbsp;Manual installation may be required if only production dependencies are installed (as in [playwright.yml](https://github.com/NYPL/digital-research-books/blob/main/.github/workflows/playwright.yml)).
+ℹ️&nbsp;&nbsp;Manual installation may be required if only production dependencies are installed.
 
 
 #### 2. Install Playwright browsers


### PR DESCRIPTION
## Changes summary
Fixes failing job `run_e2e_tests` in **Web Full CI/CD** following merging #1040 to main (see [run](https://github.com/NYPL/digital-research-books/actions/runs/25013063036)), which updated the **Playwright Tests** workflow file name to `web-playwright-tests.yml` but did not update the path in the affected workflow.

Confirmed there are no more remaining references to the prior file name `playwright.yml` in the codebase.