### PR TITLE
NOREF: Replace NYPL Connect header link test

### DIFF
--- a/web/playwright/landing-page/landing-page.ts
+++ b/web/playwright/landing-page/landing-page.ts
@@ -30,6 +30,7 @@ class LandingPage {
   readonly researchHeaderLink: Locator;
   readonly educationHeaderLink: Locator;
   readonly eventsHeaderLink: Locator;
+  readonly visitHeaderLink: Locator;
   readonly giveHeaderLink: Locator;
   readonly getHelpHeaderLink: Locator;
   readonly searchHeaderLink: Locator;
@@ -121,6 +122,7 @@ class LandingPage {
       "[href='//www.nypl.org/education'] >> nth=0"
     );
     this.eventsHeaderLink = page.locator("[href='//www.nypl.org/events']");
+    this.visitHeaderLink = page.locator("[href='//www.nypl.org/visit']");
     this.giveHeaderLink = page.locator("[href='//www.nypl.org/give']");
     this.getHelpHeaderLink = page.locator("[href='//www.nypl.org/get-help']");
     this.searchHeaderLink = page.locator(

--- a/web/playwright/landing-page/landing-page.ts
+++ b/web/playwright/landing-page/landing-page.ts
@@ -30,7 +30,6 @@ class LandingPage {
   readonly researchHeaderLink: Locator;
   readonly educationHeaderLink: Locator;
   readonly eventsHeaderLink: Locator;
-  readonly connectHeaderLink: Locator;
   readonly giveHeaderLink: Locator;
   readonly getHelpHeaderLink: Locator;
   readonly searchHeaderLink: Locator;
@@ -122,7 +121,6 @@ class LandingPage {
       "[href='//www.nypl.org/education'] >> nth=0"
     );
     this.eventsHeaderLink = page.locator("[href='//www.nypl.org/events']");
-    this.connectHeaderLink = page.locator("[href='//www.nypl.org/connect']");
     this.giveHeaderLink = page.locator("[href='//www.nypl.org/give']");
     this.getHelpHeaderLink = page.locator("[href='//www.nypl.org/get-help']");
     this.searchHeaderLink = page.locator(

--- a/web/playwright/landing-page/landing.spec.ts
+++ b/web/playwright/landing-page/landing.spec.ts
@@ -47,6 +47,7 @@ test.describe("Header Links", () => {
     await landingPage.verifyHeaderLinkVisible(landingPage.researchHeaderLink);
     await landingPage.verifyHeaderLinkVisible(landingPage.educationHeaderLink);
     await landingPage.verifyHeaderLinkVisible(landingPage.eventsHeaderLink);
+    await landingPage.verifyHeaderLinkVisible(landingPage.visitHeaderLink);
     await landingPage.verifyHeaderLinkVisible(landingPage.giveHeaderLink);
     await landingPage.verifyHeaderLinkVisible(landingPage.getHelpHeaderLink);
     await landingPage.verifyHeaderLinkVisible(landingPage.searchHeaderLink);

--- a/web/playwright/landing-page/landing.spec.ts
+++ b/web/playwright/landing-page/landing.spec.ts
@@ -47,7 +47,6 @@ test.describe("Header Links", () => {
     await landingPage.verifyHeaderLinkVisible(landingPage.researchHeaderLink);
     await landingPage.verifyHeaderLinkVisible(landingPage.educationHeaderLink);
     await landingPage.verifyHeaderLinkVisible(landingPage.eventsHeaderLink);
-    await landingPage.verifyHeaderLinkVisible(landingPage.connectHeaderLink);
     await landingPage.verifyHeaderLinkVisible(landingPage.giveHeaderLink);
     await landingPage.verifyHeaderLinkVisible(landingPage.getHelpHeaderLink);
     await landingPage.verifyHeaderLinkVisible(landingPage.searchHeaderLink);

--- a/web/playwright/research-assistant-page/research-assistant-page.spec.ts
+++ b/web/playwright/research-assistant-page/research-assistant-page.spec.ts
@@ -60,7 +60,7 @@ test.describe(
     let context: BrowserContext;
     let page: Page;
     let researchAssistantPage: ResearchAssistantPage;
-    const testQuery = "I want to learn about Bryant Park.";
+    const testQuery = "I want to learn about history of rivers in New York.";
 
     test.beforeAll(async ({ browser }) => {
       context = await browser.newContext();


### PR DESCRIPTION
## Changes
Replaces a legacy landing page test that checked for a header link that is no longer there (i.e. Connect) and has been replaced by Visit (see NYPL Header app [changelog](https://github.com/NYPL/nypl-header-app/blob/main/CHANGELOG.md)). Resolves a [failed test](https://github.com/NYPL/digital-research-books/actions/runs/28467500062/job/84371594145?pr=1152#step:13:145) currently impacting frontend PR checks.

## How to test
Spin up a local build and run DRB E2E tests:
```
npm run playwright:drb
```