### PR TITLE
SCHOL-651 - switch /chat to gemini-embedding-2

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -662,7 +662,7 @@
         "filename": "etl-pipeline/tests/unit/api/assistant/agent/test_agent.py",
         "hashed_secret": "e9b4dce312643ee0e1bd0561a50d9d5a7e5a2be1",
         "is_verified": false,
-        "line_number": 26
+        "line_number": 32
       }
     ],
     "etl-pipeline/tests/unit/api/blueprints/test_create_api_collection_blueprint.py": [
@@ -1131,5 +1131,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-16T18:23:40Z"
+  "generated_at": "2026-06-24T21:27:41Z"
 }

--- a/etl-pipeline/api/assistant/agent.py
+++ b/etl-pipeline/api/assistant/agent.py
@@ -48,8 +48,9 @@ from .search import hybrid_search, ReciprocalRankFuser, ScoredHit
 from .types import CatalogSearchResult, ContentSearchResult
 
 # shared code
-from vector_indexing.components.embedders.google import Gemini001Embedder
+from vector_indexing.components.embedders.base import Embedder
 from vector_indexing.components.backends.turbopuffer import TurbopufferBackend
+from vector_indexing.core.config import get_index_config
 from vector_indexing.core.utils import Timer
 from logger import create_log
 from utils.common import require_env, wrap
@@ -253,7 +254,7 @@ class CatalogSearchExecutionContext:
     """Container used to inject objects into each agent run execution."""
 
     backend: TurbopufferBackend
-    embedder: Gemini001Embedder
+    embedder: Embedder
     session_id: str
     conversation_type: str = "catalogSearch"
     search_results: Dict = field(default_factory=dict)
@@ -269,7 +270,7 @@ class ContentSearchExecutionContext:
     """
 
     backend: TurbopufferBackend
-    embedder: Gemini001Embedder
+    embedder: Embedder
     session_id: str
     edition_id: int
     barcode: Optional[str] = None
@@ -517,8 +518,10 @@ async def update_chat(
     # some reused objs (backend, system prompts, async loop, etc...) (for sharing btw server \
     # request workers/threads)
 
-    backend = TurbopufferBackend(index_name=require_env("TURBOPUFFER_NAMESPACE"))
-    embedder = Gemini001Embedder()
+    index_name = require_env("TURBOPUFFER_NAMESPACE")
+    index_config = get_index_config(index_name)
+    backend = index_config["backend"]
+    embedder = index_config["embedder"]
 
     # NOTE: we are not using litellm bc it has a bug converting `list | None = None`
     # in agents sdk @functol_tool param type annotations into gemini API compatible

--- a/etl-pipeline/config/.env.production
+++ b/etl-pipeline/config/.env.production
@@ -68,7 +68,7 @@ API_PROXY_CORS_ALLOWED=http[s]?://.*nypl.org
 READER_VERSION=v2
 
 TURBOPUFFER_REGION=aws-us-east-1
-TURBOPUFFER_NAMESPACE=vra-dev
+TURBOPUFFER_NAMESPACE=vra-10k-gemini_embedding_2
 
 # Custom instrumentation for New Relic AI monitoring
 NEW_RELIC_CUSTOM_LLM_EVENT_LOGGING_ENABLED=false

--- a/etl-pipeline/config/.env.qa
+++ b/etl-pipeline/config/.env.qa
@@ -73,7 +73,7 @@ READER_VERSION=v2
 PDF_BUCKET=pdf-pipeline-store-qa
 
 TURBOPUFFER_REGION=aws-us-east-1
-TURBOPUFFER_NAMESPACE=vra-dev
+TURBOPUFFER_NAMESPACE=vra-10k-gemini_embedding_2
 
 # Custom instrumentation for New Relic AI monitoring
 NEW_RELIC_CUSTOM_LLM_EVENT_LOGGING_ENABLED=true

--- a/etl-pipeline/tests/functional/api/assistant/agent/test_on_max_turns.py
+++ b/etl-pipeline/tests/functional/api/assistant/agent/test_on_max_turns.py
@@ -16,6 +16,7 @@ class TestOnMaxTurns:
         3. raw_responses has exactly 2 entries (max_turns agent-loop LLM calls).
         """
         # Prevent real embedder/backend initialization
+        # hybrid_search raises before embedder is used, so the return value doesn't matter
         mock_embedder = mocker.MagicMock()
         mock_backend = mocker.MagicMock()
         mocker.patch(

--- a/etl-pipeline/tests/functional/api/assistant/agent/test_on_max_turns.py
+++ b/etl-pipeline/tests/functional/api/assistant/agent/test_on_max_turns.py
@@ -15,12 +15,13 @@ class TestOnMaxTurns:
         2. final_output is a non-empty string (graceful LLM response).
         3. raw_responses has exactly 2 entries (max_turns agent-loop LLM calls).
         """
-        # Prevent real backend initialization
-        mocker.patch("api.assistant.agent.TurbopufferBackend")
-
-        # Prevent real Google Embedder API calls; embed_query returns a mock (hybrid_search
-        # raises before it's used, so the return value doesn't matter)
-        mocker.patch("api.assistant.agent.Gemini001Embedder")
+        # Prevent real embedder/backend initialization
+        mock_embedder = mocker.MagicMock()
+        mock_backend = mocker.MagicMock()
+        mocker.patch(
+            "api.assistant.agent.get_index_config",
+            return_value={"embedder": mock_embedder, "backend": mock_backend},
+        )
 
         # Force search tool to always fail → triggers LLM retry
         mocker.patch(

--- a/etl-pipeline/tests/stochastic_processes/conftest.py
+++ b/etl-pipeline/tests/stochastic_processes/conftest.py
@@ -65,8 +65,11 @@ def mock_search_backend(mocker):
     """
     mock_embedder = mocker.MagicMock()
     mock_embedder.embed_query.return_value = np.zeros(768).tolist()
-    mocker.patch("api.assistant.agent.Gemini001Embedder", return_value=mock_embedder)
-    mocker.patch("api.assistant.agent.TurbopufferBackend")
+    mock_backend = mocker.MagicMock()
+    mocker.patch(
+        "api.assistant.agent.get_index_config",
+        return_value={"embedder": mock_embedder, "backend": mock_backend},
+    )
 
     def _setup(chunk_docs: List[ChunkDocument]) -> List[ChunkDocument]:
         scored_hits = [(cd, 0.5) for cd in chunk_docs]

--- a/etl-pipeline/tests/stochastic_processes/conftest.py
+++ b/etl-pipeline/tests/stochastic_processes/conftest.py
@@ -43,6 +43,7 @@ def make_chunk_doc(
     )
 
 
+# TODO: see if similar functionality is duplicated elsewhere in teh code/test base
 @pytest.fixture
 def mock_search_backend(mocker):
     """
@@ -52,13 +53,14 @@ def mock_search_backend(mocker):
     For search_book all chunks should be from the same edition/book.
 
     Call the returned function with a list of ChunkDocuments to activate the
-    mocks. The fixture stubs:
+    mocked backend.
+    The fixture stubs:
       - hybrid_search → returns ChunkDocuments as ScoredHits
       - map_editions_and_records → returns synthetic item_ids keyed by book_id
       - get_frbr_data_by_edition → returns SimpleNamespace ORM-like rows
         built from each ChunkDocument's book_metadata (first chunk per edition)
-      - Gemini001Embedder → returns a dummy zero vector from embed_query
-      - TurbopufferBackend → replaced with a no-op mock
+      - Embedder → returns a dummy zero vector from embed_query (via get_index_config())
+      - Backend → replaced with a no-op mock (via get_index_config())
 
     Returns:
         Callable that accepts a list of ChunkDocuments and activates all mocks.

--- a/etl-pipeline/tests/unit/api/assistant/agent/test_agent.py
+++ b/etl-pipeline/tests/unit/api/assistant/agent/test_agent.py
@@ -20,7 +20,13 @@ class TestAgent:
         """Test update_chat in catalogSearch mode returns run_result."""
 
         # Mock external resource dependencies
-        mocker.patch("api.assistant.agent.TurbopufferBackend")
+        mocker.patch(
+            "api.assistant.agent.get_index_config",
+            return_value={
+                "embedder": mocker.MagicMock(),
+                "backend": mocker.MagicMock(),
+            },
+        )
         mocker.patch("api.assistant.agent.get_async_engine")
         mocker.patch("api.assistant.agent.SQLAlchemySession")
         mocker.patch.dict(os.environ, {"GOOGLE_API_KEY": "fake-key"})

--- a/etl-pipeline/vector_indexing/core/config.py
+++ b/etl-pipeline/vector_indexing/core/config.py
@@ -181,6 +181,7 @@ def _index_config_data():
         {  # Gemini-embedding-001
             "names": [
                 "vra-dev",
+                "vra-test",
                 "vra_test-sketches_of_the_north_river-gemini-001",
                 "vra_test-eval300-gemini_001",  # pragma: allowlist secret
             ],


### PR DESCRIPTION
## Describe your changes
Switch /chat endpoint to use gemini-embedding-2 for queries and indexed documents.

The change converts to the new "get_index_config" paradigm where a configuration exists for each index that specified an embedding model and index schema used both for index document embedding creation and query embedding creation.

Tests were also updated to accomodate the refactor

No default index is hardcoded into agent.py, the index used by /chat is entirely determined by the env file.

## How to test
all existing tests should pass.