### PR TITLE
SCHOL-650: prep gemini 2 embedding

### DIFF
--- a/etl-pipeline/api/assistant/agent.py
+++ b/etl-pipeline/api/assistant/agent.py
@@ -48,7 +48,7 @@ from .search import hybrid_search, ReciprocalRankFuser, ScoredHit
 from .types import CatalogSearchResult, ContentSearchResult
 
 # shared code
-from vector_indexing.components.embedders.google import GoogleEmbedder
+from vector_indexing.components.embedders.google import Gemini001Embedder
 from vector_indexing.components.backends.turbopuffer import TurbopufferBackend
 from vector_indexing.core.utils import Timer
 from logger import create_log
@@ -260,7 +260,7 @@ class CatalogSearchExecutionContext:
     """Container used to inject objects into each agent run execution."""
 
     backend: TurbopufferBackend
-    embedder: GoogleEmbedder
+    embedder: Gemini001Embedder
     session_id: str
     conversation_type: str = "catalogSearch"
     search_results: Dict = field(default_factory=dict)
@@ -276,7 +276,7 @@ class ContentSearchExecutionContext:
     """
 
     backend: TurbopufferBackend
-    embedder: GoogleEmbedder
+    embedder: Gemini001Embedder
     session_id: str
     edition_id: int
     barcode: Optional[str] = None
@@ -525,7 +525,7 @@ async def update_chat(
     # request workers/threads)
 
     backend = TurbopufferBackend(index_name=require_env("TURBOPUFFER_NAMESPACE"))
-    embedder = GoogleEmbedder()
+    embedder = Gemini001Embedder()
 
     # NOTE: we are not using litellm bc it has a bug converting `list | None = None`
     # in agents sdk @functol_tool param type annotations into gemini API compatible

--- a/etl-pipeline/api/assistant/legacy/search.py
+++ b/etl-pipeline/api/assistant/legacy/search.py
@@ -4,7 +4,7 @@ from elasticsearch.dsl import Search, Q, Response
 
 from typing import Dict
 
-from vector_indexing.components.embedders.google import GoogleEmbedder
+from vector_indexing.components.embedders.google import Gemini001Embedder
 from utils.elastic import get_or_create_default_connection
 from logger import create_log
 
@@ -19,7 +19,7 @@ logger = create_log(__name__)
 # TODO: explicitly control n hits to return in Search()
 # TODO: stop returning embedding with hit
 # self = object.__new__(Searcher)
-# embedder = GoogleEmbedder()
+# embedder = Gemini001Embedder()
 # index_name = "vra_chunks_gemini-embedding-001"
 # MAYBE: create a "search" factory that handles some of the common code in \
 # different search methods (metadata i/o, elastic search boilerplate, etc...)

--- a/etl-pipeline/dev_scripts/embedding/concurrency_vs_thruput.py
+++ b/etl-pipeline/dev_scripts/embedding/concurrency_vs_thruput.py
@@ -1,5 +1,8 @@
 """
-Benchmark throughput of the SageMaker deployment of HF TEI container.
+Benchmark throughput of any Embedder implementation.
+
+Configure EMBEDDER at the top of the file, then run with:
+    uv run dev_scripts/embedding/benchmark_throughput_hf_sagemaker.py
 """
 
 import asyncio
@@ -10,32 +13,36 @@ from datetime import datetime
 from pathlib import Path
 from typing import List
 
-import boto3
 import numpy as np
-import sagemaker
 
-# from sagemaker.predictor import Predictor # requires manual passing of JSONSerializer
-# from sagemaker.deserializers import JSONDeserializer
-# from sagemaker.serializers import JSONSerializer
-from sagemaker.huggingface import HuggingFacePredictor
-from transformers import AutoTokenizer
+from logger import configure_loggers, create_log
+from vector_indexing.components.embedders import *
+
+logger = create_log(__name__)
 
 # ---------------------------------------------------------------------------
-# Configuration
+# Configuration - set EMBEDDER to whatever you want to benchmark
 # ---------------------------------------------------------------------------
 
-ENDPOINT_NAME = "hf-tei-20260423-142720"  # Qwen, g6e
-AWS_PROFILE = "sandbox"
-
-TOTAL_REQUESTS = 200  # requests at each concurrency level
-CONCURRENCY_LEVELS = [1, 16, 32, 64]
+CONCURRENCY_LEVELS = [1]
+# CONCURRENCY_LEVELS = [1, 16, 32, 64]
 # CONCURRENCY_LEVELS = [1, 4, 8, 10, 13, 16]
 
-# TODO: for higher thruput. try  {inputs: [<str>, <str>]} (this works!),  batch_transform, async inference endpoint
+# EMBEDDER: Embedder = Qwen38BEmbedder(
+#     endpoint_name="hf-tei-20260423-142720",
+#     aws_profile="sandbox",
+#     concurrency=1,  # benchmark controls concurrency via the semaphore
+# )
+EMBEDDER = Gemini001Embedder()
+# TODO: for sagemaker embedders, for higher thruput. try  {inputs: [<str>, <str>]} (this works!),  batch_transform, async inference endpoint
+
+# TOTAL_REQUESTS = 200
+TOTAL_REQUESTS = 4000
 
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
+
 
 # ~730 tokens of representative research-book text.
 # At ~4 chars/token this comes to roughly 2 900 characters.
@@ -134,16 +141,110 @@ class BatchResult:
 
 
 # ---------------------------------------------------------------------------
-# Throughput Benchmark logic
+# Token counting
 # ---------------------------------------------------------------------------
 
 
-async def _call_endpoint(predictor: HuggingFacePredictor, semaphore: asyncio.Semaphore):
-    """Run one synchronous predictor.predict() call inside a thread."""
+def _count_tokens_sagemaker(embedder: SageMakerTEIEmbedder, text: str) -> int:
+    """Load the HF tokenizer for the deployed model and count tokens in `text`."""
+    from transformers import AutoTokenizer
+
+    # model_name calls describe_endpoint_config + describe_model on the SM client
+    hf_model_id = embedder.model_name
+    tokenizer = AutoTokenizer.from_pretrained(hf_model_id)
+    return len(tokenizer.encode(text))
+
+
+def _count_tokens_gemini(
+    embedder: Gemini001Embedder | Gemini2Embedder, text: str
+) -> int:
+    """Use the Gemini count_tokens API to count tokens in `text`."""
+    # https://ai.google.dev/gemini-api/docs/tokens
+    response = embedder._client.models.count_tokens(
+        model=embedder.model_name,
+        contents=text,
+    )
+    return response.total_tokens
+
+
+def _count_tokens_sentence_transformers(embedder, text: str) -> int:
+    """Use the wrapped HF tokenizer to count tokens in `text`."""
+    return len(embedder._embedder.tokenizer.encode(text))
+
+
+def get_token_count(embedder: Embedder, text: str) -> int:
+    """Return the token count for `text` using the embedder's native tokenizer.
+
+    Raises NotImplementedError for embedder types that have no token-counting
+    implementation yet.
+    """
+    if isinstance(embedder, SageMakerTEIEmbedder):
+        return _count_tokens_sagemaker(embedder, text)
+    if isinstance(embedder, Gemini001Embedder):
+        return _count_tokens_gemini(embedder, text)
+    if isinstance(embedder, Gemini2Embedder):
+        return _count_tokens_gemini(embedder, text)
+    if isinstance(embedder, SentenceTransformersEmbedder):
+        return _count_tokens_sentence_transformers(embedder, text)
+    raise NotImplementedError(
+        f"Token counting is not implemented for {type(embedder).__name__}. "
+        "Add a case to get_token_count() before benchmarking this embedder type."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Metadata
+# ---------------------------------------------------------------------------
+
+
+def get_embedder_metadata(embedder: Embedder) -> dict:
+    """Return a dict of embedder-type-specific metadata for benchmark reporting.
+
+    For SageMaker embedders this includes endpoint name, instance type, and
+    HF_MODEL_ID. For other embedder types it includes whatever is relevant.
+    """
+    base = {
+        "embedder_class": type(embedder).__name__,
+        "model_name": embedder.model_name,
+    }
+
+    if isinstance(embedder, SageMakerTEIEmbedder):
+        sm = embedder._predictor.sagemaker_session.sagemaker_client
+        config = sm.describe_endpoint_config(
+            EndpointConfigName=embedder._predictor._get_endpoint_config_name()
+        )
+        variant = config["ProductionVariants"][0]
+        instance_type = variant.get("InstanceType")
+        model = sm.describe_model(ModelName=variant["ModelName"])
+        hf_model_id = (
+            model["PrimaryContainer"]
+            .get("Environment", {})
+            .get("HF_MODEL_ID", embedder._endpoint_name)
+        )
+        return {
+            **base,
+            "endpoint_name": embedder._endpoint_name,
+            "instance_type": instance_type,
+            "hf_model_id": hf_model_id,
+        }
+
+    if isinstance(embedder, (Gemini001Embedder, Gemini2Embedder)):
+        return {**base, "dimensions": embedder.dimensions}
+
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Throughput benchmark logic
+# ---------------------------------------------------------------------------
+
+
+async def _call_embedder(embedder: Embedder, semaphore: asyncio.Semaphore):
+    """Run one synchronous embedder.embed_document() call inside a thread."""
     async with semaphore:
         start = time.perf_counter()
         try:
-            await asyncio.to_thread(predictor.predict, {"inputs": DUMMY_TEXT})
+            await asyncio.to_thread(embedder.embed_document, DUMMY_TEXT)
             elapsed = time.perf_counter() - start
             return elapsed, None
         except Exception as exc:
@@ -152,7 +253,7 @@ async def _call_endpoint(predictor: HuggingFacePredictor, semaphore: asyncio.Sem
 
 
 async def run_benchmark(
-    predictor: HuggingFacePredictor,
+    embedder: Embedder,
     concurrency: int,
     total_requests: int,
     token_count: int,
@@ -162,16 +263,15 @@ async def run_benchmark(
     Return summary of throughput.
     """
 
-    semaphore = asyncio.Semaphore(concurrency)
-    tasks = [_call_endpoint(predictor, semaphore) for _ in range(total_requests)]
-
     # Run inference for *total_requests*
+    semaphore = asyncio.Semaphore(concurrency)
+    tasks = [_call_embedder(embedder, semaphore) for _ in range(total_requests)]
     print(f"  Benchmarking concurrency={concurrency} ...")
     wall_start = time.perf_counter()
     outcomes = await asyncio.gather(*tasks)
     wall_time = time.perf_counter() - wall_start
 
-    # Collect latency on success, record error on failure
+    # Collect latency/thruput on success, record error on failure
     latencies = []
     errors = 0
     for elapsed, exc in outcomes:
@@ -183,12 +283,14 @@ async def run_benchmark(
 
     latencies_ms = np.array(latencies) * 1000
 
+    tokens_per_s = (total_requests * token_count) / wall_time
+
     result = BatchResult(
         concurrency=concurrency,
         total_requests=total_requests,
         total_time_s=wall_time,
         req_per_s=total_requests / wall_time,
-        tokens_per_s=(total_requests * token_count) / wall_time,
+        tokens_per_s=tokens_per_s,
         avg_latency_ms=float(np.mean(latencies_ms)) if latencies_ms.size else 0.0,
         p50_latency_ms=float(np.percentile(latencies_ms, 50))
         if latencies_ms.size
@@ -206,6 +308,7 @@ async def run_benchmark(
     print(
         f"    concurrency={concurrency:>2}  "
         f"throughput={result.req_per_s:.2f} req/s  "
+        f"tok/s={result.tokens_per_s:>10.1f}  "
         f"avg_latency={result.avg_latency_ms:.1f} ms  "
         f"p95={result.p95_latency_ms:.1f} ms  "
         f"errors={errors}"
@@ -218,59 +321,30 @@ async def run_benchmark(
 # ---------------------------------------------------------------------------
 
 
-def get_endpoint_info(predictor: HuggingFacePredictor) -> tuple[str | None, str | None]:
-    """Return (HF_MODEL_ID, instance_type) by introspecting the predictor's session.
-
-    Uses predictor._get_endpoint_config_name() (caches describe_endpoint) so we only
-    need two API calls: describe_endpoint_config + describe_model.
-    """
-    sm = predictor.sagemaker_session.sagemaker_client
-    config = sm.describe_endpoint_config(
-        EndpointConfigName=predictor._get_endpoint_config_name()
-    )
-    variant = config["ProductionVariants"][0]
-    instance_type = variant.get("InstanceType")
-    model = sm.describe_model(ModelName=variant["ModelName"])
-    hf_model_id = model["PrimaryContainer"].get("Environment", {}).get("HF_MODEL_ID")
-    return hf_model_id, instance_type
-
-
 async def main() -> List[BatchResult]:
-    """Run the benchmark across all CONCURRENCY_LEVELS and write results to OUTPUT_FILE."""
-    boto3.setup_default_session(profile_name=AWS_PROFILE)
-    session = sagemaker.Session()
+    """Run the benchmark across all CONCURRENCY_LEVELS and write results to a JSON file."""
+    configure_loggers(stage="development")
 
-    predictor = HuggingFacePredictor(
-        endpoint_name=ENDPOINT_NAME,
-        sagemaker_session=session,
-    )
+    embedder = EMBEDDER
+    metadata = get_embedder_metadata(embedder)
+    token_count = get_token_count(embedder, DUMMY_TEXT)
 
-    hf_model_id, instance_type = get_endpoint_info(predictor)
-
-    if hf_model_id is None:
-        raise ValueError(
-            "Could not determine HF_MODEL_ID from endpoint config; cannot load tokenizer."
-        )
-    _tokenizer = AutoTokenizer.from_pretrained(hf_model_id)
-    dummy_text_tokens: int = len(_tokenizer.encode(DUMMY_TEXT))
-    # ALT: use the /tokenize endpoint of the deployed model. see: https://huggingface.github.io/text-embeddings-inference/#/Text%20Embeddings%20Inference/tokenize
-
-    print(f"Endpoint      : {ENDPOINT_NAME}")
-    print(f"Instance type : {instance_type or '(not found)'}")
-    print(f"HF_MODEL_ID   : {hf_model_id}")
+    print(f"Embedder class: {metadata['embedder_class']}")
+    for key, val in metadata.items():
+        if key != "embedder_class":
+            print(f"  {key}: {val}")
     print(f"Requests      : {TOTAL_REQUESTS} per concurrency level")
-    print(f"Dummy text    : ~{dummy_text_tokens} tokens\n")
+    print(f"Dummy text    : ~{token_count} tokens\n")
 
     assert max(CONCURRENCY_LEVELS) < TOTAL_REQUESTS, (
-        f"Max concurrency ({max(CONCURRENCY_LEVELS)}) must be less than TOTAL_REQUESTS ({TOTAL_REQUESTS})"
+        f"Max concurrency ({max(CONCURRENCY_LEVELS)}) must be less than "
+        f"TOTAL_REQUESTS ({TOTAL_REQUESTS})"
     )
 
     # Run inference throughput benchmark for all concurrency levels
     results: List[BatchResult] = []
     for concurrency in CONCURRENCY_LEVELS:
-        result = await run_benchmark(
-            predictor, concurrency, TOTAL_REQUESTS, dummy_text_tokens
-        )
+        result = await run_benchmark(embedder, concurrency, TOTAL_REQUESTS, token_count)
         results.append(result)
 
     # Print multi-concurrency benchmark summary table
@@ -295,9 +369,9 @@ async def main() -> List[BatchResult]:
     output_file = Path(__file__).parent / "results" / f"benchmark_{timestamp}.json"
     output_file.parent.mkdir(parents=True, exist_ok=True)
     output = {
-        "endpoint": ENDPOINT_NAME,
-        "instance_type": instance_type,
-        "hf_model_id": hf_model_id,
+        **metadata,
+        "total_requests_per_level": TOTAL_REQUESTS,
+        "dummy_text_tokens": token_count,
         "results": [r.to_dict() for r in results],
     }
     with open(output_file, "w") as f:

--- a/etl-pipeline/dev_scripts/embedding/concurrency_vs_thruput.py
+++ b/etl-pipeline/dev_scripts/embedding/concurrency_vs_thruput.py
@@ -1,9 +1,20 @@
 """
-Benchmark throughput of any Embedder implementation.
+Benchmark throughput of any Embedder implementation at various concurrency levels.
 
-Configure EMBEDDER at the top of the file, then run with:
-    uv run dev_scripts/embedding/benchmark_throughput_hf_sagemaker.py
+Configure EMBEDDER at the top of the file, then run.
 """
+
+# Add project root to path if running directly
+if __name__ == "__main__":
+    from dotenv import find_dotenv
+    import sys
+    from pathlib import Path
+
+    project_root = Path(
+        find_dotenv("requirements.txt", raise_error_if_not_found=True)
+    ).parent
+    if str(project_root) not in sys.path:
+        sys.path.insert(0, str(project_root))
 
 import asyncio
 import dataclasses
@@ -17,8 +28,11 @@ import numpy as np
 
 from logger import configure_loggers, create_log
 from vector_indexing.components.embedders import *
+from utils.load_env import load_env
 
 logger = create_log(__name__)
+
+load_env("config/.env.production")
 
 # ---------------------------------------------------------------------------
 # Configuration - set EMBEDDER to whatever you want to benchmark
@@ -31,13 +45,24 @@ CONCURRENCY_LEVELS = [1]
 # EMBEDDER: Embedder = Qwen38BEmbedder(
 #     endpoint_name="hf-tei-20260423-142720",
 #     aws_profile="sandbox",
-#     concurrency=1,  # benchmark controls concurrency via the semaphore
+#     batch_concurrency=1,  # benchmark controls concurrency via the semaphore
 # )
-EMBEDDER = Gemini001Embedder()
 # TODO: for sagemaker embedders, for higher thruput. try  {inputs: [<str>, <str>]} (this works!),  batch_transform, async inference endpoint
 
-# TOTAL_REQUESTS = 200
-TOTAL_REQUESTS = 4000
+# EMBEDDER = Gemini001Embedder()
+EMBEDDER = Gemini2Embedder()
+
+
+BATCHED = True  # if True, use embed_document_batch() with EMBEDDER._batch_size chunks per request
+
+# TOTAL_CHUNKS = 200
+TOTAL_CHUNKS = 1000
+
+if BATCHED:
+    assert TOTAL_CHUNKS % EMBEDDER._batch_size == 0, (
+        f"TOTAL_CHUNKS ({TOTAL_CHUNKS}) must be an exact multiple of "
+        f"EMBEDDER._batch_size ({EMBEDDER._batch_size}) when BATCHED=True"
+    )
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -127,8 +152,10 @@ class BatchResult:
 
     concurrency: int
     total_requests: int
+    total_chunks: int
     total_time_s: float
     req_per_s: float
+    chunks_per_s: float
     tokens_per_s: float
     avg_latency_ms: float
     p50_latency_ms: float
@@ -240,11 +267,19 @@ def get_embedder_metadata(embedder: Embedder) -> dict:
 
 
 async def _call_embedder(embedder: Embedder, semaphore: asyncio.Semaphore):
-    """Run one synchronous embedder.embed_document() call inside a thread."""
+    """Run one embed call inside a thread and record duration.
+
+    When BATCHED=True, sends embedder._batch_size documents per request via
+    embed_document_batch(); otherwise sends a single document via embed_document().
+    """
     async with semaphore:
         start = time.perf_counter()
         try:
-            await asyncio.to_thread(embedder.embed_document, DUMMY_TEXT)
+            if BATCHED:
+                batch = [DUMMY_TEXT] * embedder._batch_size
+                await asyncio.to_thread(embedder.embed_document_batch, batch)
+            else:
+                await asyncio.to_thread(embedder.embed_document, DUMMY_TEXT)
             elapsed = time.perf_counter() - start
             return elapsed, None
         except Exception as exc:
@@ -255,17 +290,20 @@ async def _call_embedder(embedder: Embedder, semaphore: asyncio.Semaphore):
 async def run_benchmark(
     embedder: Embedder,
     concurrency: int,
-    total_requests: int,
+    total_chunks: int,
     token_count: int,
 ) -> BatchResult:
     """
-    Send *total_requests* embedding requests capped at *concurrency* in-flight at once.
+    Embed *total_chunks* chunks capped at *concurrency* requests in-flight at once.
+    When BATCHED=True each request carries embedder._batch_size chunks; otherwise one.
     Return summary of throughput.
     """
+    chunks_per_request = embedder._batch_size if BATCHED else 1
+    num_requests = total_chunks // chunks_per_request
 
-    # Run inference for *total_requests*
+    # Run inference for *num_requests*
     semaphore = asyncio.Semaphore(concurrency)
-    tasks = [_call_embedder(embedder, semaphore) for _ in range(total_requests)]
+    tasks = [_call_embedder(embedder, semaphore) for _ in range(num_requests)]
     print(f"  Benchmarking concurrency={concurrency} ...")
     wall_start = time.perf_counter()
     outcomes = await asyncio.gather(*tasks)
@@ -283,13 +321,16 @@ async def run_benchmark(
 
     latencies_ms = np.array(latencies) * 1000
 
-    tokens_per_s = (total_requests * token_count) / wall_time
+    chunks_per_s = total_chunks / wall_time
+    tokens_per_s = total_chunks * token_count / wall_time
 
     result = BatchResult(
         concurrency=concurrency,
-        total_requests=total_requests,
+        total_requests=num_requests,
+        total_chunks=total_chunks,
         total_time_s=wall_time,
-        req_per_s=total_requests / wall_time,
+        req_per_s=num_requests / wall_time,
+        chunks_per_s=chunks_per_s,
         tokens_per_s=tokens_per_s,
         avg_latency_ms=float(np.mean(latencies_ms)) if latencies_ms.size else 0.0,
         p50_latency_ms=float(np.percentile(latencies_ms, 50))
@@ -307,7 +348,8 @@ async def run_benchmark(
     # Print batch results
     print(
         f"    concurrency={concurrency:>2}  "
-        f"throughput={result.req_per_s:.2f} req/s  "
+        f"req/s={result.req_per_s:.2f}  "
+        f"chunks/s={result.chunks_per_s:>8.2f}  "
         f"tok/s={result.tokens_per_s:>10.1f}  "
         f"avg_latency={result.avg_latency_ms:.1f} ms  "
         f"p95={result.p95_latency_ms:.1f} ms  "
@@ -333,29 +375,34 @@ async def main() -> List[BatchResult]:
     for key, val in metadata.items():
         if key != "embedder_class":
             print(f"  {key}: {val}")
-    print(f"Requests      : {TOTAL_REQUESTS} per concurrency level")
+    chunks_per_request = EMBEDDER._batch_size if BATCHED else 1
+    num_requests = TOTAL_CHUNKS // chunks_per_request
+    print(
+        f"Chunks        : {TOTAL_CHUNKS} per concurrency level (batched with {num_requests} requests @ {chunks_per_request} chunk(s)/req)"
+    )
     print(f"Dummy text    : ~{token_count} tokens\n")
 
-    assert max(CONCURRENCY_LEVELS) < TOTAL_REQUESTS, (
+    assert max(CONCURRENCY_LEVELS) < num_requests, (
         f"Max concurrency ({max(CONCURRENCY_LEVELS)}) must be less than "
-        f"TOTAL_REQUESTS ({TOTAL_REQUESTS})"
+        f"num_requests ({num_requests})"
     )
 
     # Run inference throughput benchmark for all concurrency levels
     results: List[BatchResult] = []
     for concurrency in CONCURRENCY_LEVELS:
-        result = await run_benchmark(embedder, concurrency, TOTAL_REQUESTS, token_count)
+        result = await run_benchmark(embedder, concurrency, TOTAL_CHUNKS, token_count)
         results.append(result)
 
     # Print multi-concurrency benchmark summary table
     print("\n--- Summary ---")
-    header = f"{'Concurrency':>11}  {'Req/s':>8}  {'Tok/s':>10}  {'Avg (ms)':>10}  {'P50 (ms)':>10}  {'P95 (ms)':>10}  {'P99 (ms)':>10}  {'Errors':>7}"
+    header = f"{'Concurrency':>11}  {'Req/s':>8}  {'Chunks/s':>10}  {'Tok/s':>10}  {'Avg (ms)':>10}  {'P50 (ms)':>10}  {'P95 (ms)':>10}  {'P99 (ms)':>10}  {'Errors':>7}"
     print(header)
     print("-" * len(header))
     for r in results:
         print(
             f"{r.concurrency:>11}  "
             f"{r.req_per_s:>8.2f}  "
+            f"{r.chunks_per_s:>10.2f}  "
             f"{r.tokens_per_s:>10.1f}  "
             f"{r.avg_latency_ms:>10.1f}  "
             f"{r.p50_latency_ms:>10.1f}  "
@@ -366,11 +413,14 @@ async def main() -> List[BatchResult]:
 
     # Serialize results to JSON
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    output_file = Path(__file__).parent / "results" / f"benchmark_{timestamp}.json"
+    output_file = (
+        Path(__file__).parent / "thruput_results" / f"benchmark_{timestamp}.json"
+    )
     output_file.parent.mkdir(parents=True, exist_ok=True)
     output = {
         **metadata,
-        "total_requests_per_level": TOTAL_REQUESTS,
+        "total_chunks": TOTAL_CHUNKS,
+        "batched": BATCHED,
         "dummy_text_tokens": token_count,
         "results": [r.to_dict() for r in results],
     }

--- a/etl-pipeline/dev_scripts/sample_turbopuffer_query.py
+++ b/etl-pipeline/dev_scripts/sample_turbopuffer_query.py
@@ -16,7 +16,7 @@ os.chdir(PROJ_ROOT)
 from utils.load_env import load_env
 
 from vector_indexing.components.backends.turbopuffer import TurbopufferBackend
-from vector_indexing.components.embedders.google import GoogleEmbedder
+from vector_indexing.components.embedders.google import Gemini001Embedder
 from api.assistant.search import hybrid_search
 
 ENVIRONMENT = "production"  # or "local", "qa"
@@ -34,7 +34,7 @@ FILTER = [
 
 
 backend = TurbopufferBackend(index_name=os.environ["TURBOPUFFER_NAMESPACE"])
-embedder = GoogleEmbedder()
+embedder = Gemini001Embedder()
 
 
 query_vector = embedder.embed_query(RANKING_QUERY)

--- a/etl-pipeline/tests/functional/api/assistant/agent/test_on_max_turns.py
+++ b/etl-pipeline/tests/functional/api/assistant/agent/test_on_max_turns.py
@@ -20,7 +20,7 @@ class TestOnMaxTurns:
 
         # Prevent real Google Embedder API calls; embed_query returns a mock (hybrid_search
         # raises before it's used, so the return value doesn't matter)
-        mocker.patch("api.assistant.agent.GoogleEmbedder")
+        mocker.patch("api.assistant.agent.Gemini001Embedder")
 
         # Force search tool to always fail → triggers LLM retry
         mocker.patch(

--- a/etl-pipeline/tests/stochastic_processes/conftest.py
+++ b/etl-pipeline/tests/stochastic_processes/conftest.py
@@ -57,7 +57,7 @@ def mock_search_backend(mocker):
       - map_editions_and_records → returns synthetic item_ids keyed by book_id
       - get_frbr_data_by_edition → returns SimpleNamespace ORM-like rows
         built from each ChunkDocument's book_metadata (first chunk per edition)
-      - GoogleEmbedder → returns a dummy zero vector from embed_query
+      - Gemini001Embedder → returns a dummy zero vector from embed_query
       - TurbopufferBackend → replaced with a no-op mock
 
     Returns:
@@ -65,7 +65,7 @@ def mock_search_backend(mocker):
     """
     mock_embedder = mocker.MagicMock()
     mock_embedder.embed_query.return_value = np.zeros(768).tolist()
-    mocker.patch("api.assistant.agent.GoogleEmbedder", return_value=mock_embedder)
+    mocker.patch("api.assistant.agent.Gemini001Embedder", return_value=mock_embedder)
     mocker.patch("api.assistant.agent.TurbopufferBackend")
 
     def _setup(chunk_docs: List[ChunkDocument]) -> List[ChunkDocument]:

--- a/etl-pipeline/tests/unit/vector_indexing/test_embedders.py
+++ b/etl-pipeline/tests/unit/vector_indexing/test_embedders.py
@@ -1,34 +1,90 @@
 """Contract tests for Embedder implementations."""
 
-import pytest
+from unittest.mock import MagicMock, patch
 
-from vector_indexing.components.embedders.sagemaker import Qwen38BEmbedder
+import pytest
+from google.genai import types
+
+from vector_indexing.components.embedders.google import (
+    Gemini001Embedder,
+    Gemini2Embedder,
+)
+from vector_indexing.components.embedders.openai import OpenAIEmbedder
+from vector_indexing.components.embedders.sagemaker import (
+    Qwen38BEmbedder,
+    Qwen3Embedder,
+)
 
 
 # ---------------------------------------------------------------------------
-# Abstract contract base
+# Abstract contract bases
 # ---------------------------------------------------------------------------
 
 
 class EmbedderContractTests:
     """Shared contract tests for every Embedder concrete.
 
-    Uses an abstract test class pattern: each concrete subclass must override
-    the `embedder` fixture to supply an Embedder instance with all external I/O mocked out.
+    Each concrete subclass must override the `embedder` fixture to supply an
+    Embedder instance with all external I/O mocked out.
     """
 
     @pytest.fixture
     def embedder(self):
         raise NotImplementedError("Subclass must provide an `embedder` fixture")
 
-    # TODO: implement — embed_document_batch returns same number of vectors as input texts
     def test_embed_document_batch_output_length_matches_input(self, embedder):
-        pytest.skip("TODO: implement test")
+        result = embedder.embed_document_batch(["alpha", "beta", "gamma"])
+        assert len(result) == 3
 
-    # TODO: implement — embed_document_batch propagates (raises) when any single
-    # embedding call fails, rather than silently dropping the item
-    def test_embed_document_batch_fails_when_single_embedding_fails(self, embedder):
-        pytest.skip("TODO: implement test")
+    def test_embed_document_batch_returns_empty_list_for_empty_input(self, embedder):
+        assert embedder.embed_document_batch([]) == []
+
+
+class APIEmbedderContractTests(EmbedderContractTests):
+    """Additional contract tests for APIEmbedder subclasses.
+
+    Subclasses must also override `unit_embedder` to supply an embedder with
+    batch_size=1, used for _make_request call-count and failure-propagation tests.
+    """
+
+    @pytest.fixture
+    def unit_embedder(self):
+        """Return an APIEmbedder with batch_size=1 for call-count tests."""
+        pytest.skip("Subclass must provide a unit_embedder fixture (batch_size=1)")
+
+    def test_embed_one_uses_make_request(self, embedder):
+        with patch.object(
+            embedder, "_make_request", wraps=embedder._make_request
+        ) as mock:
+            embedder.embed_one("hello")
+        mock.assert_called_once()
+
+    def test_embed_batch_call_count_matches_batch_size(self, unit_embedder):
+        """batch_size=1 and 3 texts → _make_request called 3 times."""
+        with patch.object(
+            unit_embedder, "_make_request", wraps=unit_embedder._make_request
+        ) as mock:
+            unit_embedder.embed_batch(["a", "b", "c"])
+        assert mock.call_count == 3
+
+    def test_embed_document_batch_fails_when_single_embedding_fails(
+        self, unit_embedder
+    ):
+        """Mock _make_request as success/error/success; assert the error propagates."""
+        original = unit_embedder._make_request
+        calls = []
+
+        def make_request_side_effect(texts, **kwargs):
+            calls.append(texts)
+            if len(calls) == 2:
+                raise RuntimeError("simulated API error on call 2")
+            return original(texts, **kwargs)
+
+        with patch.object(
+            unit_embedder, "_make_request", side_effect=make_request_side_effect
+        ):
+            with pytest.raises(Exception):
+                unit_embedder.embed_document_batch(["a", "b", "c"])
 
 
 # ---------------------------------------------------------------------------
@@ -36,17 +92,17 @@ class EmbedderContractTests:
 # ---------------------------------------------------------------------------
 
 
-class TestBedrockEmbedderContracts(EmbedderContractTests):
-    """
-    TODO: implement fixture — mock boto3 `bedrock-runtime` client.
-    `invoke_model` should return a response whose `body.read()` deserializes
-    to a list of float lists (one per input text).
-    See: vector_indexing/components/embedders/bedrock.py
-    """
+# class TestBedrockEmbedderContracts(EmbedderContractTests):
+#     """
+#     TODO: implement fixture — mock boto3 `bedrock-runtime` client.
+#     `invoke_model` should return a response whose `body.read()` deserializes
+#     to a list of float lists (one per input text).
+#     See: vector_indexing/components/embedders/bedrock.py
+#     """
 
-    @pytest.fixture
-    def embedder(self):
-        pytest.skip("TODO: implement BedrockEmbedder fixture")
+#     @pytest.fixture
+#     def embedder(self):
+#         pytest.skip("TODO: implement BedrockEmbedder fixture")
 
 
 # ---------------------------------------------------------------------------
@@ -54,17 +110,111 @@ class TestBedrockEmbedderContracts(EmbedderContractTests):
 # ---------------------------------------------------------------------------
 
 
-class TestGemini001EmbedderContracts(EmbedderContractTests):
+class TestGemini001EmbedderContracts(APIEmbedderContractTests):
+    """Contract tests for Gemini001Embedder with a mocked genai.Client.
+
+    embed_content is called with a list of strings and must return an object
+    whose .embeddings is a list of objects with a .values attribute (list[float]).
     """
-    TODO: implement fixture — pass a mock `google.genai.Client` instance.
-    `client.models.embed_content` should return an object whose `.embeddings`
-    attribute is a list of objects with a `.values` attribute (list[float]).
-    See: vector_indexing/components/embedders/google.py
-    """
+
+    def _make_client(self):
+        client = MagicMock()
+
+        def _embed_content(**kwargs):
+            contents = kwargs.get("contents", [])
+            n = len(contents) if isinstance(contents, list) else 1
+            result = MagicMock()
+            result.embeddings = [MagicMock(values=[0.1] * 768) for _ in range(n)]
+            return result
+
+        client.models.embed_content.side_effect = _embed_content
+        return client
 
     @pytest.fixture
     def embedder(self):
-        pytest.skip("TODO: implement Gemini001Embedder fixture")
+        return Gemini001Embedder(client=self._make_client())
+
+    @pytest.fixture
+    def unit_embedder(self):
+        return Gemini001Embedder(client=self._make_client(), batch_size=1)
+
+
+# ---------------------------------------------------------------------------
+# Gemini2Embedder
+# ---------------------------------------------------------------------------
+
+
+class TestGemini2EmbedderContracts(APIEmbedderContractTests):
+    """Contract + behavioral tests for Gemini2Embedder with a mocked genai.Client.
+
+    The mock client's embed_content returns one 768-d vector per Content object
+    in the contents list, mirroring real API behavior.
+    """
+
+    @pytest.fixture
+    def mock_client(self):
+        client = MagicMock()
+
+        def _embed_content(**kwargs):
+            contents = kwargs.get("contents", [])
+            n = len(contents) if isinstance(contents, list) else 1
+            result = MagicMock()
+            result.embeddings = [MagicMock(values=[0.1] * 768) for _ in range(n)]
+            return result
+
+        client.models.embed_content.side_effect = _embed_content
+        return client
+
+    @pytest.fixture
+    def embedder(self, mock_client):
+        return Gemini2Embedder(client=mock_client)
+
+    @pytest.fixture
+    def unit_embedder(self, mock_client):
+        return Gemini2Embedder(client=mock_client, batch_size=1)
+
+    # --- Gemini2-specific tests ---
+
+    def test_embed_document_prepends_document_prefix(self, embedder):
+        with patch.object(
+            embedder, "embed_one", return_value=[0.1] * 768
+        ) as mock_embed:
+            embedder.embed_document("my text")
+        mock_embed.assert_called_once_with("title: none | text: my text")
+
+    def test_embed_query_prepends_query_prefix(self, embedder):
+        with patch.object(
+            embedder, "embed_one", return_value=[0.1] * 768
+        ) as mock_embed:
+            embedder.embed_query("my query")
+        mock_embed.assert_called_once_with("task: search result | query: my query")
+
+    def test_embed_document_batch_prepends_document_prefix_to_all_texts(self, embedder):
+        with patch.object(
+            embedder, "embed_batch", return_value=[[0.1] * 768, [0.1] * 768]
+        ) as mock_batch:
+            embedder.embed_document_batch(["hello", "world"])
+        mock_batch.assert_called_once_with(
+            ["title: none | text: hello", "title: none | text: world"]
+        )
+
+    def test_embed_query_batch_prepends_query_prefix_to_all_texts(self, embedder):
+        with patch.object(
+            embedder, "embed_batch", return_value=[[0.1] * 768, [0.1] * 768]
+        ) as mock_batch:
+            embedder.embed_query_batch(["hello", "world"])
+        mock_batch.assert_called_once_with(
+            [
+                "task: search result | query: hello",
+                "task: search result | query: world",
+            ]
+        )
+
+    def test_call_api_wraps_texts_in_content_objects(self, embedder, mock_client):
+        embedder.embed_batch(["text1", "text2"])
+        contents = mock_client.models.embed_content.call_args.kwargs["contents"]
+        assert len(contents) == 2
+        assert all(isinstance(c, types.Content) for c in contents)
 
 
 # ---------------------------------------------------------------------------
@@ -72,17 +222,38 @@ class TestGemini001EmbedderContracts(EmbedderContractTests):
 # ---------------------------------------------------------------------------
 
 
-class TestSageMakerEmbedderContracts(EmbedderContractTests):
+class TestSageMakerEmbedderContracts(APIEmbedderContractTests):
+    """Contract tests for SageMaker TEI embedders, exercised via Qwen3Embedder.
+
+    HuggingFacePredictor is patched during construction so no real AWS calls
+    are made. predictor.predict returns [[float, ...]] per text in the batch.
     """
-    TODO: implement fixture — mock `sagemaker.Session` and
-    `HuggingFacePredictor` so that `predictor.predict` returns a list
-    containing a single float list (TEI single-text response shape).
-    See: vector_indexing/components/embedders/sagemaker.py
-    """
+
+    def _make_embedder(self, predict_side_effect=None, batch_size=1):
+        with (
+            patch("vector_indexing.components.embedders.sagemaker.boto3.Session"),
+            patch("vector_indexing.components.embedders.sagemaker.sagemaker.Session"),
+            patch(
+                "vector_indexing.components.embedders.sagemaker.HuggingFacePredictor"
+            ) as MockPredictor,
+        ):
+            mock_predictor = MagicMock()
+            if predict_side_effect is not None:
+                mock_predictor.predict.side_effect = predict_side_effect
+            else:
+                mock_predictor.predict.return_value = [[0.1] * 768]
+            MockPredictor.return_value = mock_predictor
+            return Qwen3Embedder(
+                endpoint_name="test-endpoint", dimensions=768, batch_size=batch_size
+            )
 
     @pytest.fixture
     def embedder(self):
-        pytest.skip("TODO: implement SageMakerEmbedder fixture")
+        return self._make_embedder()
+
+    @pytest.fixture
+    def unit_embedder(self):
+        return self._make_embedder(batch_size=1)
 
 
 # ---------------------------------------------------------------------------
@@ -90,17 +261,57 @@ class TestSageMakerEmbedderContracts(EmbedderContractTests):
 # ---------------------------------------------------------------------------
 
 
-class TestOpenAIEmbedderContracts(EmbedderContractTests):
+class TestOpenAIEmbedderContracts(APIEmbedderContractTests):
+    """Contract tests for OpenAIEmbedder with requests.post mocked.
+
+    _make_request posts a batch of texts and expects
+    {"data": [{"index": i, "embedding": [float, ...]}, ...]} in return.
     """
-    TODO: implement fixture — patch `requests.post` to return a mock Response
-    whose `.json()` returns `{"data": [{"embedding": [0.1, ...]}]}` for each
-    text in the batch.
-    See: vector_indexing/components/embedders/openai_compat.py
-    """
+
+    def _make_mock_post(self, side_effect=None):
+        mock_post = MagicMock()
+        if side_effect is not None:
+            mock_post.side_effect = side_effect
+        else:
+
+            def _post(*args, **kwargs):
+                inputs = kwargs.get("json", {}).get("input", [])
+                response = MagicMock()
+                response.json.return_value = {
+                    "data": [
+                        {"index": i, "embedding": [0.1] * 768}
+                        for i in range(len(inputs))
+                    ]
+                }
+                return response
+
+            mock_post.side_effect = _post
+        return mock_post
 
     @pytest.fixture
     def embedder(self):
-        pytest.skip("TODO: implement OpenAIEmbedder fixture")
+        with patch(
+            "vector_indexing.components.embedders.openai.requests.post",
+            self._make_mock_post(),
+        ):
+            yield OpenAIEmbedder(
+                base_url="http://localhost:1234",
+                model_name="test-model",
+                dimensions=768,
+            )
+
+    @pytest.fixture
+    def unit_embedder(self):
+        with patch(
+            "vector_indexing.components.embedders.openai.requests.post",
+            self._make_mock_post(),
+        ):
+            yield OpenAIEmbedder(
+                base_url="http://localhost:1234",
+                model_name="test-model",
+                dimensions=768,
+                batch_size=1,
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -108,16 +319,16 @@ class TestOpenAIEmbedderContracts(EmbedderContractTests):
 # ---------------------------------------------------------------------------
 
 
-class TestSentenceTransformersEmbedderContracts(EmbedderContractTests):
-    """
-    TODO: implement fixture — patch `sentence_transformers.SentenceTransformer`
-    so that `.encode(texts)` returns a numpy array of shape (len(texts), dims).
-    See: vector_indexing/components/embedders/sentence_transformers.py
-    """
+# class TestSentenceTransformersEmbedderContracts(EmbedderContractTests):
+#     """
+#     TODO: implement fixture — patch `sentence_transformers.SentenceTransformer`
+#     so that `.encode(texts)` returns a numpy array of shape (len(texts), dims).
+#     See: vector_indexing/components/embedders/sentence_transformers.py
+#     """
 
-    @pytest.fixture
-    def embedder(self):
-        pytest.skip("TODO: implement SentenceTransformersEmbedder fixture")
+#     @pytest.fixture
+#     def embedder(self):
+#         pytest.skip("TODO: implement SentenceTransformersEmbedder fixture")
 
 
 # ---------------------------------------------------------------------------
@@ -135,13 +346,13 @@ class TestQwen38BEmbedderImportWorkaround:
         assert Qwen38BEmbedder._fix_import_prefix("hello world") == "hello world"
 
 
-class TestQwen38BEmbedderContracts(EmbedderContractTests):
-    """
-    TODO: implement fixture — same shape as SageMakerEmbedder fixture but
-    instantiate Qwen38BEmbedder.
-    See: vector_indexing/components/embedders/sagemaker.py
-    """
+# class TestQwen38BEmbedderContracts(EmbedderContractTests):
+#     """
+#     TODO: implement fixture — same shape as SageMakerEmbedder fixture but
+#     instantiate Qwen38BEmbedder.
+#     See: vector_indexing/components/embedders/sagemaker.py
+#     """
 
-    @pytest.fixture
-    def embedder(self):
-        pytest.skip("TODO: implement Qwen38BEmbedder fixture")
+#     @pytest.fixture
+#     def embedder(self):
+#         pytest.skip("TODO: implement Qwen38BEmbedder fixture")

--- a/etl-pipeline/tests/unit/vector_indexing/test_embedders.py
+++ b/etl-pipeline/tests/unit/vector_indexing/test_embedders.py
@@ -50,11 +50,11 @@ class TestBedrockEmbedderContracts(EmbedderContractTests):
 
 
 # ---------------------------------------------------------------------------
-# GoogleEmbedder
+# Gemini001Embedder
 # ---------------------------------------------------------------------------
 
 
-class TestGoogleEmbedderContracts(EmbedderContractTests):
+class TestGemini001EmbedderContracts(EmbedderContractTests):
     """
     TODO: implement fixture — pass a mock `google.genai.Client` instance.
     `client.models.embed_content` should return an object whose `.embeddings`
@@ -64,7 +64,7 @@ class TestGoogleEmbedderContracts(EmbedderContractTests):
 
     @pytest.fixture
     def embedder(self):
-        pytest.skip("TODO: implement GoogleEmbedder fixture")
+        pytest.skip("TODO: implement Gemini001Embedder fixture")
 
 
 # ---------------------------------------------------------------------------

--- a/etl-pipeline/vector_indexing/components/embedders/__init__.py
+++ b/etl-pipeline/vector_indexing/components/embedders/__init__.py
@@ -2,7 +2,10 @@
 
 from vector_indexing.components.embedders.base import Embedder
 from vector_indexing.components.embedders.bedrock import BedrockEmbedder
-from vector_indexing.components.embedders.google import GoogleEmbedder
+from vector_indexing.components.embedders.google import (
+    Gemini001Embedder,
+    Gemini2Embedder,
+)
 from vector_indexing.components.embedders.openai import OpenAIEmbedder
 from vector_indexing.components.embedders.sagemaker import (
     HarrierEmbedder,
@@ -15,7 +18,8 @@ from vector_indexing.components.embedders.sagemaker import (
 __all__ = [
     "Embedder",
     "BedrockEmbedder",
-    "GoogleEmbedder",
+    "Gemini001Embedder",
+    "Gemini2Embedder",
     "HarrierEmbedder",
     "PplxEmbedder",
     "Qwen38BEmbedder",

--- a/etl-pipeline/vector_indexing/components/embedders/__init__.py
+++ b/etl-pipeline/vector_indexing/components/embedders/__init__.py
@@ -7,6 +7,9 @@ from vector_indexing.components.embedders.google import (
     Gemini2Embedder,
 )
 from vector_indexing.components.embedders.openai import OpenAIEmbedder
+from vector_indexing.components.embedders.sentence_transformers import (
+    SentenceTransformersEmbedder,
+)
 from vector_indexing.components.embedders.sagemaker import (
     HarrierEmbedder,
     PplxEmbedder,
@@ -26,4 +29,5 @@ __all__ = [
     "Qwen3Embedder",
     "OpenAIEmbedder",
     "SageMakerTEIEmbedder",
+    "SentenceTransformersEmbedder",
 ]

--- a/etl-pipeline/vector_indexing/components/embedders/base.py
+++ b/etl-pipeline/vector_indexing/components/embedders/base.py
@@ -50,3 +50,17 @@ class Embedder(ABC):
 
     # NOTE: the usage pattern in Pipeline.index_books(), requires batch failure
     # if any single embedding fails
+
+
+class APIEmbedder(Embedder, ABC):
+    """Abstract base for API-backed embedders.
+
+    Subclasses must implement ``_make_request`` which performs a single batched
+    API call. ``embed_one`` and ``embed_batch`` should route through it so that
+    failures surface consistently.
+    """
+
+    @abstractmethod
+    def _make_request(self, texts: list[str], **kwargs):
+        """Make a single batched API call and return raw results."""
+        ...

--- a/etl-pipeline/vector_indexing/components/embedders/google.py
+++ b/etl-pipeline/vector_indexing/components/embedders/google.py
@@ -37,6 +37,8 @@ DEFAULT_RATE_LIMIT_PERIOD = 60  # seconds
 # TODO: set RPM and TPM and set up _make_request to have @limits derived from the \
 # RPM and TPM (for configured tokens per chunk = 750). This will require some factory function
 
+# TODO: add batch_concurrency support, and benchmark to id ideal concurrency.
+
 
 def _l2_normalize(vector: list[float]) -> list[float]:
     """L2-normalize a vector. Required for gemini-embedding-001 at non-3072 dims."""

--- a/etl-pipeline/vector_indexing/components/embedders/google.py
+++ b/etl-pipeline/vector_indexing/components/embedders/google.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import numpy as np
+
 from google import genai
 from google.genai import types
 from google.genai.errors import ClientError
@@ -21,8 +23,7 @@ if TYPE_CHECKING:
     from google.genai import Client
 
 
-# Gemini-embedding-001 defaults
-DEFAULT_MODEL = "gemini-embedding-001"
+# Tutorial Docs: # https://ai.google.dev/gemini-api/docs/embeddings
 DEFAULT_DIMS = 768
 DEFAULT_BATCH_SIZE = 100
 # Rate limit: 20 calls/min with batch size 100 = 2000 embeddings/min
@@ -31,10 +32,13 @@ DEFAULT_BATCH_SIZE = 100
 DEFAULT_RATE_LIMIT_CALLS = 20
 DEFAULT_RATE_LIMIT_PERIOD = 60  # seconds
 
-# Gemini-embedding-2 defaults
-DEFAULT_MODEL_2 = "gemini-embedding-2"
-DEFAULT_DIMS_2 = 768
-DEFAULT_BATCH_SIZE_2 = 100
+
+def _l2_normalize(vector: list[float]) -> list[float]:
+    """L2-normalize a vector. Required for gemini-embedding-001 at non-3072 dims."""
+    # https://ai.google.dev/gemini-api/docs/embeddings
+    embedding_values_np = np.array(vector)
+    normed_embedding = embedding_values_np / np.linalg.norm(embedding_values_np)
+    return normed_embedding.tolist()
 
 
 def _is_rate_limit_error(exception: BaseException) -> bool:
@@ -66,7 +70,7 @@ class Gemini001Embedder(Embedder):
 
     def __init__(
         self,
-        model: str = DEFAULT_MODEL,
+        model: str = "gemini-embedding-001",
         dimensions: int = DEFAULT_DIMS,
         batch_size: int = DEFAULT_BATCH_SIZE,
         client: "Client | None" = None,
@@ -86,11 +90,6 @@ class Gemini001Embedder(Embedder):
         """Return the model identifier."""
         return self._model
 
-    @property
-    def batch_size(self) -> int:
-        """Return the maximum batch size for API calls."""
-        return self._batch_size
-
     def embed_one(
         self, text: str, task_type: str = "RETRIEVAL_DOCUMENT"
     ) -> list[float]:
@@ -102,7 +101,7 @@ class Gemini001Embedder(Embedder):
                 "output_dimensionality": self._dimensions,
             },
         )
-        return result.embeddings[0].values
+        return _l2_normalize(result.embeddings[0].values)
 
     def embed_batch(
         self, texts: list[str], task_type: str = "RETRIEVAL_DOCUMENT"
@@ -114,7 +113,7 @@ class Gemini001Embedder(Embedder):
         for i in range(0, len(texts), self._batch_size):
             batch = texts[i : i + self._batch_size]
             result = self._call_api(batch, task_type)
-            vectors.extend([emb.values for emb in result.embeddings])
+            vectors.extend([_l2_normalize(emb.values) for emb in result.embeddings])
         return vectors
 
     def embed_document(self, text: str) -> list[float]:
@@ -146,9 +145,7 @@ class Gemini001Embedder(Embedder):
         """Make rate-limited API call with retry on rate limit errors."""
         return self._client.models.embed_content(
             model=self._model,
-            contents=[
-                types.Content(parts=[types.Part.from_text(text=t)]) for t in batch
-            ],
+            contents=batch,
             config={
                 "task_type": task_type,
                 "output_dimensionality": self._dimensions,
@@ -159,26 +156,28 @@ class Gemini001Embedder(Embedder):
 class Gemini2Embedder(Embedder):
     """Google Gemini Embedding 2 model implementation.
 
-    Unlike gemini-embedding-001, this model does not support task_type as a
-    parameter. Task context is specified via instruction prefixes in the input text:
-      - Documents: "title: none | text: {content}"
-      - Queries:   "task: search result | query: {content}"
-
-    For batching, each input is wrapped in a Content object. Passing raw strings
-    in a list produces a single aggregated embedding rather than per-item embeddings.
+    Differences with gemini-001:
+    - Task type is specified via instruction prefixes
+      in the embedded text:
+        - Documents: "title: none | text: {content}"
+        - Queries:   "task: search result | query: {content}"
+    - For batching, each input is wrapped in a Content object. Passing raw strings
+      in a list produces a single aggregated embedding rather than per-item embeddings.
+    - For truncated embeddings (MRL below 3072), the API returns
+      pre-normalized embeddings.
 
     Args:
         model: model name (default: gemini-embedding-2)
-        dimensions: output vector dimensions — 128-3072, recommend 768/1536/3072 (default: 3072)
-        batch_size: max Content objects per API call (default: 100)
+        dimensions: output vector dimensions — 128-3072, recommend 768/1536/3072 (default: 768)
+        batch_size: max Content objects to embed per API call (default: 100)
         client: optional pre-configured genai.Client instance
     """
 
     def __init__(
         self,
-        model: str = DEFAULT_MODEL_2,
-        dimensions: int = DEFAULT_DIMS_2,
-        batch_size: int = DEFAULT_BATCH_SIZE_2,
+        model: str = "gemini-embedding-2",
+        dimensions: int = DEFAULT_DIMS,
+        batch_size: int = DEFAULT_BATCH_SIZE,
         client: "Client | None" = None,
     ):
         self._model = model
@@ -193,10 +192,6 @@ class Gemini2Embedder(Embedder):
     @property
     def model_name(self) -> str:
         return self._model
-
-    @property
-    def batch_size(self) -> int:
-        return self._batch_size
 
     def embed_one(self, text: str) -> list[float]:
         result = self._call_api([text])
@@ -213,18 +208,26 @@ class Gemini2Embedder(Embedder):
             vectors.extend([emb.values for emb in result.embeddings])
         return vectors
 
+    def _format_document(self, text: str) -> str:
+        return f"title: none | text: {text}"
+
+    def _format_query(self, text: str) -> str:
+        return f"task: search result | query: {text}"
+
     def embed_document(self, text: str) -> list[float]:
-        return self.embed_one(f"title: none | text: {text}")
+        return self.embed_one(self._format_document(text))
 
     def embed_document_batch(self, texts: list[str]) -> list[list[float]]:
-        return self.embed_batch([f"title: none | text: {t}" for t in texts])
+        return self.embed_batch([self._format_document(t) for t in texts])
 
     def embed_query(self, text: str) -> list[float]:
-        return self.embed_one(f"task: search result | query: {text}")
+        return self.embed_one(self._format_query(text))
 
     def embed_query_batch(self, texts: list[str]) -> list[list[float]]:
-        return self.embed_batch([f"task: search result | query: {t}" for t in texts])
+        return self.embed_batch([self._format_query(t) for t in texts])
 
+    # MAYBE: since Content() does work for gemini-001 too (I think), _call_api()
+    # could be pulled out to a module function shared by both embedders.
     @retry(
         stop=stop_after_attempt(7),
         wait=wait_exponential(multiplier=4, max=70),

--- a/etl-pipeline/vector_indexing/components/embedders/google.py
+++ b/etl-pipeline/vector_indexing/components/embedders/google.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 from google import genai
 from google.genai import types
-from google.genai.errors import ClientError
+from google.genai.errors import ClientError, ServerError
 from ratelimit import limits, sleep_and_retry
 from tenacity import (
     retry,
@@ -15,7 +15,7 @@ from tenacity import (
     wait_exponential,
 )
 
-from vector_indexing.components.embedders.base import Embedder
+from vector_indexing.components.embedders.base import APIEmbedder
 from logger import create_log
 
 if TYPE_CHECKING:
@@ -30,9 +30,12 @@ DEFAULT_BATCH_SIZE = 100
 # Rate limit: 20 calls/min with batch size 100 = 2000 embeddings/min
 # (3000/min usually breaks the token limit with current chunking leading to
 # more backoff attempts and thus lower thruput)
+# June 2026: new rate limits: reqs/min=20k, toks/min=20M
 # DEFAULT_RATE_LIMIT_CALLS = 20
-DEFAULT_RATE_LIMIT_CALLS = 20_000
+DEFAULT_RATE_LIMIT_CALLS = 15_000
 DEFAULT_RATE_LIMIT_PERIOD = 60  # seconds
+# TODO: set RPM and TPM and set up _make_request to have @limits derived from the \
+# RPM and TPM (for configured tokens per chunk = 750). This will require some factory function
 
 
 def _l2_normalize(vector: list[float]) -> list[float]:
@@ -50,7 +53,19 @@ def _is_rate_limit_error(exception: BaseException) -> bool:
     )
 
 
-class Gemini001Embedder(Embedder):
+def _is_service_unavailable_error(exception: BaseException) -> bool:
+    """Check if exception is a service unavailable error (HTTP 503)."""
+    # google.genai.errors.ServerError: 503 UNAVAILABLE. {'error': {'code': 503, 'message': 'The service is currently unavailable.', 'status': 'UNAVAILABLE'}}
+    return (
+        isinstance(exception, ServerError) and getattr(exception, "code", None) == 503
+    )
+
+
+def _should_retry(exception: BaseException) -> bool:
+    return _is_rate_limit_error(exception) or _is_service_unavailable_error(exception)
+
+
+class Gemini001Embedder(APIEmbedder):
     """Google Gemini embedding-001 model implementation.
 
     Uses the google-genai client with built-in rate limiting and
@@ -95,14 +110,7 @@ class Gemini001Embedder(Embedder):
     def embed_one(
         self, text: str, task_type: str = "RETRIEVAL_DOCUMENT"
     ) -> list[float]:
-        result = self._client.models.embed_content(
-            model=self._model,
-            contents=text,
-            config={
-                "task_type": task_type,
-                "output_dimensionality": self._dimensions,
-            },
-        )
+        result = self._make_request([text], task_type=task_type)
         return _l2_normalize(result.embeddings[0].values)
 
     def embed_batch(
@@ -114,7 +122,7 @@ class Gemini001Embedder(Embedder):
         vectors: list[list[float]] = []
         for i in range(0, len(texts), self._batch_size):
             batch = texts[i : i + self._batch_size]
-            result = self._call_api(batch, task_type)
+            result = self._make_request(batch, task_type=task_type)
             vectors.extend([_l2_normalize(emb.values) for emb in result.embeddings])
         return vectors
 
@@ -135,15 +143,17 @@ class Gemini001Embedder(Embedder):
     @retry(
         stop=stop_after_attempt(7),
         wait=wait_exponential(multiplier=4, max=70),
-        retry=retry_if_exception(_is_rate_limit_error),
+        retry=retry_if_exception(_should_retry),
         before_sleep=lambda retry_state: logger.warning(
-            f"Rate limit hit, retrying in {retry_state.next_action.sleep:.1f}s "
+            f"Retrying in {retry_state.next_action.sleep:.1f}s "
             f"(attempt {retry_state.attempt_number}): {retry_state.outcome.exception()}"
         ),
     )
     @sleep_and_retry
     @limits(calls=DEFAULT_RATE_LIMIT_CALLS, period=DEFAULT_RATE_LIMIT_PERIOD)
-    def _call_api(self, batch: list[str], task_type: str):
+    def _make_request(
+        self, batch: list[str], task_type: str = "RETRIEVAL_DOCUMENT", **kwargs
+    ):
         """Make rate-limited API call with retry on rate limit errors."""
         return self._client.models.embed_content(
             model=self._model,
@@ -155,7 +165,7 @@ class Gemini001Embedder(Embedder):
         )
 
 
-class Gemini2Embedder(Embedder):
+class Gemini2Embedder(APIEmbedder):
     """Google Gemini Embedding 2 model implementation.
 
     Differences with gemini-001:
@@ -196,7 +206,7 @@ class Gemini2Embedder(Embedder):
         return self._model
 
     def embed_one(self, text: str) -> list[float]:
-        result = self._call_api([text])
+        result = self._make_request([text])
         return result.embeddings[0].values
 
     def embed_batch(self, texts: list[str]) -> list[list[float]]:
@@ -206,7 +216,7 @@ class Gemini2Embedder(Embedder):
         vectors: list[list[float]] = []
         for i in range(0, len(texts), self._batch_size):
             batch = texts[i : i + self._batch_size]
-            result = self._call_api(batch)
+            result = self._make_request(batch)
             vectors.extend([emb.values for emb in result.embeddings])
         return vectors
 
@@ -233,15 +243,15 @@ class Gemini2Embedder(Embedder):
     @retry(
         stop=stop_after_attempt(7),
         wait=wait_exponential(multiplier=4, max=70),
-        retry=retry_if_exception(_is_rate_limit_error),
+        retry=retry_if_exception(_should_retry),
         before_sleep=lambda retry_state: logger.warning(
-            f"Rate limit hit, retrying in {retry_state.next_action.sleep:.1f}s "
+            f"Retrying in {retry_state.next_action.sleep:.1f}s "
             f"(attempt {retry_state.attempt_number}): {retry_state.outcome.exception()}"
         ),
     )
     @sleep_and_retry
     @limits(calls=DEFAULT_RATE_LIMIT_CALLS, period=DEFAULT_RATE_LIMIT_PERIOD)
-    def _call_api(self, texts: list[str]):
+    def _make_request(self, texts: list[str], **kwargs):
         """Make rate-limited API call with retry on rate limit errors."""
         return self._client.models.embed_content(
             model=self._model,

--- a/etl-pipeline/vector_indexing/components/embedders/google.py
+++ b/etl-pipeline/vector_indexing/components/embedders/google.py
@@ -240,7 +240,7 @@ class Gemini2Embedder(APIEmbedder):
     def embed_query_batch(self, texts: list[str]) -> list[list[float]]:
         return self.embed_batch([self._format_query(t) for t in texts])
 
-    # MAYBE: since Content() does work for gemini-001 too (I think), _call_api()
+    # MAYBE: since Content() does work for gemini-001 too (I think), _make_request()
     # could be pulled out to a module function shared by both embedders.
     @retry(
         stop=stop_after_attempt(7),

--- a/etl-pipeline/vector_indexing/components/embedders/google.py
+++ b/etl-pipeline/vector_indexing/components/embedders/google.py
@@ -1,11 +1,9 @@
 """Google Gemini embedding implementations."""
 
 from __future__ import annotations
-
 from typing import TYPE_CHECKING
 
 import numpy as np
-
 from google import genai
 from google.genai import types
 from google.genai.errors import ClientError
@@ -18,10 +16,13 @@ from tenacity import (
 )
 
 from vector_indexing.components.embedders.base import Embedder
+from logger import create_log
 
 if TYPE_CHECKING:
     from google.genai import Client
 
+
+logger = create_log(__name__)
 
 # Tutorial Docs: # https://ai.google.dev/gemini-api/docs/embeddings
 DEFAULT_DIMS = 768
@@ -29,7 +30,8 @@ DEFAULT_BATCH_SIZE = 100
 # Rate limit: 20 calls/min with batch size 100 = 2000 embeddings/min
 # (3000/min usually breaks the token limit with current chunking leading to
 # more backoff attempts and thus lower thruput)
-DEFAULT_RATE_LIMIT_CALLS = 20
+# DEFAULT_RATE_LIMIT_CALLS = 20
+DEFAULT_RATE_LIMIT_CALLS = 20_000
 DEFAULT_RATE_LIMIT_PERIOD = 60  # seconds
 
 
@@ -134,7 +136,7 @@ class Gemini001Embedder(Embedder):
         stop=stop_after_attempt(7),
         wait=wait_exponential(multiplier=4, max=70),
         retry=retry_if_exception(_is_rate_limit_error),
-        before_sleep=lambda retry_state: print(
+        before_sleep=lambda retry_state: logger.warning(
             f"Rate limit hit, retrying in {retry_state.next_action.sleep:.1f}s "
             f"(attempt {retry_state.attempt_number}): {retry_state.outcome.exception()}"
         ),
@@ -232,7 +234,7 @@ class Gemini2Embedder(Embedder):
         stop=stop_after_attempt(7),
         wait=wait_exponential(multiplier=4, max=70),
         retry=retry_if_exception(_is_rate_limit_error),
-        before_sleep=lambda retry_state: print(
+        before_sleep=lambda retry_state: logger.warning(
             f"Rate limit hit, retrying in {retry_state.next_action.sleep:.1f}s "
             f"(attempt {retry_state.attempt_number}): {retry_state.outcome.exception()}"
         ),

--- a/etl-pipeline/vector_indexing/components/embedders/google.py
+++ b/etl-pipeline/vector_indexing/components/embedders/google.py
@@ -1,10 +1,11 @@
-"""Google Gemini embedding implementation."""
+"""Google Gemini embedding implementations."""
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
 from google import genai
+from google.genai import types
 from google.genai.errors import ClientError
 from ratelimit import limits, sleep_and_retry
 from tenacity import (
@@ -20,7 +21,7 @@ if TYPE_CHECKING:
     from google.genai import Client
 
 
-# Default model configuration
+# Gemini-embedding-001 defaults
 DEFAULT_MODEL = "gemini-embedding-001"
 DEFAULT_DIMS = 768
 DEFAULT_BATCH_SIZE = 100
@@ -30,6 +31,11 @@ DEFAULT_BATCH_SIZE = 100
 DEFAULT_RATE_LIMIT_CALLS = 20
 DEFAULT_RATE_LIMIT_PERIOD = 60  # seconds
 
+# Gemini-embedding-2 defaults
+DEFAULT_MODEL_2 = "gemini-embedding-2"
+DEFAULT_DIMS_2 = 768
+DEFAULT_BATCH_SIZE_2 = 100
+
 
 def _is_rate_limit_error(exception: BaseException) -> bool:
     """Check if exception is a rate limit error (HTTP 429)."""
@@ -38,8 +44,8 @@ def _is_rate_limit_error(exception: BaseException) -> bool:
     )
 
 
-class GoogleEmbedder(Embedder):
-    """Google Gemini embedding model implementation.
+class Gemini001Embedder(Embedder):
+    """Google Gemini embedding-001 model implementation.
 
     Uses the google-genai client with built-in rate limiting and
     exponential backoff retry for rate limit errors.
@@ -140,9 +146,102 @@ class GoogleEmbedder(Embedder):
         """Make rate-limited API call with retry on rate limit errors."""
         return self._client.models.embed_content(
             model=self._model,
-            contents=batch,
+            contents=[
+                types.Content(parts=[types.Part.from_text(text=t)]) for t in batch
+            ],
             config={
                 "task_type": task_type,
                 "output_dimensionality": self._dimensions,
             },
+        )
+
+
+class Gemini2Embedder(Embedder):
+    """Google Gemini Embedding 2 model implementation.
+
+    Unlike gemini-embedding-001, this model does not support task_type as a
+    parameter. Task context is specified via instruction prefixes in the input text:
+      - Documents: "title: none | text: {content}"
+      - Queries:   "task: search result | query: {content}"
+
+    For batching, each input is wrapped in a Content object. Passing raw strings
+    in a list produces a single aggregated embedding rather than per-item embeddings.
+
+    Args:
+        model: model name (default: gemini-embedding-2)
+        dimensions: output vector dimensions — 128-3072, recommend 768/1536/3072 (default: 3072)
+        batch_size: max Content objects per API call (default: 100)
+        client: optional pre-configured genai.Client instance
+    """
+
+    def __init__(
+        self,
+        model: str = DEFAULT_MODEL_2,
+        dimensions: int = DEFAULT_DIMS_2,
+        batch_size: int = DEFAULT_BATCH_SIZE_2,
+        client: "Client | None" = None,
+    ):
+        self._model = model
+        self._dimensions = dimensions
+        self._batch_size = batch_size
+        self._client = client or genai.Client()
+
+    @property
+    def dimensions(self) -> int:
+        return self._dimensions
+
+    @property
+    def model_name(self) -> str:
+        return self._model
+
+    @property
+    def batch_size(self) -> int:
+        return self._batch_size
+
+    def embed_one(self, text: str) -> list[float]:
+        result = self._call_api([text])
+        return result.embeddings[0].values
+
+    def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        if not texts:
+            return []
+
+        vectors: list[list[float]] = []
+        for i in range(0, len(texts), self._batch_size):
+            batch = texts[i : i + self._batch_size]
+            result = self._call_api(batch)
+            vectors.extend([emb.values for emb in result.embeddings])
+        return vectors
+
+    def embed_document(self, text: str) -> list[float]:
+        return self.embed_one(f"title: none | text: {text}")
+
+    def embed_document_batch(self, texts: list[str]) -> list[list[float]]:
+        return self.embed_batch([f"title: none | text: {t}" for t in texts])
+
+    def embed_query(self, text: str) -> list[float]:
+        return self.embed_one(f"task: search result | query: {text}")
+
+    def embed_query_batch(self, texts: list[str]) -> list[list[float]]:
+        return self.embed_batch([f"task: search result | query: {t}" for t in texts])
+
+    @retry(
+        stop=stop_after_attempt(7),
+        wait=wait_exponential(multiplier=4, max=70),
+        retry=retry_if_exception(_is_rate_limit_error),
+        before_sleep=lambda retry_state: print(
+            f"Rate limit hit, retrying in {retry_state.next_action.sleep:.1f}s "
+            f"(attempt {retry_state.attempt_number}): {retry_state.outcome.exception()}"
+        ),
+    )
+    @sleep_and_retry
+    @limits(calls=DEFAULT_RATE_LIMIT_CALLS, period=DEFAULT_RATE_LIMIT_PERIOD)
+    def _call_api(self, texts: list[str]):
+        """Make rate-limited API call with retry on rate limit errors."""
+        return self._client.models.embed_content(
+            model=self._model,
+            contents=[
+                types.Content(parts=[types.Part.from_text(text=t)]) for t in texts
+            ],
+            config={"output_dimensionality": self._dimensions},
         )

--- a/etl-pipeline/vector_indexing/components/embedders/openai.py
+++ b/etl-pipeline/vector_indexing/components/embedders/openai.py
@@ -5,14 +5,18 @@ from __future__ import annotations
 
 import requests
 
-from vector_indexing.components.embedders.base import Embedder
+from vector_indexing.components.embedders.base import APIEmbedder
 
 
 DEFAULT_BATCH_SIZE = 32
 
 
-class OpenAIEmbedder(Embedder):
+class OpenAIEmbedder(APIEmbedder):
     """Embedding model served by any OpenAI-compatible embeddings endpoint.
+
+    This endpoint is task-agnostic: document and query embeddings are identical,
+    so embed_document/embed_query are aliases for embed_one/embed_batch.
+    Sub-class this class to implement task-aware embedders for specific models.
 
     Args:
         base_url: Base URL of the endpoint (e.g. ``http://localhost:1234``).
@@ -20,9 +24,6 @@ class OpenAIEmbedder(Embedder):
         model_name: Model identifier to pass in the request payload.
         dimensions: Output vector dimensions. Must match the model's output size.
         batch_size: Max texts per API call (default: 32).
-
-        .embed_document(), .embed_document_batch(), .embed_query(), and .embed_query_batch()
-        inherited from the abstract class raise NotImplementedError.
     """
 
     def __init__(
@@ -57,51 +58,41 @@ class OpenAIEmbedder(Embedder):
         """Return the full embeddings endpoint URL."""
         return f"{self._base_url}/v1/embeddings"
 
-    def embed_one(self, text: str) -> list[float]:
-        """Embed a single text string."""
-        payload = {
-            "model": self.model_name,
-            "input": text.strip(),
-        }
-
+    def _make_request(self, texts: list[str], **kwargs) -> list[list[float]]:
+        """POST a batch of texts to the embeddings endpoint and return vectors in input order."""
+        payload = {"model": self.model_name, "input": [t.strip() for t in texts]}
         response = requests.post(
             self.endpoint,
             headers={"Content-Type": "application/json"},
             json=payload,
-            timeout=60,
+            timeout=120,
         )
         response.raise_for_status()
-
         data = response.json()
-        return data["data"][0]["embedding"]
+        # Sort by index in case the server returns items out of order.
+        return [
+            item["embedding"] for item in sorted(data["data"], key=lambda x: x["index"])
+        ]
+
+    def embed_one(self, text: str) -> list[float]:
+        return self._make_request([text])[0]
 
     def embed_batch(self, texts: list[str]) -> list[list[float]]:
-        """Embed multiple texts in batches."""
         if not texts:
             return []
-
         vectors: list[list[float]] = []
-
         for i in range(0, len(texts), self._batch_size):
-            batch = [t.strip() for t in texts[i : i + self._batch_size]]
-
-            payload = {
-                "model": self.model_name,
-                "input": batch,
-            }
-
-            response = requests.post(
-                self.endpoint,
-                headers={"Content-Type": "application/json"},
-                json=payload,
-                timeout=120,
-            )
-            response.raise_for_status()
-
-            data = response.json()
-            # Response has an 'index' key indicating the original order.
-            # Sort to be safe even if the server returns them out of order.
-            batch_embeddings = sorted(data["data"], key=lambda x: x["index"])
-            vectors.extend([item["embedding"] for item in batch_embeddings])
-
+            vectors.extend(self._make_request(texts[i : i + self._batch_size]))
         return vectors
+
+    def embed_document(self, text: str) -> list[float]:
+        return self.embed_one(text)
+
+    def embed_document_batch(self, texts: list[str]) -> list[list[float]]:
+        return self.embed_batch(texts)
+
+    def embed_query(self, text: str) -> list[float]:
+        return self.embed_one(text)
+
+    def embed_query_batch(self, texts: list[str]) -> list[list[float]]:
+        return self.embed_batch(texts)

--- a/etl-pipeline/vector_indexing/components/embedders/sagemaker.py
+++ b/etl-pipeline/vector_indexing/components/embedders/sagemaker.py
@@ -16,10 +16,10 @@ from sagemaker.huggingface import HuggingFacePredictor
 # from sagemaker.serializers import JSONSerializer
 
 from utils.s3 import get_boto3_session_with_assumed_role
-from vector_indexing.components.embedders.base import Embedder
+from vector_indexing.components.embedders.base import APIEmbedder
 
 
-class SageMakerTEIEmbedder(Embedder):
+class SageMakerTEIEmbedder(APIEmbedder):
     """Intermediary abstract class for all types of embedding models served on SageMaker HF TEI endpoints.
 
     Args:
@@ -31,21 +31,23 @@ class SageMakerTEIEmbedder(Embedder):
             ``assume_role`` is also provided, this profile is applied to the
             default session used to perform the STS AssumeRole call.
         assume_role: ARN of an IAM role to assume for model inference calls.
-        concurrency: concurrent requests in embed_batch()
+        batch_concurrency: concurrent requests in embed_batch(), ignored by .embed_one()
     """
 
     def __init__(
         self,
         endpoint_name: str,
         dimensions: int | None = None,
-        concurrency: int = 1,
+        batch_size: int = 1,
+        batch_concurrency: int = 1,
         aws_profile: str | None = None,
         assume_role: str | None = None,
     ) -> None:
         self._endpoint_name = endpoint_name
         self._dimensions = dimensions
         self._aws_profile = aws_profile
-        self._concurrency = concurrency
+        self._batch_size = batch_size
+        self._batch_concurrency = batch_concurrency
         boto_session = (
             boto3.Session(profile_name=self._aws_profile)
             if self._aws_profile
@@ -87,34 +89,52 @@ class SageMakerTEIEmbedder(Embedder):
             .get("HF_MODEL_ID", self._endpoint_name)
         )
 
-    def embed_one(self, text: str, prompt_name: str | None = None) -> list[float]:
-        """Embed a single text string."""
+    def _make_request(self, texts: list[str], **kwargs) -> list[list[float]]:
+        """Call the TEI endpoint with a batch of texts and return a list of vectors.
+
+        TEI accepts {"inputs": [str, ...]} and returns [[float, ...], ...].
+        L2 normalization is applied by TEI post-truncation by default regardless of `dimensions`.
+        """
+        prompt_name = kwargs.get("prompt_name")
         extra_args = {}
         if self._dimensions:
             extra_args["dimensions"] = self._dimensions
         if prompt_name:
             extra_args["prompt_name"] = prompt_name
+        return self._predictor.predict({"inputs": texts, **extra_args})
 
-        # NOTE: The HF TEI endpoint accepts {"inputs": "text"} and returns a list of floats.
-        # NOTE: L2 normalization is applied post-hoc by default regardless of `dimensions`
-        embeddings = self._predictor.predict({"inputs": text, **extra_args})
-        return embeddings[0]
+    def embed_one(self, text: str, prompt_name: str | None = None) -> list[float]:
+        """Embed a single text string."""
+        return self._make_request([text], prompt_name=prompt_name)[0]
 
     def embed_batch(
         self, texts: list[str], prompt_name: str | None = None
     ) -> list[list[float]]:
-        """Embed multiple texts up to `concurrency` in-flight requests."""
-        # TODO: look at other sagemaker deployments that support better batch speed and cost like, batch_transform, async inference endpoint
-        # TODO: try  {inputs: [<str>, <str>]}. see --max-client-batch-size https://github.com/huggingface/text-embeddings-inference
-        if self._concurrency <= 1:
-            return [self.embed_one(text, prompt_name=prompt_name) for text in texts]
+        """Embed multiple texts, chunked by batch_size with optional concurrency.
+
+        See --max-client-batch-size https://github.com/huggingface/text-embeddings-inference
+        TODO: look at other sagemaker deployments for better batch speed/cost: batch_transform, async inference endpoint
+        """
+        batches = [
+            texts[i : i + self._batch_size]
+            for i in range(0, len(texts), self._batch_size)
+        ]
+        if self._batch_concurrency <= 1:
+            results: list[list[float]] = []
+            for batch in batches:
+                results.extend(self._make_request(batch, prompt_name=prompt_name))
+            return results
         with concurrent.futures.ThreadPoolExecutor(
-            max_workers=self._concurrency
+            max_workers=self._batch_concurrency
         ) as executor:
             futures = [
-                executor.submit(self.embed_one, text, prompt_name) for text in texts
+                executor.submit(self._make_request, batch, prompt_name=prompt_name)
+                for batch in batches
             ]
-            return [f.result() for f in futures]
+            results = []
+            for f in futures:
+                results.extend(f.result())
+            return results
 
 
 class Qwen3Embedder(SageMakerTEIEmbedder):

--- a/etl-pipeline/vector_indexing/components/loaders/s3.py
+++ b/etl-pipeline/vector_indexing/components/loaders/s3.py
@@ -106,6 +106,10 @@ class S3BookLoader(BookLoader):
         self._grin_access_key = grin_access_key or os.environ.get("GRIN_ACCESS_KEY")
         self._gpg = gnupg.GPG()
 
+        if self._cache is not None:
+            if isinstance(self._cache, DiskBookCache):
+                logger.info(f"Using cache at {self._cache.cache_dir}")
+
     @cached_property
     def s3(self) -> S3Client:
         """Lazily initialize S3 client."""

--- a/etl-pipeline/vector_indexing/core/config.py
+++ b/etl-pipeline/vector_indexing/core/config.py
@@ -6,8 +6,10 @@ import os
 from copy import deepcopy
 from dataclasses import dataclass, field, fields
 from pathlib import Path
+from typing import Any
 
 from glom import assign, delete
+from pydantic import BaseModel, ConfigDict, Field
 
 from utils.common import require_env
 
@@ -147,11 +149,29 @@ def load_from_module(obj_name: str, module) -> type:
     return cls
 
 
+class EmbedderConfig(BaseModel):
+    model_config = ConfigDict(validate_by_alias=True)
+
+    class_name: str = Field(alias="class")
+    params: dict[str, Any]
+
+
+class IndexConfigEntry(BaseModel):
+    model_config = ConfigDict(validate_by_alias=True)
+
+    names: list[str]
+    embedder: EmbedderConfig
+    tpuf_schema: dict = Field(alias="schema")
+
+
 QWEN3_EMBEDDING_DIMENSIONS = HARRIER_OSS_V1_DIMENSIONS = PPLX_V1_DIMENSIONS = 1024
 
 
 # MAYBE: add barcode source for each index name
 def _index_config_data():
+    """Each index config entry dict must conform to the `IndexConfigEntry`
+    pydantic model, validated at runtime in get_index_config_dict().
+    """
     from vector_indexing.components.backends.turbopuffer import (
         load_default_schema,
         get_default_schema_with_dims,
@@ -166,11 +186,7 @@ def _index_config_data():
             ],
             "embedder": {
                 "class": "Gemini001Embedder",
-                "params": {
-                    # All are default and unnecessary to specify here
-                    "model": "gemini-embedding-001",
-                    "dimensions": 768,
-                },
+                "params": {},
             },
             "schema": load_default_schema(),  # 768 dims
         },
@@ -180,12 +196,9 @@ def _index_config_data():
             ],
             "embedder": {
                 "class": "Gemini2Embedder",
-                "params": {
-                    "model": "gemini-embedding-2",
-                    "dimensions": 768,
-                },
+                "params": {},
             },
-            "schema": load_default_schema(),
+            "schema": load_default_schema(),  # 768 dims
         },
         {  # Harrier
             "names": [
@@ -288,10 +301,13 @@ def get_index_config_dict(index_name, overrides: dict[str, object] | None = None
     if entry is None:
         raise ValueError(f"No index config found for index name: {index_name!r}")
     copied = deepcopy(entry)
-    return _apply_index_config_overrides(copied, overrides=overrides)
+    result = _apply_index_config_overrides(copied, overrides=overrides)
+    IndexConfigEntry.model_validate(result)
+    return result
 
 
 def get_index_config(index_name, overrides: dict[str, object] | None = None):
+    """Get the embedder and backend configured for a given index."""
     from vector_indexing.components.backends.turbopuffer import TurbopufferBackend
     from vector_indexing.components import embedders as embedders_module
 

--- a/etl-pipeline/vector_indexing/core/config.py
+++ b/etl-pipeline/vector_indexing/core/config.py
@@ -158,17 +158,30 @@ def _index_config_data():
     )
 
     return [
-        {  # Google
+        {  # Gemini-embedding-001
             "names": [
                 "vra-dev",
                 "vra_test-sketches_of_the_north_river-gemini-001",
                 "vra_test-eval300-gemini_001",  # pragma: allowlist secret
             ],
             "embedder": {
-                "class": "GoogleEmbedder",
+                "class": "Gemini001Embedder",
                 "params": {
                     # All are default and unnecessary to specify here
                     "model": "gemini-embedding-001",
+                    "dimensions": 768,
+                },
+            },
+            "schema": load_default_schema(),  # 768 dims
+        },
+        {  # Gemini-embedding-2
+            "names": [
+                "vra-10k-gemini_embedding_2",
+            ],
+            "embedder": {
+                "class": "Gemini2Embedder",
+                "params": {
+                    "model": "gemini-embedding-2",
                     "dimensions": 768,
                 },
             },

--- a/etl-pipeline/vector_indexing/pipeline/orchestrator.py
+++ b/etl-pipeline/vector_indexing/pipeline/orchestrator.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 # These are imported at runtime for default initialization
 from vector_indexing import SentenceSplitterChunker
 from vector_indexing.components.loaders import S3BookLoader
-from vector_indexing.components.embedders import GoogleEmbedder
+from vector_indexing.components.embedders import Gemini001Embedder
 from vector_indexing.components.metadata import MetadataProvider
 from vector_indexing.components.backends.turbopuffer import TurbopufferBackend
 
@@ -160,7 +160,7 @@ class Pipeline:
         # Q: is there compelling reason to define these defaults elsewhere?
         self._loader = loader if loader is not None else S3BookLoader()
         self._chunker = chunker if chunker is not None else SentenceSplitterChunker()
-        self._embedder = embedder if embedder is not None else GoogleEmbedder()
+        self._embedder = embedder if embedder is not None else Gemini001Embedder()
         self._metadata_provider = (
             metadata_provider if metadata_provider is not None else MetadataProvider()
         )
@@ -358,7 +358,7 @@ def main(barcodes: list[str] | None = None) -> BatchResult:
     """
     from vector_indexing.components.backends.turbopuffer import TurbopufferBackend
     from vector_indexing.components.chunkers.sentence import SentenceSplitterChunker
-    from vector_indexing.components.embedders.google import GoogleEmbedder
+    from vector_indexing.components.embedders.google import Gemini001Embedder
     from vector_indexing.components.loaders.s3 import CachedS3BookLoader
     from vector_indexing.components.metadata.provider import MetadataProvider
 
@@ -368,7 +368,7 @@ def main(barcodes: list[str] | None = None) -> BatchResult:
     pipeline = Pipeline(
         loader=CachedS3BookLoader(),
         chunker=SentenceSplitterChunker(),
-        embedder=GoogleEmbedder(),
+        embedder=Gemini001Embedder(),
         metadata_provider=MetadataProvider(),
         backend=TurbopufferBackend(index_name="vra-dev-test"),
     )

--- a/etl-pipeline/vector_indexing/scripts/index_books.py
+++ b/etl-pipeline/vector_indexing/scripts/index_books.py
@@ -569,6 +569,7 @@ def main():
         )
 
         batch_pct = 100.0 * batch_index / total_batches
+        # NOTE: total batch in the run, not the job (if --resume-latest existing job)
         print(
             f"[Batch {batch_index}/{total_batches} | {batch_pct:.0f}%] Saved batch result: {saved_path}"
         )

--- a/etl-pipeline/vector_indexing/scripts/index_books.py
+++ b/etl-pipeline/vector_indexing/scripts/index_books.py
@@ -17,7 +17,7 @@ For resumed runs, later batches may rerun barcodes from previous batches.
 
 Usage:
     # From barcodes:
-    python -m vector_indexing.scripts.index_books --barcodes 33433001234567 33433009876543
+    python -m vector_indexing.scripts.index_books --barcodes 33333011962152 33433002996126
 
     # From barcode file (one per line):
     python -m vector_indexing.scripts.index_books --file barcodes.txt
@@ -29,13 +29,13 @@ Usage:
     python -m vector_indexing.scripts.index_books --10k --index-name vra_test-10k-harrier_oss_v1_.6b --resume-latest
 
     # Dry run (no actual indexing):
-    python -m vector_indexing.scripts.index_books --barcodes 33433001234567 --dry-run
+    python -m vector_indexing.scripts.index_books --barcodes 33433002996126 --dry-run
 
-    # Use local files:
-    python -m vector_indexing.scripts.index_books --barcodes 33433001234567 --loader LocalBookLoader
+    # Use non-default book loader:
+    python -m vector_indexing.scripts.index_books --barcodes 33433002996126 --loader CachedS3BookLoader --loader-args '{"cache_dir": "../../vra_experiments/data/experiment_books"}'
 
     # Use mock embedder (for testing):
-    python -m vector_indexing.scripts.index_books --barcodes 33433001234567 --mock-embedder
+    python -m vector_indexing.scripts.index_books --barcodes 33433002996126 --mock-embedder
 
     # Use qa environment config:
     python -m vector_indexing.scripts.index_books --10k --index-name vra_test-10k-harrier_oss_v1_.6b --env qa

--- a/etl-pipeline/vector_indexing/utils/barcodes.py
+++ b/etl-pipeline/vector_indexing/utils/barcodes.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from sqlalchemy import create_engine, select
 from sqlalchemy.orm import Session
 


### PR DESCRIPTION
## Describe your changes

Add a gemini 2 embedder to support differences in API btw gemini-001 and gemini-2 embeddings

Support thruput benchmarking for all embedders, including batch requests

add embedder class contract tests

standardize the API for Embedders that call an external API

benchmark thruput results for gemini embedding models -> https://newyorkpubliclibrary.atlassian.net/wiki/x/BgC7ZQ

## How to test
all tests should pass in addition to new tests