### PR TITLE
SCHOL-656: Landing Page VQA issue 26-28

### DIFF
--- a/web/src/components/ResearchAssistantLanding/AccessSection/HowItWorksSection.tsx
+++ b/web/src/components/ResearchAssistantLanding/AccessSection/HowItWorksSection.tsx
@@ -164,7 +164,7 @@ const HowItWorksSection: React.FC = () => {
             <Image
               src={CONTROL_SUBNAV_IMAGE}
               alt="A subnavigation bar with two options: 'Enhanced Search' and 'Keyword search.' This illustrates how patrons can maintain control by opting out of the AI tool and switching back to traditional search at any time."
-              maxWidth="512px"
+              maxWidth={{ base: "none", md: "512px" }}
               background="transparent"
               flexShrink="0"
             />

--- a/web/src/components/ResearchAssistantLanding/SearchSection.tsx
+++ b/web/src/components/ResearchAssistantLanding/SearchSection.tsx
@@ -76,7 +76,7 @@ const SearchSection: React.FC<SearchSectionProps> = ({ textInputRef }) => {
             isFocused
               ? {
                   boxShadow: "none",
-                  outline: "3px solid",
+                  outline: "2px solid",
                   outlineColor: "section.research.secondary",
                 }
               : {}
@@ -116,7 +116,11 @@ const SearchSection: React.FC<SearchSectionProps> = ({ textInputRef }) => {
               },
             }}
           />
-          <Flex flexDir="row" paddingY="xs">
+          <Flex
+            flexDir="row"
+            paddingY="xs"
+            paddingLeft={{ base: "xs", md: "0" }}
+          >
             <Button
               onClick={handleLocalSearchSubmit}
               id="research-landing-submit"


### PR DESCRIPTION
[SCHOL-656](https://newyorkpubliclibrary.atlassian.net/browse/SCHOL-626)
[Landing Page QA Doc](https://docs.google.com/document/d/1msi8-x84kV0CoLAz9Pl7BNW7kiTeDVqeymSBo-zYkTg/edit?tab=t.0#heading=h.kn3jq7ihhh82)

## Describe your changes
Addresses VQA issue 26-28:
- Input Box focus state stroke changed to 2px
- Input Box now has space between text and button on mobile and tablet
- Fixes HowItWorks's fourth card to have correct padding

## How to test
- Test on Local Machine

[SCHOL-656]: https://newyorkpubliclibrary.atlassian.net/browse/SCHOL-656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ