### PR TITLE
SCHOL-676: Add DataLayer for Landing Page Query

### DIFF
--- a/web/src/components/ResearchAssistant/ResearchAssistant.tsx
+++ b/web/src/components/ResearchAssistant/ResearchAssistant.tsx
@@ -1,11 +1,12 @@
 import { Box, Flex } from "@nypl/design-system-react-components";
-import React, { useEffect, useMemo } from "react";
+import React, { useEffect, useMemo, useRef } from "react";
 import {
   HEADER_HEIGHT,
   MARGIN_BLEED,
   PADDING_COUNTER,
 } from "~/src/constants/researchAssistant";
 import { useResearchAssistant } from "~/src/context/ResearchAssistantContext";
+import { trackEvent } from "~/src/lib/gtag/Analytics";
 import { isCatalogResults } from "~/src/util/ResearchAssistantUtils";
 import BackToResultsButton from "../BackToResultsButton/BackToResultsButton";
 import EmptySearchPrompt from "../EmptySearchPrompt/EmptySearchPrompt";
@@ -25,12 +26,15 @@ const ResearchAssistant: React.FC = () => {
     isLoading,
   } = useResearchAssistant();
 
+  const isLandingPageQuery = useRef(false);
+
   useEffect(() => {
     if (!messages || messages.length === 0) {
       const initialMessage = sessionStorage.getItem(
         "researchAssistantInitialMessage"
       );
       if (initialMessage) {
+        isLandingPageQuery.current = true;
         sendMessage(initialMessage);
         sessionStorage.removeItem("researchAssistantInitialMessage");
       }
@@ -59,19 +63,17 @@ const ResearchAssistant: React.FC = () => {
   }, [messages.length, results]);
 
   useEffect(() => {
-    const queryFromLandingPage = sessionStorage.getItem("queryFromLandingPage");
-    if (queryFromLandingPage && !isLoading && latestResults) {
+    if (isLandingPageQuery.current && !isLoading && latestResults) {
       let resultsCount = 0;
       if (isCatalogResults(latestResults)) {
         resultsCount = latestResults.paging?.totalRecords || 0;
       }
-      window.dataLayer = window.dataLayer || [];
-      window.dataLayer.push({
+      trackEvent({
         event: "view_query_results",
         query_type: "landing_page",
         results_count: resultsCount,
       });
-      sessionStorage.removeItem("queryFromLandingPage");
+      isLandingPageQuery.current = false;
     }
   }, [isLoading, latestResults]);
 

--- a/web/src/components/ResearchAssistant/ResearchAssistant.tsx
+++ b/web/src/components/ResearchAssistant/ResearchAssistant.tsx
@@ -58,6 +58,23 @@ const ResearchAssistant: React.FC = () => {
     return null;
   }, [messages.length, results]);
 
+  useEffect(() => {
+    const queryFromLandingPage = sessionStorage.getItem("queryFromLandingPage");
+    if (queryFromLandingPage && !isLoading && latestResults) {
+      let resultsCount = 0;
+      if (isCatalogResults(latestResults)) {
+        resultsCount = latestResults.paging?.totalRecords || 0;
+      }
+      window.dataLayer = window.dataLayer || [];
+      window.dataLayer.push({
+        event: "view_query_results",
+        query_type: "landing_page",
+        results_count: resultsCount,
+      });
+      sessionStorage.removeItem("queryFromLandingPage");
+    }
+  }, [isLoading, latestResults]);
+
   return (
     <>
       <Box

--- a/web/src/components/ResearchAssistantLanding/SearchSection.tsx
+++ b/web/src/components/ResearchAssistantLanding/SearchSection.tsx
@@ -24,7 +24,6 @@ const SearchSection: React.FC<SearchSectionProps> = ({ textInputRef }) => {
 
   const onSubmit = (query: string) => {
     sessionStorage.setItem("researchAssistantInitialMessage", query);
-    sessionStorage.setItem("queryFromLandingPage", "true");
     router.push("/research-assistant");
   };
 

--- a/web/src/components/ResearchAssistantLanding/SearchSection.tsx
+++ b/web/src/components/ResearchAssistantLanding/SearchSection.tsx
@@ -24,6 +24,7 @@ const SearchSection: React.FC<SearchSectionProps> = ({ textInputRef }) => {
 
   const onSubmit = (query: string) => {
     sessionStorage.setItem("researchAssistantInitialMessage", query);
+    sessionStorage.setItem("queryFromLandingPage", "true");
     router.push("/research-assistant");
   };
 

--- a/web/src/lib/gtag/Analytics.test.ts
+++ b/web/src/lib/gtag/Analytics.test.ts
@@ -10,12 +10,12 @@ describe("Google Analytics", () => {
       const dataLayer = window.dataLayer;
 
       trackEvent({
-        "event":  "file_download",
-        "click_text": "Download PDF",
-        "file_extension": "pdf",
-        "file_name": "File Name",
-        "item_title": "Item Title",
-        "item_author": "Item Author",
+        event: "file_download",
+        click_text: "Download PDF",
+        file_extension: "pdf",
+        file_name: "File Name",
+        item_title: "Item Title",
+        item_author: "Item Author",
       });
 
       const eventData = dataLayer[0];
@@ -33,6 +33,26 @@ describe("Google Analytics", () => {
       expect(fileName).toEqual("File Name");
       expect(itemTitle).toEqual("Item Title");
       expect(itemAuthor).toEqual("Item Author");
+    });
+
+    test("it should update window.dataLayer for query results events", () => {
+      const dataLayer = window.dataLayer;
+
+      trackEvent({
+        event: "query_results",
+        query_type: "title",
+        results_count: 42,
+      });
+
+      const eventData = dataLayer[0];
+      const eventValue = eventData.event;
+      const queryType = eventData.query_type;
+      const resultsCount = eventData.results_count;
+
+      expect(dataLayer).toHaveLength(1);
+      expect(eventValue).toEqual("query_results");
+      expect(queryType).toEqual("title");
+      expect(resultsCount).toEqual(42);
     });
   });
 });

--- a/web/src/lib/gtag/Analytics.ts
+++ b/web/src/lib/gtag/Analytics.ts
@@ -1,20 +1,28 @@
-type EventData = (ReadOnlineData | DownloadData) & {
-    event: string;
-    item_title: string;
-    item_author: string | string[];
+type ReadOnlineData = {
+  read_online_url: string;
 };
 
-type ReadOnlineData = {
-    read_online_url: string;
-}
-
 type DownloadData = {
-    click_text: string;
-    file_extension: string;
-    file_name: string;
-}
+  click_text: string;
+  file_extension: string;
+  file_name: string;
+};
+
+type ReadOnlineOrDownloadData = (ReadOnlineData | DownloadData) & {
+  event: string;
+  item_title: string;
+  item_author: string | string[];
+};
+
+type QueryResultsData = {
+  event: string;
+  query_type: string;
+  results_count: number;
+};
+
+type EventData = ReadOnlineOrDownloadData | QueryResultsData;
 
 export const trackEvent = (eventData: EventData) => {
-    const dataLayer = window.dataLayer || [];
-    dataLayer.push(eventData);
+  const dataLayer = window.dataLayer || [];
+  dataLayer.push(eventData);
 };


### PR DESCRIPTION
[SCHOL-676](https://newyorkpubliclibrary.atlassian.net/browse/SCHOL-676)

## Describe your changes
- Added a temp. flag in session `queryFromLandingPage` to keep record that query came from landing page.
- ResearchAssistant now pushes to dataLayer when new results come in (only from landing page for now).

## How to test
- Test on local machine using dev tools
- Once this review is passed, Data team will test if data is streaming to GA4.

[SCHOL-676]: https://newyorkpubliclibrary.atlassian.net/browse/SCHOL-676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ