### PR TITLE
NOREF: centralize data seed into single script and update docs

### DIFF
--- a/etl-pipeline/README.md
+++ b/etl-pipeline/README.md
@@ -60,28 +60,15 @@ This guide provides step-by-step instructions to set up local development and st
 #### (Option A) Run in docker compose
 
 
-1. Seed data in the local dockerized DB instance (one-time only):
+1. Seed data for DRB and VRA in the local dockerized Postgres DB instance (one-time only):
 
    ```bash
    # Run the database seeding process
-   docker compose -f docker-compose.setup.yml up --abort-on-container-exit
+   ./seed_local_db.sh
    ```
-
-   Or to instead seed known books using a local fixture file:
-
-   ```bash
-   # Run dockerized local development setup
-   docker compose run --rm --entrypoint python devsetup main.py \
-      -p LocalDevelopmentSetupProcess \
-      -e docker-compose
-
-   # Run seeding script
-   docker compose run --rm --entrypoint python devsetup \
-      -m tests.integration.api.assistant.support.seed_frbr_data
-   ```
-   Note: Any semantic search hits from the vector database must be accompanied with FRBR graph data in the Postgres database in order to be returned by the /chat endpoint.
-   - The first method seeds the Postgres database with brand new records from HathiTrust (making it highly non-deterministic) but they are not indexed in the vector database and hence cannot be returned as results from /chat.
-   - The second method seeds the Postgres database with records known to exist in at least the following vector database namespaces, allowing them to be returned by /chat:
+   Note: The /chat endpoint looks up FRBR data in the Postgres database matching semantic search hits in Turbopuffer. The seed process inserts two kinds of data:
+   1) brand new records from HathiTrust (highly non-deterministic) that are indexed in the vector database and hence cannot be returned as results from /chat.
+   2) records known to exist in the following Turbopuffer namespaces, which can be returned by /chat:
      - vra-dev
      - vra-test
 

--- a/etl-pipeline/seed_local_db.sh
+++ b/etl-pipeline/seed_local_db.sh
@@ -1,10 +1,16 @@
 #!/bin/bash
 set -euo pipefail
 
+# Ensure docker services are running
 docker compose up --no-recreate --wait
 
 source .venv/bin/activate
+
+# Seed DRB data into DB. `-e local` specifies the local dockerized DB instance as the target.
 python main.py -e local -p SeedLocalDataProcess -i daily
+
+# Seed VRA data into DB. `-e local` specifies the local dockerized DB instance as the target.
+python -m tests.integration.api.assistant.support.seed_frbr_data -e local
 
 #  ALT: make SeedLocalDataProcess fully idempotent so it won't alter the DB state if it's already run
 # then add seeddb to main docker compose file with `depends_on: devsetup; condition: service_completed_successfully`
@@ -14,5 +20,3 @@ python main.py -e local -p SeedLocalDataProcess -i daily
 # ALT: use a concise docker-compose.seed.yaml that just overrides devsetup cmd to do both init \
 # and seed, called when needed by docker compose up -f docker-compose.yaml -f docker-compose.seed.yaml \
 # per https://docs.docker.com/reference/cli/docker/compose/#use--f-to-specify-the-name-and-path-of-one-or-more-compose-files 
-
-# TODO: Seed from fixture file

--- a/etl-pipeline/tests/integration/api/assistant/support/seed_frbr_data.py
+++ b/etl-pipeline/tests/integration/api/assistant/support/seed_frbr_data.py
@@ -3,26 +3,27 @@
 Upsert order (respects FK dependencies):
     works -> editions -> records -> items -> links -> item_links -> rights -> item_rights
 
-Defaults to docker-compose env config but can be used for any local DB with the
-appropriate .env config file. See usage instructions below.
 
 Depended on for running VRA integration tests against a local DRB API instance,
 which require specific FRBR data to be present for /chat requests to succeed.
 
-Dockerized DB usage:
-    From etl-pipeline/:
-        # Run dockerized local development setup
-        docker compose run --rm --entrypoint python devsetup main.py \
-            -p LocalDevelopmentSetupProcess \
-            -e docker-compose
+The dockerized postgres database must be running for the seed script to insert 
+data. Here are 2 ways to ensure it is running before the script is executed. 
+Both require CWD to be "etl-pipeline/".
 
-        # Run seeding script
-        docker compose run --rm --entrypoint python devsetup \
+A) 
+```
+docker compose up --no-recreate --wait
+python -m tests.integration.api.assistant.support.seed_frbr_data -e local
+```
+
+B)
+This relies on the dependency conditions for the `devsetup` service defined in 
+docker-compose.yaml to start the dockerized database before executing the script.
+```
+docker compose run --rm --entrypoint python devsetup \
             -m tests.integration.api.assistant.support.seed_frbr_data
-
-Local DB usage:
-    From etl-pipeline/ after running local development setup:
-        python -m tests.integration.api.assistant.support.seed_frbr_data -e local
+```
 """
 
 import argparse


### PR DESCRIPTION
## Describe your changes

`seed_frbr_data.py` relies on the local docker postgress instance to be running. The docs previously ensured this with a command overrode the entry-point + command of the "devsetup" docker service to use that services dependency conditions to guarantee the postgres service was running. Also the docs instructed to run one "OR" another of 2 different seeding commands, which was confusing.

I centralize data seed into single script and update docs to reflect  this. I also use a more explicit mechanism to ensure the postgres services is running (a direct `docker compose up --wait` command)


Q for reviewer: should the seed_local_data.sh shutdown all docker services after it runs?

## How to test
run seed locally