### PR TITLE
SCHOL-637: Replace Preview button with Read online

### DIFF
--- a/web/playwright/research-assistant-page/research-assistant-page.spec.ts
+++ b/web/playwright/research-assistant-page/research-assistant-page.spec.ts
@@ -165,14 +165,17 @@ test.describe("Research Assistant Page Functionality", { tag: "@vra" }, () => {
         await researchAssistantPage.firstResultTitleLink.click({ trial: true });
       }).toPass();
 
-      await expect(researchAssistantPage.firstResultPreviewBtn).toHaveAttribute(
-        "href",
-        itemPageUrlPattern
-      );
-      await expect(researchAssistantPage.firstResultPreviewBtn).toBeVisible();
-      await expect(researchAssistantPage.firstResultPreviewBtn).toBeEnabled();
+      await expect(
+        researchAssistantPage.firstResultReadOnlineBtn
+      ).toHaveAttribute("href", itemPageUrlPattern);
+      await expect(
+        researchAssistantPage.firstResultReadOnlineBtn
+      ).toBeVisible();
+      await expect(
+        researchAssistantPage.firstResultReadOnlineBtn
+      ).toBeEnabled();
       await expect(async () => {
-        await researchAssistantPage.firstResultPreviewBtn.click({
+        await researchAssistantPage.firstResultReadOnlineBtn.click({
           trial: true,
         });
       }).toPass();

--- a/web/playwright/research-assistant-page/research-assistant-page.ts
+++ b/web/playwright/research-assistant-page/research-assistant-page.ts
@@ -36,7 +36,7 @@ class ResearchAssistantPage {
   readonly firstResultAuthor: Locator;
   readonly firstResultEdition: Locator;
   readonly firstResultPublisher: Locator;
-  readonly firstResultPreviewBtn: Locator;
+  readonly firstResultReadOnlineBtn: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -93,8 +93,8 @@ class ResearchAssistantPage {
     this.firstResultPublisher = this.firstResult.getByTestId(
       RESULT_PUBLISHER_TEST_ID
     );
-    this.firstResultPreviewBtn = this.firstResult.getByRole("link", {
-      name: "Preview",
+    this.firstResultReadOnlineBtn = this.firstResult.getByRole("link", {
+      name: "Read online",
     });
   }
 

--- a/web/src/__tests__/fixtures/CatalogSearchFixture.ts
+++ b/web/src/__tests__/fixtures/CatalogSearchFixture.ts
@@ -1,8 +1,9 @@
 import { Agent } from "~/src/types/DataModel";
 import {
   CatalogEdition,
+  CatalogItem,
+  CatalogLink,
   CatalogSearchResults,
-  SearchParams,
 } from "~/src/types/ResearchAssistant";
 
 const mockPaging = {
@@ -19,191 +20,255 @@ const createAgent = (name: string): Agent => ({
   roles: ["author"],
 });
 
-export const catalogResults: CatalogSearchResults = {
+const defaultFlags = {
+  catalog: false,
+  download: false,
+  embed: false,
+  reader: false,
+};
+
+let nextLinkId = 1;
+
+export const createLink = (
+  overrides: Partial<CatalogLink> = {}
+): CatalogLink => ({
+  id: nextLinkId++,
+  url: "https://example.org/resource",
+  media_type: "text/html",
+  content: null,
+  flags: { ...defaultFlags },
+  ...overrides,
+});
+
+export const createItem = (
+  overrides?: Partial<CatalogItem> & { linkOverrides?: Partial<CatalogLink>[] }
+): CatalogItem => {
+  const { linkOverrides, ...rest } = overrides || {};
+
+  return {
+    id: 2001,
+    edition_id: 1001,
+    content_type: "ebook",
+    contributors: [],
+    drm: null,
+    links: linkOverrides
+      ? linkOverrides.map((lo) => createLink(lo))
+      : [
+          createLink({
+            media_type: "text/html",
+            flags: { ...defaultFlags, embed: true },
+          }),
+          createLink({
+            media_type: "application/ocr",
+            flags: { ...defaultFlags, reader: true },
+          }),
+        ],
+    measurements: null,
+    physical_location: null,
+    rights: [
+      {
+        license: "public_domain",
+        rights_statement: "Public Domain",
+        source: "test-source",
+      },
+    ],
+    source: "grin",
+    ...rest,
+  };
+};
+
+const defaultLanguage = {
+  language: "English",
+  iso_2: "en",
+  iso_3: "eng",
+};
+
+const baseEdition: Partial<CatalogEdition> = {
+  items: [],
+  languages: [defaultLanguage],
+  links: [],
+  measurements: [],
+  publishers: [],
+  snippets: [],
+};
+
+export const createEdition = (
+  overrides: Partial<CatalogEdition> & { snippetCount?: number } = {}
+): CatalogEdition => {
+  const { snippetCount = 1, ...rest } = overrides;
+
+  const snippets =
+    rest.snippets ??
+    Array.from({ length: snippetCount }, (_, i) => ({
+      chunk_score: 0.5 - i * 0.1,
+      start_page: i + 1,
+      end_page: i + 10,
+      item_id: 2001,
+      text: `Test snippet ${i + 1}`,
+    }));
+
+  return {
+    ...baseEdition,
+    id: 1001,
+    title: "Test Edition Title",
+    publication_date: "2024",
+    publication_place: null,
+    work_authors: [createAgent("Test Author")],
+    work_title: "Test Title",
+    work_uuid: "test-work-uuid-1",
+    alt_titles: [],
+    contributors: [],
+    dates: [{ date: "2024", type: "publication_date" }],
+    edition: null,
+    edition_statement: "1st ed",
+    extent: "100 p.",
+    sub_title: null,
+    summary: "Test summary",
+    table_of_contents: null,
+    volume: null,
+    work: [],
+    work_alt_titles: [],
+    work_contributors: [],
+    work_dates: null,
+    work_id: 4001,
+    work_languages: [],
+    work_measurements: [],
+    work_medium: null,
+    work_series: null,
+    work_series_position: null,
+    work_sub_title: null,
+    work_subjects: [],
+    snippets,
+    ...rest,
+  } as CatalogEdition;
+};
+
+export const createWork = (edition: CatalogEdition, overrides?: any) => ({
+  uuid: edition.work_uuid,
+  title: edition.work_title,
+  editions: [edition],
+  edition_count: 1,
+  ...overrides,
+});
+
+const createPaging = (
+  totalRecords = 0,
+  overrides: Partial<CatalogSearchResults["paging"]> = {}
+): CatalogSearchResults["paging"] => ({
+  ...mockPaging,
+  totalRecords,
+  ...overrides,
+});
+
+export const createCatalogResults = ({
+  editions = [],
+  query = "test",
+  totalRecords = editions.length,
+  paging = {},
+}: {
+  editions?: CatalogEdition[];
+  query?: string;
+  totalRecords?: number;
+  paging?: Partial<CatalogSearchResults["paging"]>;
+} = {}): CatalogSearchResults => ({
+  editions,
+  search_params: {
+    query: [["keyword", query]],
+    filters: [],
+  },
+  paging: createPaging(totalRecords, paging),
+});
+
+export const catalogResults = createCatalogResults({
+  query: "test",
+  totalRecords: 2,
   editions: [
-    {
+    createEdition({
       id: 1,
       title: "Test Book 1",
-      items: [],
-      languages: [{ language: "English", iso_2: "en", iso_3: "eng" }],
-      links: [],
-      measurements: [],
-      publication_date: "2023",
-      publication_place: undefined,
-      publishers: [],
-      snippets: [],
-      work_authors: [createAgent("Author One"), createAgent("Author Two")],
       work_title: "Test Book 1",
       work_uuid: "1",
-    } as CatalogEdition,
-    {
+      publication_date: "2023",
+      publication_place: undefined,
+      work_authors: [createAgent("Author One"), createAgent("Author Two")],
+    }),
+    createEdition({
       id: 2,
       title: "Test Book 2",
-      items: [],
-      languages: [{ language: "English", iso_2: "en", iso_3: "eng" }],
-      links: [],
-      measurements: [],
-      publication_date: "2022",
-      publication_place: undefined,
-      publishers: [],
-      snippets: [],
-      work_authors: [createAgent("Author Three")],
       work_title: "Test Book 2",
       work_uuid: "2",
-    } as CatalogEdition,
+      publication_date: "2022",
+      publication_place: undefined,
+      work_authors: [createAgent("Author Three")],
+    }),
   ],
-  search_params: {
-    query: [["keyword", "test"]],
-    filters: [],
-  } as SearchParams,
-  paging: {
-    recordsPerPage: mockPaging.recordsPerPage,
-    firstPage: mockPaging.firstPage,
-    previousPage: mockPaging.previousPage,
-    currentPage: mockPaging.currentPage,
-    nextPage: mockPaging.nextPage,
-    lastPage: mockPaging.lastPage,
-    totalRecords: 2,
-  },
-};
+});
 
-export const minimalCatalogResults: CatalogSearchResults = {
+export const minimalCatalogResults = createCatalogResults({
+  query: "minimal",
   editions: [
-    {
+    createEdition({
       id: 3,
       title: "Minimal Book",
-      items: [],
-      languages: [{ language: "English", iso_2: "en", iso_3: "eng" }],
-      links: [],
-      measurements: [],
-      publishers: [],
-      snippets: [],
-      work_authors: [],
       work_title: "Minimal Book",
       work_uuid: "3",
-    } as CatalogEdition,
+      work_authors: [],
+      snippetCount: 0,
+    }),
   ],
-  search_params: { query: [["keyword", "minimal"]] } as SearchParams,
-  paging: {
-    recordsPerPage: mockPaging.recordsPerPage,
-    firstPage: mockPaging.firstPage,
-    previousPage: mockPaging.previousPage,
-    currentPage: mockPaging.currentPage,
-    nextPage: mockPaging.nextPage,
-    lastPage: mockPaging.lastPage,
-    totalRecords: 1,
-  },
-};
+});
 
-export const multiPageCatalogResults: CatalogSearchResults = {
-  ...catalogResults,
-  paging: {
-    ...catalogResults.paging,
-    lastPage: 3,
-    nextPage: 2,
-    totalRecords: 25,
-  },
-};
+export const multiPageCatalogResults = createCatalogResults({
+  query: "test",
+  editions: catalogResults.editions,
+  totalRecords: 25,
+  paging: { lastPage: 3, nextPage: 2 },
+});
 
-export const emptyCatalogResults: CatalogSearchResults = {
-  editions: [],
-  search_params: { query: [["keyword", "nothing"]] } as SearchParams,
-  paging: {
-    recordsPerPage: 10,
-    firstPage: 1,
-    previousPage: 1,
-    currentPage: 1,
-    nextPage: 1,
-    lastPage: 1,
-    totalRecords: 0,
-  },
-};
+export const emptyCatalogResults = createCatalogResults({
+  query: "nothing",
+});
 
-export const singleAuthorCatalogResults: CatalogSearchResults = {
+export const singleAuthorCatalogResults = createCatalogResults({
+  query: "single",
   editions: [
-    {
+    createEdition({
       id: 4,
       title: "Single Author Book",
-      items: [],
-      languages: [{ language: "English", iso_2: "en", iso_3: "eng" }],
-      links: [],
-      measurements: [],
-      publishers: [],
-      snippets: [],
-      work_authors: [createAgent("Solo Author")],
       work_title: "Single Author Book",
       work_uuid: "4",
-    } as CatalogEdition,
+      work_authors: [createAgent("Solo Author")],
+    }),
   ],
-  search_params: { query: [["keyword", "single"]] } as SearchParams,
-  paging: {
-    recordsPerPage: mockPaging.recordsPerPage,
-    firstPage: mockPaging.firstPage,
-    previousPage: mockPaging.previousPage,
-    currentPage: mockPaging.currentPage,
-    nextPage: mockPaging.nextPage,
-    lastPage: mockPaging.lastPage,
-    totalRecords: 1,
-  },
-};
+});
 
-export const manyAuthorsCatalogResults: CatalogSearchResults = {
+export const manyAuthorsCatalogResults = createCatalogResults({
+  query: "many",
   editions: [
-    {
+    createEdition({
       id: 5,
       title: "Many Authors Book",
-      items: [],
-      languages: [{ language: "English", iso_2: "en", iso_3: "eng" }],
-      links: [],
-      measurements: [],
-      publishers: [],
-      snippets: [],
+      work_title: "Many Authors Book",
+      work_uuid: "5",
       work_authors: Array.from({ length: 4 }, (_, i) =>
         createAgent(`Author ${i + 1}`)
       ),
-      work_title: "Many Authors Book",
-      work_uuid: "5",
-    } as CatalogEdition,
+    }),
   ],
-  search_params: { query: [["keyword", "many"]] } as SearchParams,
-  paging: {
-    recordsPerPage: mockPaging.recordsPerPage,
-    firstPage: mockPaging.firstPage,
-    previousPage: mockPaging.previousPage,
-    currentPage: mockPaging.currentPage,
-    nextPage: mockPaging.nextPage,
-    lastPage: mockPaging.lastPage,
-    totalRecords: 1,
-  },
-};
+});
 
-export const longFieldsCatalogResults: CatalogSearchResults = {
+export const longFieldsCatalogResults = createCatalogResults({
+  query: "long",
   editions: [
-    {
+    createEdition({
       id: 6,
       title: "A Very Long Title ".repeat(50),
-      items: [],
-      languages: [{ language: "English", iso_2: "en", iso_3: "eng" }],
-      links: [],
-      measurements: [],
+      work_title: "A Very Long Title ".repeat(50),
+      work_uuid: "6",
       publication_date: "2024",
-      publishers: [],
-      snippets: [],
       work_authors: Array.from({ length: 20 }, (_, i) =>
         createAgent(`Author ${i + 1}`)
       ),
-      work_title: "A Very Long Title ".repeat(50),
-      work_uuid: "6",
-    } as CatalogEdition,
+    }),
   ],
-  search_params: { query: [["keyword", "long"]] } as SearchParams,
-  paging: {
-    recordsPerPage: mockPaging.recordsPerPage,
-    firstPage: mockPaging.firstPage,
-    previousPage: mockPaging.previousPage,
-    currentPage: mockPaging.currentPage,
-    nextPage: mockPaging.nextPage,
-    lastPage: mockPaging.lastPage,
-    totalRecords: 1,
-  },
-};
+});

--- a/web/src/components/EditionCard/Ctas.tsx
+++ b/web/src/components/EditionCard/Ctas.tsx
@@ -3,7 +3,7 @@ import { useCookies } from "react-cookie";
 import { NYPL_SESSION_ID } from "~/src/constants/auth";
 import { Agent, ApiItem } from "~/src/types/DataModel";
 import EditionCardUtils from "~/src/util/EditionCardUtils";
-import PreviewLink from "../ResultCard/Ctas/PreviewLink";
+import OcrReadLink from "../ResultCard/Ctas/OcrReadLink";
 import DownloadLink from "./DownloadLink";
 import EddLink from "./EddLink";
 import ReadOnlineLink from "./ReadOnlineLink";
@@ -35,7 +35,7 @@ const Ctas: React.FC<{
               title={title}
             />
           ) : (
-            <PreviewLink previewLink={readOnlineLink} />
+            <OcrReadLink readLink={readOnlineLink} />
           ))}
         {downloadLink && (
           <DownloadLink

--- a/web/src/components/ResultCard/Ctas/Ctas.tsx
+++ b/web/src/components/ResultCard/Ctas/Ctas.tsx
@@ -6,7 +6,7 @@ import { CatalogItem } from "~/src/types/ResearchAssistant";
 import EditionCardUtils from "~/src/util/EditionCardUtils";
 import DownloadLink from "./DownloadLink";
 import EddLink from "./EddLink";
-import PreviewLink from "./PreviewLink";
+import OcrReadLink from "./OcrReadLink";
 import ReadOnlineLink from "./ReadOnlineLink";
 
 interface CtasProps {
@@ -56,10 +56,11 @@ const Ctas: React.FC<CtasProps> = ({
               title={title}
             />
           ) : (
-            <PreviewLink
-              previewLink={readOnlineLink}
+            <OcrReadLink
+              readLink={readOnlineLink}
               workId={workId}
               editionId={editionId}
+              title={title}
             />
           ))}
         {downloadLink && (

--- a/web/src/components/ResultCard/Ctas/OcrReadLink.tsx
+++ b/web/src/components/ResultCard/Ctas/OcrReadLink.tsx
@@ -4,19 +4,21 @@ import { useResultPageContext } from "~/src/context/ResultPageContext";
 import { ItemLink } from "~/src/types/DataModel";
 import Link from "../../Link/Link";
 
-interface PreviewLinkProps {
-  previewLink: ItemLink;
+interface OcrReadLinkProps {
+  readLink: ItemLink;
   workId?: string;
   editionId?: number;
+  title?: string;
 }
 
-const PreviewLink: React.FC<PreviewLinkProps> = ({
-  previewLink,
+const OcrReadLink: React.FC<OcrReadLinkProps> = ({
+  readLink,
   workId,
   editionId,
+  title,
 }) => {
   const { page } = useResultPageContext();
-  const isResearchAssistant = page === "vra";
+  const isEnhancedSearch = page === "vra";
 
   const itemPageUrl = workId
     ? {
@@ -27,17 +29,17 @@ const PreviewLink: React.FC<PreviewLinkProps> = ({
 
   return (
     <>
-      {isResearchAssistant && previewLink && workId ? (
+      {isEnhancedSearch && readLink && workId ? (
         <Box>
           <Link
             to={itemPageUrl}
             variant="buttonPrimary"
             width="100%"
-            aria-label="Preview item"
+            aria-label={`${title} Read online`}
             bgColor="section.research.secondary"
             _hover={{ bgColor: "section.research.primary" }}
           >
-            Preview
+            Read online
           </Link>
         </Box>
       ) : (
@@ -47,4 +49,4 @@ const PreviewLink: React.FC<PreviewLinkProps> = ({
   );
 };
 
-export default PreviewLink;
+export default OcrReadLink;

--- a/web/src/components/ResultCard/ResultCard.tsx
+++ b/web/src/components/ResultCard/ResultCard.tsx
@@ -60,7 +60,11 @@ export const ResultCard: React.FC<ResultCardProps> = ({
   isFeaturedEdition,
 }) => {
   const { page } = useResultPageContext();
-  const previewItem = EditionCardUtils.getPreviewItem((edition as any)?.items);
+  const isEnhancedSearch = page !== "drb" && page !== "keyword";
+  const previewItem = EditionCardUtils.getPreviewItem(
+    (edition as any)?.items,
+    isEnhancedSearch
+  );
 
   const editionYearElem = () => {
     const editionDisplay =

--- a/web/src/components/ResultCard/__tests__/EnhancedSearchReadLink.test.tsx
+++ b/web/src/components/ResultCard/__tests__/EnhancedSearchReadLink.test.tsx
@@ -1,9 +1,9 @@
 import { render, screen } from "@testing-library/react";
 import { ResultPageProvider } from "~/src/context/ResultPageContext";
 import { PageType } from "~/src/types/ResearchAssistant";
-import PreviewLink from "../Ctas/PreviewLink";
+import OcrReadLink from "../Ctas/OcrReadLink";
 
-const previewLink = {
+const readLink = {
   link_id: 1,
   mediaType: "text/html",
   url: "preview",
@@ -13,25 +13,28 @@ const previewLink = {
     reader: false,
   },
 };
+
 const workId = "work1";
 const editionId = 123;
+const title = "Test Book";
 
 const renderWithProvider = (page: PageType) =>
   render(
     <ResultPageProvider value={{ page }}>
-      <PreviewLink
-        previewLink={previewLink}
+      <OcrReadLink
+        readLink={readLink}
         workId={workId}
         editionId={editionId}
+        title={title}
       />
     </ResultPageProvider>
   );
 
-describe("PreviewLink", () => {
+describe("EnhancedSearchReadLink", () => {
   test("renders preview button in VRA context", () => {
     renderWithProvider("vra");
     expect(
-      screen.getByRole("link", { name: /Preview item/i })
+      screen.getByRole("link", { name: /Read online/i })
     ).toBeInTheDocument();
   });
 

--- a/web/src/components/ResultCard/__tests__/ResultCard.test.tsx
+++ b/web/src/components/ResultCard/__tests__/ResultCard.test.tsx
@@ -1,88 +1,23 @@
 import { render, screen } from "@testing-library/react";
+import {
+  createEdition,
+  createItem,
+  createWork,
+} from "~/src/__tests__/fixtures/CatalogSearchFixture";
 import { ResultPageProvider } from "~/src/context/ResultPageContext";
-import { CatalogEdition, PageType } from "~/src/types/ResearchAssistant";
+import { PageType } from "~/src/types/ResearchAssistant";
 import { ResultCard } from "../ResultCard";
 
-const mockAuthors = [
-  {
-    lcnaf: "",
-    name: "Test Author",
-    primary: "true",
-    viaf: "",
-  },
-];
-const mockEdition = {
+const mockEdition = createEdition({
   id: 1,
   title: "Test Title",
-  items: [
-    {
-      content_type: "ebook",
-      contributors: [],
-      drm: null,
-      edition_id: 1,
-      id: 2001,
-      links: [
-        {
-          content: null,
-          flags: {
-            reader: true,
-            catalog: false,
-            download: false,
-          },
-          id: 3002,
-          media_type: "application/ocr",
-          url: "https://example.org/reader/1",
-        },
-        {
-          content: null,
-          flags: {
-            embed: true,
-            catalog: false,
-            download: false,
-            reader: false,
-          },
-          id: 3003,
-          media_type: "text/html",
-          url: "https://example.org/embed/2",
-        },
-      ],
-      measurements: null,
-      physical_location: null,
-      rights: [
-        {
-          license: "public_domain",
-          rights_statement: "Public Domain",
-          source: "test-source",
-        },
-      ],
-      source: "grin",
-    },
-  ],
-  languages: [{ language: "English", iso_2: "en", iso_3: "eng" }],
-  links: [],
-  measurements: [],
-  publication_date: "2024",
-  publishers: [],
-  snippets: [
-    {
-      chunk_score: 0.5,
-      end_page: 10,
-      item_id: 2001,
-      start_page: 1,
-      text: "Test snippet",
-    },
-  ],
-  work_authors: mockAuthors,
   work_title: "Test Title",
   work_uuid: "1234",
-} as CatalogEdition;
+  items: [createItem()],
+});
 
-const mockWork = {
-  uuid: "1234",
-  title: "Test Title",
-  editions: [mockEdition],
-  edition_count: 1,
-};
+const mockAuthors = mockEdition.work_authors;
+const mockWork = createWork(mockEdition);
 
 const renderWithPage = (page: PageType) =>
   render(

--- a/web/src/components/ResultCard/__tests__/ResultCard.test.tsx
+++ b/web/src/components/ResultCard/__tests__/ResultCard.test.tsx
@@ -1,0 +1,128 @@
+import { render, screen } from "@testing-library/react";
+import { ResultPageProvider } from "~/src/context/ResultPageContext";
+import { CatalogEdition, PageType } from "~/src/types/ResearchAssistant";
+import { ResultCard } from "../ResultCard";
+
+const mockAuthors = [
+  {
+    lcnaf: "",
+    name: "Test Author",
+    primary: "true",
+    viaf: "",
+  },
+];
+const mockEdition = {
+  id: 1,
+  title: "Test Title",
+  items: [
+    {
+      content_type: "ebook",
+      contributors: [],
+      drm: null,
+      edition_id: 1,
+      id: 2001,
+      links: [
+        {
+          content: null,
+          flags: {
+            reader: true,
+            catalog: false,
+            download: false,
+          },
+          id: 3002,
+          media_type: "application/ocr",
+          url: "https://example.org/reader/1",
+        },
+        {
+          content: null,
+          flags: {
+            embed: true,
+            catalog: false,
+            download: false,
+            reader: false,
+          },
+          id: 3003,
+          media_type: "text/html",
+          url: "https://example.org/embed/2",
+        },
+      ],
+      measurements: null,
+      physical_location: null,
+      rights: [
+        {
+          license: "public_domain",
+          rights_statement: "Public Domain",
+          source: "test-source",
+        },
+      ],
+      source: "grin",
+    },
+  ],
+  languages: [{ language: "English", iso_2: "en", iso_3: "eng" }],
+  links: [],
+  measurements: [],
+  publication_date: "2024",
+  publishers: [],
+  snippets: [
+    {
+      chunk_score: 0.5,
+      end_page: 10,
+      item_id: 2001,
+      start_page: 1,
+      text: "Test snippet",
+    },
+  ],
+  work_authors: mockAuthors,
+  work_title: "Test Title",
+  work_uuid: "1234",
+} as CatalogEdition;
+
+const mockWork = {
+  uuid: "1234",
+  title: "Test Title",
+  editions: [mockEdition],
+  edition_count: 1,
+};
+
+const renderWithPage = (page: PageType) =>
+  render(
+    <ResultPageProvider value={{ page }}>
+      <ResultCard authors={mockAuthors} edition={mockEdition} work={mockWork} />
+    </ResultPageProvider>
+  );
+
+describe("ResultCard", () => {
+  describe("renders book content in card", () => {
+    test("renders title with link", () => {
+      renderWithPage("vra");
+      expect(
+        screen.getByRole("link", { name: "Test Title" })
+      ).toBeInTheDocument();
+    });
+
+    test("renders authors", () => {
+      renderWithPage("vra");
+      expect(screen.getByText(/Test Author/i)).toBeInTheDocument();
+    });
+
+    test("renders edition year", () => {
+      renderWithPage("vra");
+      expect(screen.getByText(/2024 edition/i)).toBeInTheDocument();
+    });
+
+    test("renders relevant sections accordion item", () => {
+      renderWithPage("vra");
+
+      const relevanceLabel = screen.getByText(/Why am I seeing this result/i);
+      expect(relevanceLabel).toBeInTheDocument();
+    });
+
+    test("does not render relevant sections accordion item", () => {
+      renderWithPage("keyword");
+
+      expect(
+        screen.queryByText(/Why am I seeing this result/i)
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/web/src/util/EditionCardUtils.tsx
+++ b/web/src/util/EditionCardUtils.tsx
@@ -185,12 +185,19 @@ export default class EditionCardUtils {
   }
 
   // return first item if links are available
-  static getPreviewItem(items: ApiItem[] | undefined) {
+  static getPreviewItem(
+    items: ApiItem[] | undefined,
+    isEnhancedSearch: boolean = false
+  ) {
     if (!items) return undefined;
 
     const firstItem = items[0];
 
-    return firstItem && firstItem.links ? firstItem : undefined;
+    const previewItem = isEnhancedSearch
+      ? items.find((item) => item.source === "grin" && item.links) ?? firstItem
+      : firstItem;
+
+    return previewItem && previewItem.links ? previewItem : undefined;
   }
 
   static isAvailableOnline(item: ApiItem) {


### PR DESCRIPTION
## Describe your changes

- Renames `PreviewLink` to `OcrReadLink` and updates for read online.
- Updates `getPreviewItem` logic to handle Enhanced Search items using `source === 'grin'`. This will eventually be removed or replaced with the backend orchestration changes.
- Adds unit tests for the `ResultsCard` component and cleans up `CatalogSearchFixture` to use factory functions to generate mocks.

## How to test
Locally