### PR TITLE
Fixed the partial initialization of the session and engine, fix the autoflush behavior

### DIFF
--- a/etl-pipeline/managers/db.py
+++ b/etl-pipeline/managers/db.py
@@ -27,7 +27,7 @@ class DBManager:
         self.session = None
 
     def __enter__(self):
-        self.create_session(autoflush=True)
+        self.create_session()
         return self
 
     def __exit__(self, exc_type, exc_value, exc_tb):
@@ -78,8 +78,12 @@ class DBManager:
         self.session.rollback()
 
     def close_connection(self):
-        self.session.close()
-        self.engine.dispose()
+        if self.session is not None:
+            self.session.close()
+            self.session = None
+        if self.engine is not None:
+            self.engine.dispose()
+            self.engine = None
 
     def bulk_save_objects(self, objects, only_changed=True, retry=False):
         try:

--- a/etl-pipeline/tests/unit/managers/test_db_manager.py
+++ b/etl-pipeline/tests/unit/managers/test_db_manager.py
@@ -148,15 +148,35 @@ class TestDBManager:
         test_instance.session.rollback.assert_called_once
 
     def test_close_connection(self, test_instance, mocker):
-        test_instance.session = mocker.MagicMock()
-        test_instance.engine = mocker.MagicMock()
-        mock_commit = mocker.patch.object(DBManager, "commit_changes")
+        mock_session = mocker.MagicMock()
+        mock_engine = mocker.MagicMock()
+        test_instance.session = mock_session
+        test_instance.engine = mock_engine
 
         test_instance.close_connection()
 
-        mock_commit.assert_called_once
-        test_instance.session.close.assert_called_once
-        test_instance.engine.dispose.assert_called_once
+        mock_session.close.assert_called_once()
+        mock_engine.dispose.assert_called_once()
+        assert test_instance.session is None
+        assert test_instance.engine is None
+
+    def test_close_connection_no_session(self, test_instance, mocker):
+        mock_engine = mocker.MagicMock()
+        test_instance.session = None
+        test_instance.engine = mock_engine
+
+        test_instance.close_connection()
+
+        mock_engine.dispose.assert_called_once()
+
+    def test_close_connection_no_engine(self, test_instance, mocker):
+        mock_session = mocker.MagicMock()
+        test_instance.session = mock_session
+        test_instance.engine = None
+
+        test_instance.close_connection()
+
+        mock_session.close.assert_called_once()
 
     def test_bulk_save_objects_default(self, test_instance, mocker):
         test_instance.session = mocker.MagicMock()


### PR DESCRIPTION
Implements tickets SCHOL-584 and SCHOL-581

Basic fixes for the postgres client. Neither of these changes significantly alter behavior, just code safety.

