### PR TITLE
Use GRIN barcode over edition_id for loading book metadata based on TP query

### DIFF
--- a/.github/actions/mask-etl-pipeline-secrets/mask_secrets.py
+++ b/.github/actions/mask-etl-pipeline-secrets/mask_secrets.py
@@ -22,34 +22,34 @@ from utils.load_env import parameter_values
 
 def main():
     """Mask all secrets from .env.*.secrets files."""
-    
+
     # Find all .env.*.secrets files in config directory
     config_dir = etl_pipeline_dir / "config"
     secrets_pattern = str(config_dir / ".env.*.secrets")
     secrets_files = glob.glob(secrets_pattern)
-    
+
     if not secrets_files:
         print("No .env.*.secrets files found to mask")
         return
-    
+
     print(f"Found {len(secrets_files)} secrets file(s) to process")
-    
+
     total = len(secrets_files)
     for index, secrets_file in enumerate(secrets_files, start=1):
         print(f"Processing secrets file {index} of {total}...")
-        
+
         # Load SSM arns
         env_vars = dotenv_values(secrets_file)
         arns = [v for v in env_vars.values() if v]  # Non-empty values only
-        
+
         if not arns:
             print(f"  No variables to mask in secrets file {index}")
             continue
-        
+
         try:
             # Fetch secret values from SSM
             arn_to_value = parameter_values(arns)
-            
+
             # Mask each decrypted value.
             # Multi-line secrets must be split and each line masked individually,
             # as ::add-mask:: only supports single-line values. see: https://github.com/actions/toolkit/blob/main/docs/commands.md#register-a-secret
@@ -60,13 +60,13 @@ def main():
                     if line:
                         print(f"::add-mask::{line}")
                 masked_count += 1
-            
+
             print(f"  Masked {masked_count} secret(s) from secrets file {index}")
-            
+
         except Exception as e:
             print(f"  Error processing secrets file {index}: {e}")
             sys.exit(1)
-    
+
     print("Secret masking complete")
 
 

--- a/etl-pipeline/api/assistant/agent.py
+++ b/etl-pipeline/api/assistant/agent.py
@@ -277,14 +277,10 @@ class ContentSearchExecutionContext:
 
     backend: TurbopufferBackend
     embedder: GoogleEmbedder
-<<<<<<< HEAD
     session_id: str
     edition_id: int
-    conversation_type: str = "contentSearch"
-=======
-    edition_id: Optional[int] = None
     barcode: Optional[str] = None
->>>>>>> b1cdce594e (Switch to barcode rather than edition_id)
+    conversation_type: str = "contentSearch"
     search_results: Dict = field(default_factory=dict)
     frbr_fields: Dict = field(default_factory=dict)
 
@@ -549,7 +545,6 @@ async def update_chat(
 
     # Search within single book
     if conversation_type == "contentSearch":
-<<<<<<< HEAD
         # Fetch FRBR data for the book
         with Timer(
             "get_frbr_data_by_edition",
@@ -563,7 +558,6 @@ async def update_chat(
                 f"FRBR data missing for content search in edition {edition_id}"
             )
             raise ValueError(f"No edition found with id {edition_id}")
-=======
         # Prefer barcode-based lookup when provided. Barcode is stable across
         # FRBR re-clustering, whereas edition_id is not.
         if barcode is not None:
@@ -592,19 +586,14 @@ async def update_chat(
                     f"FRBR data missing for content search in edition {edition_id}"
                 )
             resolved_edition_id = edition_id
->>>>>>> b1cdce594e (Switch to barcode rather than edition_id)
         frbr_fields = format_frbr_fields(frbr_data[0].Work, frbr_data[0].Edition)
 
         exec_context = ContentSearchExecutionContext(
             backend=backend,
             embedder=embedder,
-<<<<<<< HEAD
-            edition_id=edition_id,
-            session_id=session_id,
-=======
             edition_id=resolved_edition_id,
+            session_id=session_id,
             barcode=barcode,
->>>>>>> b1cdce594e (Switch to barcode rather than edition_id)
             frbr_fields=frbr_fields,
         )
 

--- a/etl-pipeline/api/assistant/agent.py
+++ b/etl-pipeline/api/assistant/agent.py
@@ -35,6 +35,18 @@ from openai.types.shared import Reasoning
 from sqlalchemy import text
 
 
+# api code
+from ..utils import remove_markdown_comments
+from ..db import (
+    get_frbr_data_by_barcode,
+    get_frbr_data_by_edition,
+    get_readonly_session,
+    get_async_engine,
+    get_engine,
+)
+from .search import hybrid_search, ReciprocalRankFuser, ScoredHit
+from .types import CatalogSearchResult, ContentSearchResult
+
 # shared code
 from vector_indexing.components.embedders.google import GoogleEmbedder
 from vector_indexing.components.backends.turbopuffer import TurbopufferBackend
@@ -256,13 +268,23 @@ class CatalogSearchExecutionContext:
 
 @dataclass
 class ContentSearchExecutionContext:
-    """Container used to inject objects into each agent run execution."""
+    """Container used to inject objects into each agent run execution.
+
+    Either edition_id or barcode must be provided. When barcode is set, the
+    book filter for Turbopuffer searches is applied on `barcode` (stable across
+    FRBR re-clustering); otherwise it falls back to filtering on `edition_id`.
+    """
 
     backend: TurbopufferBackend
     embedder: GoogleEmbedder
+<<<<<<< HEAD
     session_id: str
     edition_id: int
     conversation_type: str = "contentSearch"
+=======
+    edition_id: Optional[int] = None
+    barcode: Optional[str] = None
+>>>>>>> b1cdce594e (Switch to barcode rather than edition_id)
     search_results: Dict = field(default_factory=dict)
     frbr_fields: Dict = field(default_factory=dict)
 
@@ -471,6 +493,7 @@ async def update_chat(
     conversation_type: str,
     session_id: str,
     edition_id=None,
+    barcode=None,
     max_turns: int = DEFAULT_MAX_TURNS,
 ) -> RunResult:
     """
@@ -488,7 +511,10 @@ async def update_chat(
         conversation_type: Either "contentSearch" or "catalogSearch" to pick the search mode.
         session_id: Client-supplied session ID. History is persisted to and loaded
                     from the database using this key.
-        edition_id: Required when conversation_type is "contentSearch" so the agent knows which book to inspect.
+        edition_id: Identifies the book for content search. Either this or
+            ``barcode`` must be provided when conversation_type is
+            "contentSearch". If both are provided, ``barcode`` takes
+            precedence (it is stable across FRBR re-clustering).
 
     Returns:
         The agent's RunResult obj.
@@ -523,6 +549,7 @@ async def update_chat(
 
     # Search within single book
     if conversation_type == "contentSearch":
+<<<<<<< HEAD
         # Fetch FRBR data for the book
         with Timer(
             "get_frbr_data_by_edition",
@@ -536,13 +563,48 @@ async def update_chat(
                 f"FRBR data missing for content search in edition {edition_id}"
             )
             raise ValueError(f"No edition found with id {edition_id}")
+=======
+        # Prefer barcode-based lookup when provided. Barcode is stable across
+        # FRBR re-clustering, whereas edition_id is not.
+        if barcode is not None:
+            with Timer(
+                "get_frbr_data_by_barcode",
+                on_exit=lambda name, elapsed: logger.info(
+                    f"{name} took {elapsed:.3f}s for 1 barcode"
+                ),
+            ):
+                frbr_data = get_frbr_data_by_barcode([barcode])
+            if not frbr_data:
+                logger.error(
+                    f"FRBR data missing for content search by barcode {barcode}"
+                )
+            resolved_edition_id = frbr_data[0].Edition.id if frbr_data else None
+        else:
+            with Timer(
+                "get_frbr_data_by_edition",
+                on_exit=lambda name, elapsed: logger.info(
+                    f"{name} took {elapsed:.3f}s for 1 edition"
+                ),
+            ):
+                frbr_data = get_frbr_data_by_edition([edition_id])
+            if not frbr_data:
+                logger.error(
+                    f"FRBR data missing for content search in edition {edition_id}"
+                )
+            resolved_edition_id = edition_id
+>>>>>>> b1cdce594e (Switch to barcode rather than edition_id)
         frbr_fields = format_frbr_fields(frbr_data[0].Work, frbr_data[0].Edition)
 
         exec_context = ContentSearchExecutionContext(
             backend=backend,
             embedder=embedder,
+<<<<<<< HEAD
             edition_id=edition_id,
             session_id=session_id,
+=======
+            edition_id=resolved_edition_id,
+            barcode=barcode,
+>>>>>>> b1cdce594e (Switch to barcode rather than edition_id)
             frbr_fields=frbr_fields,
         )
 
@@ -751,13 +813,14 @@ def search_catalog(
 
         # MAYBE: turn the below into 2 functions: group_by_edition_and_sort() and enrich_edition_hits() (with limit to top 10 in between)
 
-        # Group chunk hits by Edition (before adding FRBR data)
-        # edition_hit = {"chunk_hits", "agg_score", "edition_id"}
+        # Group chunk hits by barcode (stable across FRBR re-clustering).
+        # The DB-resolved edition_id is attached after the FRBR fetch below.
+        # edition_hit = {"chunk_hits", "agg_score", "barcode"}
         edition_hits = {}
         for chunk_hit in results_to_chunk_hits(results):
             edition_hits.setdefault(
-                chunk_hit["edition_id"],
-                {"edition_id": chunk_hit["edition_id"], "chunk_hits": []},
+                chunk_hit["barcode"],
+                {"barcode": chunk_hit["barcode"], "chunk_hits": []},
             )["chunk_hits"].append(chunk_hit)
 
         # Calculate aggregate edition score
@@ -786,45 +849,44 @@ def search_catalog(
             edition_hits = edition_hits[:PAGE_SIZE]
             # TODO: handle paginating or providing more edition hits
 
-        # Fetch FRBR data (from DB)
+        # Fetch FRBR data (from DB) by barcode. Barcode is stable across FRBR
+        # re-clustering, while the edition_id stored on chunk hits in TP may
+        # be stale; the DB-resolved edition_id (highest per barcode = most
+        # recently clustered) is what we attach to results for the FE.
         # TODO: remove fetch of DB data everything the LLM needs is in TP \
         # (right?) and the FE fetches other metadata in a separate request.
-        edition_ids = [h["edition_id"] for h in edition_hits]
-        logger.info(
-            f"Fetching FRBR metadata for the following edition_ids: {edition_ids}"
-        )
+        barcodes = [h["barcode"] for h in edition_hits]
+        logger.info(f"Fetching FRBR metadata for the following barcodes: {barcodes}")
         with Timer(
-            "get_frbr_data_by_edition",
+            "get_frbr_data_by_barcode",
             on_exit=lambda name, elapsed: logger.info(
-                f"{name} took {elapsed:.3f}s for {len(edition_ids)} editions"
+                f"{name} took {elapsed:.3f}s for {len(barcodes)} barcodes"
             ),
         ):
-            frbr_data = get_frbr_data_by_edition(edition_ids)
+            frbr_data = get_frbr_data_by_barcode(barcodes)
 
         # Merge ES hit data and FRBR metadata (maintaining edition sort order)
-        # ALT: if frbr_data was pre-sorted by edition_ids in the SQL call, we \
-        # could zip frbr data and edition hits bc order would be the same
-        frbr_data = {row.Edition.id: row for row in frbr_data}
+        frbr_data = {row.barcode: row for row in frbr_data}
         edition_data = []  # list of EditionResult
         missing_data = []
         for edition_hit in edition_hits:
-            # match DB orm work/edition to vector search edition hit
-            row = frbr_data.get(edition_hit["edition_id"])
+            # match DB orm work/edition to vector search edition hit by barcode
+            row = frbr_data.get(edition_hit["barcode"])
             if row is None:
-                missing_data.append(edition_hit["edition_id"])
+                missing_data.append(edition_hit["barcode"])
             else:
                 edition_data.append(
                     CatalogSearchResult(
                         orm_work=row.Work,
                         orm_edition=row.Edition,
-                        edition_id=edition_hit["edition_id"],
+                        edition_id=row.Edition.id,
                         chunk_hits=edition_hit["chunk_hits"],
                         agg_score=edition_hit["agg_score"],
                     )
                 )
         if missing_data:
             logger.error(
-                f"Missing Data: {len(missing_data)} edition_ids from vector search results have no matching data in DB: {missing_data}"
+                f"Missing Data: {len(missing_data)} barcodes from vector search results have no matching data in DB: {missing_data}"
             )
             logger.info(
                 f"Limiting results to the {len(edition_data)} editions that have metadata in the DB."
@@ -871,7 +933,8 @@ def search_book(
 ) -> str:
     try:
         logger.info(
-            f"{ctx.tool_name} tool called with args: '{ctx.tool_arguments}', for edition_id = {ctx.context.edition_id}"
+            f"{ctx.tool_name} tool called with args: '{ctx.tool_arguments}', "
+            f"for edition_id = {ctx.context.edition_id}, barcode = {ctx.context.barcode}"
         )
 
         # Post-process filters through the pipeline
@@ -879,8 +942,12 @@ def search_book(
             filters, apply_null_matching=filters_match_null
         )
 
-        # Build filter to restrict search to single book
-        book_filter = ["edition_id", "Eq", ctx.context.edition_id]
+        # Build filter to restrict search to single book. Prefer barcode
+        # (stable identifier) when available; fall back to edition_id.
+        if ctx.context.barcode is not None:
+            book_filter = ["barcode", "Eq", ctx.context.barcode]
+        else:
+            book_filter = ["edition_id", "Eq", ctx.context.edition_id]
 
         # Combine with user filters if provided
         if filters is not None:

--- a/etl-pipeline/api/blueprints/chat.py
+++ b/etl-pipeline/api/blueprints/chat.py
@@ -179,11 +179,11 @@ def chat(session_id):
 
     with LogContextVars(get_app_logger(), context=log_context):
         return _chat_handler(
-            user, session_id, conversation_type, message, edition_id, barcode
+            session_id, conversation_type, message, edition_id, barcode
         )
 
 
-def _chat_handler(user, session_id, conversation_type, message, edition_id, barcode):
+def _chat_handler(session_id, conversation_type, message, edition_id, barcode):
     """wrapper for main chat() logic to allow use of LogContextVars without a huge indent block"""
 
     logger.info(f"Chat request received: {message[:20]}...")

--- a/etl-pipeline/api/blueprints/chat.py
+++ b/etl-pipeline/api/blueprints/chat.py
@@ -157,7 +157,6 @@ def prepare_search_response(search_results) -> Tuple[str, Dict] | Tuple[None, No
 
 @chat_blueprint.route("", methods=["POST"])
 @require_api_key
-@require_basic_authentication
 @require_session_jwt
 @timer(logger)
 def chat(session_id):

--- a/etl-pipeline/api/blueprints/chat.py
+++ b/etl-pipeline/api/blueprints/chat.py
@@ -157,16 +157,20 @@ def prepare_search_response(search_results) -> Tuple[str, Dict] | Tuple[None, No
 
 @chat_blueprint.route("", methods=["POST"])
 @require_api_key
+@require_basic_authentication
 @require_session_jwt
 @timer(logger)
 def chat(session_id):
     conversation_type = request.json.get("conversationType")
     message = request.json.get("message")
     edition_id = request.json.get("editionId")
+    barcode = request.json.get("barcode")
 
     log_context = {"session_id": session_id, "conversation_type": conversation_type}
     if edition_id is not None:
         log_context["edition_id"] = edition_id
+    if barcode is not None:
+        log_context["barcode"] = barcode
 
     # New Relic custom attributes and AI monitoring conversation grouping
     for k, v in log_context.items():
@@ -175,10 +179,12 @@ def chat(session_id):
         newrelic.agent.add_custom_attribute("llm.conversation_id", session_id)
 
     with LogContextVars(get_app_logger(), context=log_context):
-        return _chat_handler(session_id, conversation_type, message, edition_id)
+        return _chat_handler(
+            user, session_id, conversation_type, message, edition_id, barcode
+        )
 
 
-def _chat_handler(session_id, conversation_type, message, edition_id):
+def _chat_handler(user, session_id, conversation_type, message, edition_id, barcode):
     """wrapper for main chat() logic to allow use of LogContextVars without a huge indent block"""
 
     logger.info(f"Chat request received: {message[:20]}...")
@@ -202,11 +208,13 @@ def _chat_handler(session_id, conversation_type, message, edition_id):
             },
         )
 
-    if conversation_type == "contentSearch" and edition_id is None:
+    if conversation_type == "contentSearch" and edition_id is None and barcode is None:
         return APIUtils.formatResponseObject(
             400,
             RESPONSE_TYPE,
-            {"message": "editionId is required for conversationType='contentSearch'"},
+            {
+                "message": "editionId or barcode is required for conversationType='contentSearch'"
+            },
         )
 
     # get LLM response + search results
@@ -215,8 +223,14 @@ def _chat_handler(session_id, conversation_type, message, edition_id):
     # high level openai agents sdk errors)
     try:
         run_result = asyncio.run(
-            update_chat(message, conversation_type, session_id, edition_id=edition_id)
-        )
+            update_chat(
+                message,
+                conversation_type,
+                session_id,
+                edition_id=edition_id,
+                barcode=barcode,
+            )
+    )
     except ValueError as e:
         # Intended to catch "No edition found with id=XXX"
         # TODO: make error filter specific to intended error, even tho its the \

--- a/etl-pipeline/api/blueprints/chat.py
+++ b/etl-pipeline/api/blueprints/chat.py
@@ -230,7 +230,7 @@ def _chat_handler(user, session_id, conversation_type, message, edition_id, barc
                 edition_id=edition_id,
                 barcode=barcode,
             )
-    )
+        )
     except ValueError as e:
         # Intended to catch "No edition found with id=XXX"
         # TODO: make error filter specific to intended error, even tho its the \

--- a/etl-pipeline/api/db.py
+++ b/etl-pipeline/api/db.py
@@ -112,13 +112,34 @@ def get_async_engine():
     return _async_engine
 
 
+def _load_editions_with_frbr_data(session, edition_ids):
+    """
+    Fetch Edition rows for the given ids, eager loading Edition.work,
+    Edition.links, Edition.items.links, and Edition.items.rights.
+
+    Uses selectinload to avoid cartesian product explosion from chained outer
+    joins.
+    """
+    if not edition_ids:
+        return []
+    return (
+        session.query(Edition)
+        .filter(Edition.id.in_(edition_ids))
+        .options(
+            selectinload(Edition.work),
+            selectinload(Edition.links),
+            selectinload(Edition.items).selectinload(Item.links),
+            selectinload(Edition.items).selectinload(Item.rights),
+        )
+        .all()
+    )
+
+
 def get_frbr_data_by_edition(edition_ids: List):
     """
     Return list of (Work, Edition) tuples for each of the passed edition_ids.
     Edition includes eager loaded: Edition.items, Edition.items.links,
     Edition.items.rights, Edition.links.
-
-    Uses selectinload to avoid cartesian product explosion from chained outer joins.
     """
     if edition_ids is None or len(edition_ids) == 0:
         return []
@@ -129,17 +150,7 @@ def get_frbr_data_by_edition(edition_ids: List):
 
     Session = get_readonly_session()
     with Session() as session:
-        editions = (
-            session.query(Edition)
-            .filter(Edition.id.in_(edition_ids))
-            .options(
-                selectinload(Edition.work),
-                selectinload(Edition.links),
-                selectinload(Edition.items).selectinload(Item.links),
-                selectinload(Edition.items).selectinload(Item.rights),
-            )
-            .all()
-        )
+        editions = _load_editions_with_frbr_data(session, edition_ids)
         return [Row(Work=e.work, Edition=e) for e in editions]
 
 
@@ -192,17 +203,7 @@ def get_frbr_data_by_barcode(barcodes: List):
         }
         edition_ids = set(barcode_to_edition_id.values())
 
-        editions = (
-            session.query(Edition)
-            .filter(Edition.id.in_(edition_ids))
-            .options(
-                selectinload(Edition.work),
-                selectinload(Edition.links),
-                selectinload(Edition.items).selectinload(Item.links),
-                selectinload(Edition.items).selectinload(Item.rights),
-            )
-            .all()
-        )
+        editions = _load_editions_with_frbr_data(session, edition_ids)
         editions_by_id = {e.id: e for e in editions}
         rows = []
         for barcode, edition_id in barcode_to_edition_id.items():

--- a/etl-pipeline/api/db.py
+++ b/etl-pipeline/api/db.py
@@ -23,6 +23,7 @@ from model import (
     Collection,
     User,
     AutomaticCollection,
+    GRINStatus,
 )
 from managers.db import DBManager
 from utils.common import require_env
@@ -140,6 +141,76 @@ def get_frbr_data_by_edition(edition_ids: List):
             .all()
         )
         return [Row(Work=e.work, Edition=e) for e in editions]
+
+
+def get_frbr_data_by_barcode(barcodes: List):
+    """
+    Return list of Row(Work, Edition, barcode) for each of the passed barcodes
+    by resolving barcode -> grin_statuses.record_id -> items.edition_id ->
+    editions/works.
+
+    A single barcode can map to multiple editions (the same record_id may be
+    referenced by items pointing at different editions when FRBR re-clusters).
+    For each barcode we return the row with the highest edition_id, since that
+    corresponds to the most recently clustered edition. Barcodes with no
+    matching grin_status / record / item / edition are omitted.
+
+    Edition includes eager loaded: Edition.items, Edition.items.links,
+    Edition.items.rights, Edition.links (matching get_frbr_data_by_edition).
+    """
+    if barcodes is None or len(barcodes) == 0:
+        return []
+
+    from collections import namedtuple
+
+    Row = namedtuple("Row", ["Work", "Edition", "barcode"])
+
+    Session = get_readonly_session()
+    with Session() as session:
+        # Resolve barcode -> highest edition_id via grin_statuses + items.
+        # Picks the max edition_id per barcode (most recently clustered).
+        resolution_rows = (
+            session.query(
+                GRINStatus.barcode,
+                func.max(Item.edition_id).label("edition_id"),
+            )
+            .join(Item, Item.record_id == GRINStatus.record_id)
+            .filter(GRINStatus.barcode.in_(barcodes))
+            .group_by(GRINStatus.barcode)
+            .all()
+        )
+        if not resolution_rows:
+            return []
+
+        # Multiple barcodes can resolve to the same edition_id (different GRIN
+        # records pointing at items clustered into the same edition). Keep a
+        # barcode -> edition_id map so each barcode produces its own Row.
+        barcode_to_edition_id = {
+            row.barcode: row.edition_id
+            for row in resolution_rows
+            if row.edition_id is not None
+        }
+        edition_ids = set(barcode_to_edition_id.values())
+
+        editions = (
+            session.query(Edition)
+            .filter(Edition.id.in_(edition_ids))
+            .options(
+                selectinload(Edition.work),
+                selectinload(Edition.links),
+                selectinload(Edition.items).selectinload(Item.links),
+                selectinload(Edition.items).selectinload(Item.rights),
+            )
+            .all()
+        )
+        editions_by_id = {e.id: e for e in editions}
+        rows = []
+        for barcode, edition_id in barcode_to_edition_id.items():
+            e = editions_by_id.get(edition_id)
+            if e is None:
+                continue
+            rows.append(Row(Work=e.work, Edition=e, barcode=barcode))
+        return rows
 
 
 class DBClient:


### PR DESCRIPTION
Use the barcode to probe into postgres after the turbopuffer query rather than the edition_id. This eliminates the issue with edition_ids becoming stale after FRBR reclustering.