### PR TITLE
SCHOL-593: Fix missing relevant snippets in contentSearch

### DIFF
--- a/web/src/components/ResearchAssistant/ResearchAssistant.tsx
+++ b/web/src/components/ResearchAssistant/ResearchAssistant.tsx
@@ -7,7 +7,6 @@ import {
 } from "~/src/constants/researchAssistant";
 import { useResearchAssistant } from "~/src/context/ResearchAssistantContext";
 import { ResultPageProvider } from "~/src/context/ResultPageContext";
-import { ConversationType } from "~/src/types/ResearchAssistant";
 import { isCatalogResults } from "~/src/util/ResearchAssistantUtils";
 import BackToResultsButton from "../BackToResultsButton/BackToResultsButton";
 import EmptySearchPrompt from "../EmptySearchPrompt/EmptySearchPrompt";
@@ -21,7 +20,6 @@ const ResearchAssistant: React.FC = () => {
     messages,
     sendMessage,
     results,
-    resultType,
     historyStack,
     goToPreviousState,
     showChat,
@@ -50,11 +48,15 @@ const ResearchAssistant: React.FC = () => {
     const exactMatch = results[messages.length];
     if (exactMatch) return exactMatch;
 
-    const latest = Object.entries(results)
-      .filter(([, value]) => value)
-      .sort(([a], [b]) => Number(b) - Number(a))[0]?.[1];
+    const sortedResults = Object.entries(results)
+      .filter(([, value]) => value && Object.keys(value).length > 0)
+      .sort(([a], [b]) => Number(b) - Number(a));
 
-    return latest || null;
+    if (sortedResults.length > 0) {
+      return sortedResults[0][1];
+    }
+
+    return null;
   }, [messages.length, results]);
 
   return (
@@ -115,10 +117,9 @@ const ResearchAssistant: React.FC = () => {
                   <CatalogResultsSkeleton />
                 ) : latestResults && Object.keys(latestResults).length > 0 ? (
                   <>
-                    {resultType === ConversationType.Catalog &&
-                      isCatalogResults(latestResults) && (
-                        <CatalogResults results={latestResults} />
-                      )}
+                    {isCatalogResults(latestResults) && (
+                      <CatalogResults results={latestResults} />
+                    )}
                   </>
                 ) : (
                   <Box width="100%" marginTop="s">

--- a/web/src/components/ResearchAssistant/ResearchAssistantWindow.tsx
+++ b/web/src/components/ResearchAssistant/ResearchAssistantWindow.tsx
@@ -93,7 +93,7 @@ const ResearchAssistantWindow: React.FC = () => {
           if (message.type === "message")
             return (
               <Box
-                key={`message-${index + 1}`}
+                key={`message-${index}`}
                 ref={
                   index === messages.length - 1 && !isLoading
                     ? messagesEndRef
@@ -101,9 +101,9 @@ const ResearchAssistantWindow: React.FC = () => {
                 }
               >
                 <MessageBubble
-                  index={index + 1}
+                  index={index}
                   message={message}
-                  messageResults={results?.[index + 1] ?? null}
+                  messageResults={results?.[index] ?? null}
                 />
               </Box>
             );
@@ -112,7 +112,7 @@ const ResearchAssistantWindow: React.FC = () => {
         {isLoading && (
           <Box ref={messagesEndRef}>
             <MessageBubble
-              index={messages.length + 1}
+              index={messages.length}
               message={LOADING_MESSAGE}
               isLoading={isLoading}
             />

--- a/web/src/components/ResearchAssistant/__tests__/ResearchAssistant.test.tsx
+++ b/web/src/components/ResearchAssistant/__tests__/ResearchAssistant.test.tsx
@@ -3,12 +3,23 @@ jest.mock("@nypl/web-reader", () => ({
   PdfReader: () => <div data-testid="mock-pdf-reader" />,
 }));
 
-import { fireEvent, render, screen } from "@testing-library/react";
+jest.mock("../CatalogResults/CatalogResults", () => ({
+  __esModule: true,
+  default: ({ results }) => (
+    <div data-testid="catalog-results">
+      {results?.search_params?.query?.[0]?.[1] || "no-query"}
+    </div>
+  ),
+}));
+
+import { fireEvent, screen } from "@testing-library/react";
+import { renderWithResearchAssistant as render } from "~/src/__tests__/testUtils/render";
 import ResearchAssistant from "../ResearchAssistant";
 
 const mockClearHistory = jest.fn();
 const mockSendMessage = jest.fn();
 const mockGoToPreviousState = jest.fn();
+window.scroll = jest.fn();
 
 const mockUseResearchAssistant = jest.fn();
 jest.mock("~/src/context/ResearchAssistantContext", () => ({
@@ -85,5 +96,148 @@ describe("ResearchAssistant", () => {
 
     getItemSpy.mockRestore();
     removeItemSpy.mockRestore();
+  });
+
+  describe("render most recent non-empty results", () => {
+    beforeEach(() => {
+      window.HTMLElement.prototype.scrollIntoView = jest.fn();
+    });
+    const userMessage = {
+      id: "1",
+      type: "message",
+      content: "Query",
+      role: "user",
+    };
+    const assistantMessage = {
+      id: "2",
+      content: [
+        {
+          annotations: [],
+          text: "Here is what I found.",
+          type: "output_text",
+        },
+      ],
+      role: "assistant",
+      type: "message",
+    };
+
+    const mockCatalogResults = {
+      editions: [],
+      search_params: { query: [["keyword", "test"]] },
+      paging: {
+        currentPage: 1,
+        firstPage: 1,
+        lastPage: 1,
+        nextPage: 1,
+        previousPage: 1,
+        recordsPerPage: 10,
+        totalRecords: 0,
+      },
+    };
+
+    const mockCatalogResultsAtIndex2 = {
+      ...mockCatalogResults,
+      search_params: { query: [["keyword", "index-2-results"]] },
+    };
+
+    const mockCatalogResultsAtIndex1 = {
+      ...mockCatalogResults,
+      search_params: { query: [["keyword", "index-1-unique-results"]] },
+    };
+
+    test("displays catalog results when results are stored at the current message count index", () => {
+      mockUseResearchAssistant.mockReturnValue({
+        messages: [userMessage, assistantMessage],
+        sendMessage: mockSendMessage,
+        isLoading: false,
+        error: null,
+        clearHistory: mockClearHistory,
+        showChat: true,
+        goToPreviousState: mockGoToPreviousState,
+        historyStack: [],
+        results: { 2: mockCatalogResultsAtIndex2 },
+      });
+
+      render(<ResearchAssistant />);
+
+      expect(screen.getByTestId("catalog-results")).toBeInTheDocument();
+      expect(screen.getByText("index-2-results")).toBeInTheDocument();
+    });
+
+    test("falls back to most recent non-empty results when no exact match for current message count", () => {
+      mockUseResearchAssistant.mockReturnValue({
+        messages: [
+          userMessage,
+          assistantMessage,
+          userMessage,
+          assistantMessage,
+        ],
+        sendMessage: mockSendMessage,
+        isLoading: false,
+        error: null,
+        clearHistory: mockClearHistory,
+        showChat: true,
+        goToPreviousState: mockGoToPreviousState,
+        historyStack: [],
+        results: {
+          1: mockCatalogResultsAtIndex1,
+          2: mockCatalogResultsAtIndex2,
+        },
+      });
+
+      render(<ResearchAssistant />);
+
+      expect(screen.getByTestId("catalog-results")).toBeInTheDocument();
+      expect(screen.getByText("index-2-results")).toBeInTheDocument();
+      expect(
+        screen.queryByText("index-1-unique-results")
+      ).not.toBeInTheDocument();
+    });
+
+    test("ignores empty object result entries and falls back to the most recent non-empty result", () => {
+      mockUseResearchAssistant.mockReturnValue({
+        messages: [
+          userMessage,
+          assistantMessage,
+          userMessage,
+          assistantMessage,
+        ],
+        sendMessage: mockSendMessage,
+        isLoading: false,
+        error: null,
+        clearHistory: mockClearHistory,
+        showChat: true,
+        goToPreviousState: mockGoToPreviousState,
+        historyStack: [],
+        results: { 3: {}, 1: mockCatalogResultsAtIndex1 },
+      });
+
+      render(<ResearchAssistant />);
+
+      expect(screen.getByTestId("catalog-results")).toBeInTheDocument();
+      expect(screen.getByText("index-1-unique-results")).toBeInTheDocument();
+      expect(screen.queryByText("index-2-results")).not.toBeInTheDocument();
+    });
+
+    test("displays no results message when all result entries are empty objects", () => {
+      mockUseResearchAssistant.mockReturnValue({
+        messages: [userMessage, assistantMessage],
+        sendMessage: mockSendMessage,
+        isLoading: false,
+        error: null,
+        clearHistory: mockClearHistory,
+        showChat: true,
+        goToPreviousState: mockGoToPreviousState,
+        historyStack: [],
+        results: { 2: {} },
+      });
+
+      render(<ResearchAssistant />);
+
+      expect(screen.queryByTestId("catalog-results")).not.toBeInTheDocument();
+      expect(
+        screen.getByText(/no results found\. try a different topic\./i)
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/web/src/components/ResearchAssistant/__tests__/ResearchAssistantWindow.test.tsx
+++ b/web/src/components/ResearchAssistant/__tests__/ResearchAssistantWindow.test.tsx
@@ -1,6 +1,11 @@
 import { screen } from "@testing-library/react";
 import { render } from "~/src/__tests__/testUtils/render";
-import { Item, ItemType, MessageRole } from "~/src/types/ResearchAssistant";
+import {
+  ContentSearchResults,
+  Item,
+  ItemType,
+  MessageRole,
+} from "~/src/types/ResearchAssistant";
 import ResearchAssistantWindow from "../ResearchAssistantWindow";
 
 const mockUseResearchAssistant = jest.fn();
@@ -112,5 +117,170 @@ describe("ResearchAssistantWindow", () => {
     expect(messages[0]).toHaveTextContent("First message");
     expect(messages[1]).toHaveTextContent("Second message");
     expect(messages[2]).toHaveTextContent("Third message");
+  });
+
+  describe("relevant snippet display based on message index", () => {
+    test("renders relevant snippets for the assistant message using the matching message index", () => {
+      const mockSnippet = {
+        chunk_score: 0.9,
+        start_page: 5,
+        end_page: 5,
+        item_id: 123,
+        text: "relevant snippet text for index test",
+      };
+
+      const contentSearchResults: ContentSearchResults = {
+        snippets: [mockSnippet],
+        search_params: { query: [["keyword", "test"]] },
+      };
+
+      const mockMessages: Item[] = [
+        {
+          id: "1",
+          content: "What is relevant?",
+          role: MessageRole.User,
+          type: ItemType.Message,
+        },
+        {
+          id: "2",
+          content: [
+            {
+              annotations: [],
+              text: "Here is what I found.",
+              type: "output_text",
+            },
+          ],
+          role: MessageRole.Assistant,
+          type: ItemType.Message,
+        },
+      ];
+
+      mockUseResearchAssistant.mockReturnValue({
+        messages: mockMessages,
+        isLoading: false,
+        results: { 1: contentSearchResults },
+        handlePreview: jest.fn(),
+      });
+
+      render(<ResearchAssistantWindow />);
+
+      expect(
+        screen.getByText(/relevant snippet text for index test/i)
+      ).toBeInTheDocument();
+    });
+
+    test("displays snippets only for the message with matching index, not from other indices", () => {
+      const snippetAtIndex1 = {
+        chunk_score: 0.9,
+        start_page: 10,
+        end_page: 10,
+        item_id: 100,
+        text: "snippets from index 1",
+      };
+
+      const snippetAtIndex3 = {
+        chunk_score: 0.85,
+        start_page: 20,
+        end_page: 20,
+        item_id: 200,
+        text: "snippets from index 3",
+      };
+
+      const resultsAtIndex1: ContentSearchResults = {
+        snippets: [snippetAtIndex1],
+        search_params: { query: [["keyword", "query1"]] },
+      };
+
+      const resultsAtIndex3: ContentSearchResults = {
+        snippets: [snippetAtIndex3],
+        search_params: { query: [["keyword", "query3"]] },
+      };
+
+      const mockMessages: Item[] = [
+        {
+          id: "1",
+          content: "First question",
+          role: MessageRole.User,
+          type: ItemType.Message,
+        },
+        {
+          id: "2",
+          content: [
+            {
+              annotations: [],
+              text: "First response",
+              type: "output_text",
+            },
+          ],
+          role: MessageRole.Assistant,
+          type: ItemType.Message,
+        },
+        {
+          id: "3",
+          content: "Second question",
+          role: MessageRole.User,
+          type: ItemType.Message,
+        },
+        {
+          id: "4",
+          content: [
+            {
+              annotations: [],
+              text: "Second response",
+              type: "output_text",
+            },
+          ],
+          role: MessageRole.Assistant,
+          type: ItemType.Message,
+        },
+      ];
+
+      mockUseResearchAssistant.mockReturnValue({
+        messages: mockMessages,
+        isLoading: false,
+        results: { 1: resultsAtIndex1, 3: resultsAtIndex3 },
+        handlePreview: jest.fn(),
+      });
+
+      render(<ResearchAssistantWindow />);
+
+      expect(screen.getByText(/snippets from index 1/i)).toBeInTheDocument();
+      expect(screen.getByText(/snippets from index 3/i)).toBeInTheDocument();
+    });
+
+    test("does not display snippets when results are undefined for a message", () => {
+      const mockMessages: Item[] = [
+        {
+          id: "1",
+          content: "What is this?",
+          role: MessageRole.User,
+          type: ItemType.Message,
+        },
+        {
+          id: "2",
+          content: [
+            {
+              annotations: [],
+              text: "I found nothing.",
+              type: "output_text",
+            },
+          ],
+          role: MessageRole.Assistant,
+          type: ItemType.Message,
+        },
+      ];
+
+      mockUseResearchAssistant.mockReturnValue({
+        messages: mockMessages,
+        isLoading: false,
+        results: { 1: null },
+        handlePreview: jest.fn(),
+      });
+
+      render(<ResearchAssistantWindow />);
+
+      expect(screen.getByText("I found nothing.")).toBeInTheDocument();
+      expect(screen.queryByText(/page \d+/i)).not.toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
[SCHOL-593](https://newyorkpubliclibrary.atlassian.net/browse/SCHOL-593)

## Describe your changes

- Updates the MessageBubble index to match the results' message index. The relevant snippets for messages was not being displayed due to a mismatch in message to result indices. (regression from #1055)
- Fixes an issue where no results are displayed for a catalog search if the current message is referring to the same result set from the previous message. The fix is to persist the latest results available.

## How to test
Locally


[SCHOL-593]: https://newyorkpubliclibrary.atlassian.net/browse/SCHOL-593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ