### PR TITLE
NOREF: Debug hang in GHA during integration test runs

### DIFF
--- a/.github/workflows/etl-pipeline-tests.yaml
+++ b/.github/workflows/etl-pipeline-tests.yaml
@@ -93,6 +93,7 @@ jobs:
           ENVIRONMENT: local
         working-directory: ./etl-pipeline
         run: |
+          pip install pytest-timeout
           make integration-drb
 
       - name: Seed local Postgres DB to support /chat API tests

--- a/.github/workflows/etl-pipeline-tests.yaml
+++ b/.github/workflows/etl-pipeline-tests.yaml
@@ -93,7 +93,6 @@ jobs:
           ENVIRONMENT: local
         working-directory: ./etl-pipeline
         run: |
-          pip install pytest-timeout
           make integration-drb
 
       - name: Seed local Postgres DB to support /chat API tests

--- a/etl-pipeline/Makefile
+++ b/etl-pipeline/Makefile
@@ -19,7 +19,7 @@ integration-drb:
 	python -m pytest tests/integration --ignore=tests/integration/api/assistant --env=$(ENVIRONMENT) -n=4 --timeout=120
 
 integration-vra:
-	python -m pytest tests/integration/api/assistant --env=$(ENVIRONMENT) -n=4
+	python -m pytest tests/integration/api/assistant --env=$(ENVIRONMENT) -n=4 --timeout=120
 
 up:
 	$(compose_command) up -d

--- a/etl-pipeline/Makefile
+++ b/etl-pipeline/Makefile
@@ -16,7 +16,7 @@ functional:
 	python -m pytest tests/functional --env=$(ENVIRONMENT) -n=4
 
 integration-drb:
-	python -m pytest tests/integration --ignore=tests/integration/api/assistant --env=$(ENVIRONMENT) -n=4
+	python -m pytest tests/integration --ignore=tests/integration/api/assistant --env=$(ENVIRONMENT) -n=4 --timeout=120
 
 integration-vra:
 	python -m pytest tests/integration/api/assistant --env=$(ENVIRONMENT) -n=4

--- a/etl-pipeline/dev-requirements.txt
+++ b/etl-pipeline/dev-requirements.txt
@@ -5,6 +5,7 @@ pytest-asyncio==1.3.0
 pytest-cov==7.0.0
 pytest-mock==3.15.1
 pytest-rerunfailures==16.1
+pytest-timeout==2.4.0
 pytest-xdist==3.8.0
 pytest==9.0.2
 requests-mock==1.12.1

--- a/etl-pipeline/services/sources/loc_service.py
+++ b/etl-pipeline/services/sources/loc_service.py
@@ -101,7 +101,7 @@ class LOCService(SourceService):
                     continue
 
                 logger.exception(f"Failed to load page data from: {page_url}")
-                return {}
+                return None
 
     def get_record(self, record_id: str):
         pass

--- a/etl-pipeline/services/sources/loc_service.py
+++ b/etl-pipeline/services/sources/loc_service.py
@@ -81,7 +81,7 @@ class LOCService(SourceService):
     def _fetch_page_json_data(self, page_url: str) -> dict | None:
         max_attempts = 3
 
-        for attempt in (0, max_attempts):
+        for attempt in range(max_attempts):
             try:
                 page_response = requests.get(
                     page_url, headers={"Accept": "application/json"}

--- a/etl-pipeline/tests/integration/api/assistant/test_chat.py
+++ b/etl-pipeline/tests/integration/api/assistant/test_chat.py
@@ -30,7 +30,12 @@ def test_chat(conversation_type, message, edition_id, vra_test_user):
     if edition_id is not None:
         payload["editionId"] = edition_id
 
-    response = requests.post(url, json=payload, headers=get_vra_auth_headers())
+    response = requests.post(
+        url,
+        json=payload,
+        headers=get_vra_auth_headers(),
+        timeout=90,  # 30s faster than pytest timeout to catch API timeouts explicitly
+    )
 
     # Verify HTTP status code is returned and is 200 OK
     assert response.status_code is not None

--- a/etl-pipeline/vector_indexing/components/embedders/bedrock.py
+++ b/etl-pipeline/vector_indexing/components/embedders/bedrock.py
@@ -36,8 +36,8 @@ class BedrockEmbedder(Embedder):
             ``assume_role`` is also provided, this profile is used to perform
             the STS AssumeRole call.
         assume_role: ARN of an IAM role to assume for model inference calls.
-        
-        .embed_document(), .embed_document_batch(), .embed_query(), and .embed_query_batch() 
+
+        .embed_document(), .embed_document_batch(), .embed_query(), and .embed_query_batch()
         inherited from the abstract class raise NotImplementedError.
     """
 

--- a/etl-pipeline/vector_indexing/components/embedders/openai.py
+++ b/etl-pipeline/vector_indexing/components/embedders/openai.py
@@ -20,8 +20,8 @@ class OpenAIEmbedder(Embedder):
         model_name: Model identifier to pass in the request payload.
         dimensions: Output vector dimensions. Must match the model's output size.
         batch_size: Max texts per API call (default: 32).
-        
-        .embed_document(), .embed_document_batch(), .embed_query(), and .embed_query_batch() 
+
+        .embed_document(), .embed_document_batch(), .embed_query(), and .embed_query_batch()
         inherited from the abstract class raise NotImplementedError.
     """
 


### PR DESCRIPTION
Attempts to debug a hang currently occurring on **ETL Pipeline Tests (Pull Request)** workflow runs in GHA for multiple open PRs ([#1093](https://github.com/NYPL/digital-research-books/pull/1093), [#1119](https://github.com/NYPL/digital-research-books/pull/1119)).

First observed with the following run, where the DRB integration test run step hung for almost 2 hours: https://github.com/NYPL/digital-research-books/actions/runs/26591926386/job/78352684141#step:12:31

