### PR TITLE
SCHOL-603: Remove require_basic_authentication from chat endpoint

### DIFF
--- a/etl-pipeline/api/blueprints/chat.py
+++ b/etl-pipeline/api/blueprints/chat.py
@@ -20,7 +20,7 @@ from ..utils import APIUtils, orm_to_dict
 from ..elastic import ElasticClient
 from ..db import DBClient
 from ..auth import require_api_key
-from ..decorators import require_basic_authentication, require_session_jwt
+from ..decorators import require_session_jwt
 from ..assistant.agent import SCORE_SORT_DIRECTION, update_chat, PAGE_SIZE
 from ..assistant.snippets import get_relevant_snippets
 
@@ -157,7 +157,6 @@ def prepare_search_response(search_results) -> Tuple[str, Dict] | Tuple[None, No
 
 @chat_blueprint.route("", methods=["POST"])
 @require_api_key
-@require_basic_authentication
 @require_session_jwt
 @timer(logger)
 def chat(user, session_id):

--- a/etl-pipeline/api/blueprints/chat.py
+++ b/etl-pipeline/api/blueprints/chat.py
@@ -159,7 +159,7 @@ def prepare_search_response(search_results) -> Tuple[str, Dict] | Tuple[None, No
 @require_api_key
 @require_session_jwt
 @timer(logger)
-def chat(user, session_id):
+def chat(session_id):
     conversation_type = request.json.get("conversationType")
     message = request.json.get("message")
     edition_id = request.json.get("editionId")
@@ -175,10 +175,10 @@ def chat(user, session_id):
         newrelic.agent.add_custom_attribute("llm.conversation_id", session_id)
 
     with LogContextVars(get_app_logger(), context=log_context):
-        return _chat_handler(user, session_id, conversation_type, message, edition_id)
+        return _chat_handler(session_id, conversation_type, message, edition_id)
 
 
-def _chat_handler(user, session_id, conversation_type, message, edition_id):
+def _chat_handler(session_id, conversation_type, message, edition_id):
     """wrapper for main chat() logic to allow use of LogContextVars without a huge indent block"""
 
     logger.info(f"Chat request received: {message[:20]}...")


### PR DESCRIPTION
## Describe your changes

Removed basic auth for the /chat endpoint to get ready for internal testing. The decorator itself is untouched, since it is used in some DRB API endpoints.

Note: we could now remove FE & test codes related to basic auth, which would be handled with a separate ticket.

## How to test

Chat feature is usable without login